### PR TITLE
Add signed in-app updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       - run: bun ci
       - run: bun run check
       - run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
-      - run: bun run tauri build --debug
+      - run: bun run tauri build --debug --config '{"bundle":{"createUpdaterArtifacts":false}}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       increment: ${{ steps.release.outputs.increment }}
       release_id: ${{ steps.release.outputs.release_id }}
+      tag: ${{ steps.release.outputs.tag }}
     steps:
       - uses: actions/checkout@v7
       - id: release
@@ -47,8 +48,11 @@ jobs:
               -F generate_release_notes=true \
               --jq .id)
           fi
-          echo "increment=true" >> "$GITHUB_OUTPUT"
-          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          {
+            echo "increment=true"
+            echo "release_id=$RELEASE_ID"
+            echo "tag=$TAG"
+          } >> "$GITHUB_OUTPUT"
 
   build:
     needs: check
@@ -59,12 +63,13 @@ jobs:
         include:
           - platform: macos-latest
             target: aarch64-apple-darwin
-          - platform: macos-latest
-            target: x86_64-apple-darwin
+            bundles: dmg,app
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            bundles: appimage
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
+            bundles: nsis
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write
@@ -87,14 +92,18 @@ jobs:
       - uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
           releaseId: ${{ needs.check.outputs.release_id }}
           releaseDraft: true
           releaseAssetNamePattern: Lite_[version]_[platform]_[arch][setup][ext]
           retryAttempts: 2
+          tagName: ${{ needs.check.outputs.tag }}
           tauriScript: bun run tauri
-          uploadUpdaterJson: false
+          updaterJsonPreferNsis: true
+          uploadUpdaterJson: true
           uploadUpdaterSignatures: false
 
   publish:
@@ -103,6 +112,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Verify updater manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.check.outputs.release_id }}
+          TAG: ${{ needs.check.outputs.tag }}
+        run: |
+          ASSETS=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets")
+          VERSION=${TAG#v}
+          jq -e --arg version "$VERSION" '([.[].name] | sort) == (["Lite_\($version)_darwin_aarch64.app.tar.gz", "Lite_\($version)_darwin_aarch64.dmg", "Lite_\($version)_linux_amd64.AppImage", "Lite_\($version)_windows_x64-setup.exe", "latest.json"] | sort)' <<< "$ASSETS" >/dev/null
+          LATEST_ID=$(jq -r 'map(select(.name == "latest.json")) | first.id // empty' <<< "$ASSETS")
+          test -n "$LATEST_ID"
+          gh api -H "Accept: application/octet-stream" "repos/$GITHUB_REPOSITORY/releases/assets/$LATEST_ID" > "$RUNNER_TEMP/latest.json"
+          jq -e --arg version "$VERSION" '.version == $version' "$RUNNER_TEMP/latest.json" >/dev/null
+          for PLATFORM in darwin-aarch64-app linux-x86_64-appimage windows-x86_64-nsis; do
+            jq -e --arg platform "$PLATFORM" '.platforms[$platform] | (.url | type == "string" and length > 0) and (.signature | type == "string" and length > 0)' "$RUNNER_TEMP/latest.json" >/dev/null
+            ASSET_ID=$(jq -r --arg platform "$PLATFORM" '.platforms[$platform].url | capture("/assets/(?<id>[0-9]+)$").id' "$RUNNER_TEMP/latest.json")
+            jq -e --argjson id "$ASSET_ID" 'any(.id == $id)' <<< "$ASSETS" >/dev/null
+          done
       - name: Publish complete release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Lite is a fast, local workspace for [Claude Code](https://code.claude.com/docs/e
 - Preview rendered Markdown safely alongside source files
 - See the active Git branch, worktree, and changed files
 - Inspect per-session context and provider usage reported by Claude or Codex
+- Install signed updates from inside Lite
 - Switch between light and dark themes
 
 Lite is intentionally quiet: idle means idle. It does not index your repository, watch every file, read provider tokens, or send telemetry.
@@ -36,31 +37,27 @@ Download Lite from the [latest GitHub Release](https://github.com/ultralytics/li
 
 ### macOS
 
-1. Download `Lite_0.0.1_darwin_aarch64.dmg` for Apple silicon or `Lite_0.0.1_darwin_x64.dmg` for an Intel Mac.
+1. Download `Lite_0.0.2_darwin_aarch64.dmg` for an Apple silicon Mac.
 2. Open the disk image and drag **Lite** into **Applications**.
 3. Open Lite from **Applications**. If macOS blocks this first unsigned release, open **System Settings → Privacy & Security**, select **Open Anyway** for Lite, then confirm.
 
 ### Windows
 
-1. Download `Lite_0.0.1_windows_x64-setup.exe` (or the `.msi` asset if you prefer Windows Installer).
+1. Download `Lite_0.0.2_windows_x64-setup.exe`.
 2. Run the installer, then open **Lite** from the Start menu.
 3. If Microsoft Defender SmartScreen appears for this early unsigned release, select **More info → Run anyway**.
 
 ### Linux
 
-Download `Lite_0.0.1_linux_amd64.AppImage` for a portable app, `Lite_0.0.1_linux_amd64.deb` for Debian or Ubuntu, or the `.rpm` asset for Fedora-compatible distributions.
+Download the portable `Lite_0.0.2_linux_amd64.AppImage`.
 
 ```bash
 # AppImage
-chmod +x Lite_0.0.1_linux_amd64.AppImage
-./Lite_0.0.1_linux_amd64.AppImage
-
-# Debian or Ubuntu
-sudo apt install ./Lite_0.0.1_linux_amd64.deb
-
-# Fedora
-sudo dnf install ./Lite_0.0.1_linux_x86_64.rpm
+chmod +x Lite_0.0.2_linux_amd64.AppImage
+./Lite_0.0.2_linux_amd64.AppImage
 ```
+
+After installing 0.0.2, use the update button beside the theme switch to check for signed updates, install them, and restart Lite. Lite never checks for updates in the background.
 
 ## 🚀 First Run
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +594,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +866,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1384,6 +1414,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1678,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "atomicwrites",
  "portable-pty",
@@ -1791,6 +1866,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-updater",
  "tungstenite",
  "uuid",
 ]
@@ -1847,6 +1923,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2109,6 +2191,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,10 +2266,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "pango"
@@ -2575,15 +2689,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2617,6 +2736,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2661,6 +2794,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,6 +2879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2731,6 +2946,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2981,6 +3219,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,7 +3446,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3220,6 +3480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,7 +3513,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3397,6 +3668,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.19",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,7 +3710,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3429,7 +3733,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3625,6 +3929,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3934,6 +4248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,6 +4494,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4719,7 +5048,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4767,6 +5096,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4811,6 +5150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4841,6 +5186,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.1"
+version = "0.0.2"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"
@@ -28,3 +28,6 @@ portable-pty = "0.9.0"
 tauri-plugin-dialog = "2.7.2"
 tungstenite = "0.30"
 uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-updater = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_dialog::DialogExt;
+use tauri_plugin_updater::UpdaterExt;
 use tungstenite::Message;
 
 const MAX_FILE_BYTES: u64 = 500_000;
@@ -1390,9 +1391,62 @@ async fn read_usage(
     }
 }
 
+fn stop_runtime(app: &AppHandle) {
+    let sessions = app
+        .state::<Sessions>()
+        .0
+        .lock()
+        .map(|mut sessions| {
+            sessions
+                .drain()
+                .map(|(_, session)| session)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    for mut session in sessions {
+        let _ = stop_pty(&mut session);
+    }
+    stop_codex_server(&app.state::<CodexServer>());
+}
+
+#[tauri::command]
+async fn check_update(app: AppHandle) -> Result<Option<String>, String> {
+    app.updater_builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| error.to_string())?
+        .check()
+        .await
+        .map(|update| update.map(|update| update.version))
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn install_update(app: AppHandle) -> Result<(), String> {
+    let cleanup_app = app.clone();
+    let update = app
+        .updater_builder()
+        .on_before_exit(move || {
+            stop_runtime(&cleanup_app);
+            cleanup_app.cleanup_before_exit();
+        })
+        .build()
+        .map_err(|error| error.to_string())?
+        .check()
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "No update is available.".to_string())?;
+    update
+        .download_and_install(|_, _| {}, || {})
+        .await
+        .map_err(|error| error.to_string())?;
+    app.restart()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(Sessions::default())
         .manage(CodexDiscovery::default())
         .plugin(tauri_plugin_dialog::init())
@@ -1414,27 +1468,15 @@ pub fn run() {
             list_directory,
             read_text_file,
             git_status,
-            read_usage
+            read_usage,
+            check_update,
+            install_update
         ])
         .build(tauri::generate_context!())
         .expect("error while building Lite")
         .run(|app, event| {
             if matches!(event, tauri::RunEvent::Exit) {
-                let sessions = app
-                    .state::<Sessions>()
-                    .0
-                    .lock()
-                    .map(|mut sessions| {
-                        sessions
-                            .drain()
-                            .map(|(_, session)| session)
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default();
-                for mut session in sessions {
-                    let _ = stop_pty(&mut session);
-                }
-                stop_codex_server(&app.state::<CodexServer>());
+                stop_runtime(app);
             }
         });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,10 +24,17 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
     "macOS": {
       "signingIdentity": "-"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": ["https://github.com/ultralytics/lite/releases/latest/download/latest.json"],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFDMUNGQTlBNDc2QUIxMzEKUldReHNXcEhtdm9jcklXYjJZUnpCaUI2dEYra2hBOFZhdVpyeDNFRGNzTWNLampRR3lvWSt0UVQK"
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,19 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { Moon, MoreHorizontal, Plus, RotateCcw, SquareTerminal, Sun, X } from "lucide-react";
+import { Moon, MoreHorizontal, Plus, RefreshCw, RotateCcw, SquareTerminal, Sun, X } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 
 import { ClaudeLogomark, LiteLogomark, OpenAILogomark } from "@/brand-icons";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,6 +34,7 @@ import "./App.css";
 const STORAGE_KEY = "lite.sessions.v1";
 const THEME_KEY = "lite.theme";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
+type UpdateStatus = "checking" | "available" | "current" | "installing" | "error";
 
 function loadSessions(): Session[] {
   try {
@@ -164,6 +173,10 @@ function App() {
   const [error, setError] = useState("");
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
   const [theme, setTheme] = useState<"light" | "dark">(initialTheme);
+  const [updateOpen, setUpdateOpen] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
+  const [availableVersion, setAvailableVersion] = useState("");
+  const [updateError, setUpdateError] = useState("");
   const runs = useRef(new Map<string, string>());
   const selected = useMemo(() => sessions.find((session) => session.id === selectedId), [sessions, selectedId]);
 
@@ -294,6 +307,36 @@ function App() {
     if (cleanupError) setError(`Session closed, but local cleanup failed: ${cleanupError}`);
   }
 
+  async function checkForUpdates() {
+    setUpdateOpen(true);
+    setUpdateStatus("checking");
+    setUpdateError("");
+    try {
+      const version = await invoke<string | null>("check_update");
+      setAvailableVersion(version ?? "");
+      setUpdateStatus(version ? "available" : "current");
+    } catch (reason) {
+      setUpdateError(String(reason));
+      setUpdateStatus("error");
+    }
+  }
+
+  async function installUpdate() {
+    setUpdateStatus("installing");
+    try {
+      await invoke("install_update");
+    } catch (reason) {
+      setUpdateError(String(reason));
+      setUpdateStatus("error");
+    }
+  }
+
+  function changeUpdateOpen(open: boolean) {
+    if (!open && (updateStatus === "checking" || updateStatus === "installing")) return;
+    setUpdateOpen(open);
+    if (!open) setAvailableVersion("");
+  }
+
   return (
     <TooltipProvider>
       <main className="h-screen overflow-hidden bg-background text-foreground">
@@ -309,7 +352,23 @@ function App() {
                       <Button
                         variant="ghost"
                         size="icon-xs"
-                        className="relative ml-auto"
+                        className="ml-auto"
+                        onClick={() => void checkForUpdates()}
+                        aria-label="Check for updates"
+                      />
+                    }
+                  >
+                    <RefreshCw />
+                  </TooltipTrigger>
+                  <TooltipContent>Check for updates</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="relative"
                         onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
                         aria-label="Toggle theme"
                       />
@@ -413,6 +472,41 @@ function App() {
             </>
           ) : null}
         </ResizablePanelGroup>
+        <Dialog open={updateOpen} onOpenChange={changeUpdateOpen}>
+          <DialogContent showCloseButton={updateStatus !== "checking" && updateStatus !== "installing"}>
+            <DialogHeader>
+              <DialogTitle>Lite updates</DialogTitle>
+              <DialogDescription>
+                {updateStatus === "checking" ? "Checking GitHub for the latest release…" : null}
+                {updateStatus === "available" ? `Lite ${availableVersion} is ready to install.` : null}
+                {updateStatus === "current" ? "You have the latest version of Lite." : null}
+                {updateStatus === "installing" ? "Downloading and installing the update…" : null}
+                {updateStatus === "error" ? `Update failed: ${updateError}` : null}
+              </DialogDescription>
+            </DialogHeader>
+            {updateStatus === "checking" || updateStatus === "installing" ? (
+              <RefreshCw className="mx-auto size-5 animate-spin text-muted-foreground motion-reduce:animate-none" />
+            ) : null}
+            {updateStatus === "available" ? (
+              <DialogFooter>
+                <Button variant="outline" onClick={() => changeUpdateOpen(false)}>
+                  Not now
+                </Button>
+                <Button onClick={() => void installUpdate()}>Install and restart</Button>
+              </DialogFooter>
+            ) : null}
+            {updateStatus === "current" ? (
+              <DialogFooter>
+                <Button onClick={() => changeUpdateOpen(false)}>Done</Button>
+              </DialogFooter>
+            ) : null}
+            {updateStatus === "error" ? (
+              <DialogFooter>
+                <Button onClick={() => void checkForUpdates()}>Try again</Button>
+              </DialogFooter>
+            ) : null}
+          </DialogContent>
+        </Dialog>
         <NewSessionDialog open={newSessionOpen} onOpenChange={setNewSessionOpen} onCreate={createSession} />
       </main>
     </TooltipProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -476,9 +476,11 @@ function App() {
           <DialogContent showCloseButton={updateStatus !== "checking" && updateStatus !== "installing"}>
             <DialogHeader>
               <DialogTitle>Lite updates</DialogTitle>
-              <DialogDescription>
+              <DialogDescription aria-live="polite">
                 {updateStatus === "checking" ? "Checking GitHub for the latest release…" : null}
-                {updateStatus === "available" ? `Lite ${availableVersion} is ready to install.` : null}
+                {updateStatus === "available"
+                  ? `Lite ${availableVersion} is ready. Updating stops running sessions; their tabs resume after restart.`
+                  : null}
                 {updateStatus === "current" ? "You have the latest version of Lite." : null}
                 {updateStatus === "installing" ? "Downloading and installing the update…" : null}
                 {updateStatus === "error" ? `Update failed: ${updateError}` : null}


### PR DESCRIPTION
## Summary

- add an explicit signed in-app update flow owned by the native Tauri runtime
- reduce releases to Apple Silicon DMG, Linux AppImage, and Windows NSIS installer
- embed signatures in `latest.json` and block publication unless all five expected assets are valid
- release Lite 0.0.2 and update installation docs

## Release assets

1. macOS Apple Silicon DMG
2. macOS updater archive
3. Linux x64 AppImage
4. Windows x64 NSIS installer
5. signed `latest.json` manifest

Intel macOS, deb, RPM, MSI, and standalone signature assets are intentionally removed. Update checks occur only when the user clicks the sidebar control; Lite does not poll in the background.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `actionlint .github/workflows/publish.yml`
- signed Apple Silicon `app` build with the production key and matching embedded public key

Closes #11

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Adds secure, user-initiated in-app updates to Lite, with signed release artifacts and stronger publishing validation.

### 📊 Key Changes

- Added a **Check for updates** button and dialog in the Lite interface.
- Implemented update checking, downloading, signature verification, installation, and automatic restart through the Tauri updater.
- Ensured active terminal sessions and the local Codex server shut down cleanly before an update or application exit.
- Enabled signed updater artifacts and configured GitHub Releases as the update source.
- Updated the release workflow to:
  - Build macOS Apple Silicon, Linux AppImage, and Windows NSIS installers.
  - Sign update artifacts using repository secrets.
  - Publish updater metadata and attach it to the correct release tag.
  - Verify asset names, versions, signatures, and platform entries before publishing.
- Removed the macOS Intel build from the release matrix.
- Bumped Lite from **0.0.1 to 0.0.2** and refreshed installation instructions.
- Disabled updater artifact generation for debug CI builds to avoid unnecessary output.

### 🎯 Purpose & Impact

- ✅ Users can check for and install signed updates directly inside Lite instead of downloading each release manually.
- 🔐 Signed artifacts help protect users from tampered or invalid update packages.
- 🛡️ Release validation reduces the chance of publishing incomplete or misconfigured updates.
- 🔄 Updates restart Lite automatically while preserving session tabs for resumption.
- 🧹 Runtime cleanup helps prevent active sessions or background services from being left behind during updates.
- 📦 Release support is streamlined around Apple Silicon macOS, Linux AppImage, and Windows installers.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
