### PR TITLE
Publish SPDX SBOM with releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
             RELEASE_ID=$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases" \
               -f tag_name="$TAG" \
               -f name="Lite $TAG" \
-              -f body="Download the installer for your operating system below. Lite runs locally and uses your existing Claude Code and Codex authentication." \
+              -f body="Download the installer for your operating system below. Lite runs locally and uses your existing Claude Code and Codex authentication. The release includes a cross-platform source and dependency SBOM." \
               -f target_commitish="$GITHUB_SHA" \
               -F draft=true \
               -F generate_release_notes=true \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,8 +106,39 @@ jobs:
           uploadUpdaterJson: true
           uploadUpdaterSignatures: false
 
+  sbom:
+    needs: check
+    if: needs.check.outputs.increment == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile --production
+      - uses: anchore/sbom-action@v0.24.0
+        env:
+          SYFT_SOURCE_NAME: Lite
+          SYFT_SOURCE_VERSION: ${{ needs.check.outputs.tag }}
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+          path: .
+          upload-artifact: false
+          upload-release-assets: false
+      - name: Validate and upload SBOM
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check.outputs.tag }}
+        run: |
+          jq -e --arg version "${TAG#v}" '.spdxVersion == "SPDX-2.3" and .name == "Lite" and any(.packages[]; .name == "lite" and .versionInfo == $version)' sbom.spdx.json >/dev/null
+          jq -e '[.packages[].externalRefs[]? | select(.referenceType == "purl") | .referenceLocator] | any(startswith("pkg:cargo/")) and any(startswith("pkg:npm/"))' sbom.spdx.json >/dev/null
+          gh release upload "$TAG" sbom.spdx.json --clobber
+
   publish:
-    needs: [check, build]
+    needs: [check, build, sbom]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -120,7 +151,7 @@ jobs:
         run: |
           ASSETS=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets")
           VERSION=${TAG#v}
-          jq -e --arg version "$VERSION" '([.[].name] | sort) == (["Lite_\($version)_darwin_aarch64.app.tar.gz", "Lite_\($version)_darwin_aarch64.dmg", "Lite_\($version)_linux_amd64.AppImage", "Lite_\($version)_windows_x64-setup.exe", "latest.json"] | sort)' <<< "$ASSETS" >/dev/null
+          jq -e --arg version "$VERSION" '([.[].name] | sort) == (["Lite_\($version)_darwin_aarch64.app.tar.gz", "Lite_\($version)_darwin_aarch64.dmg", "Lite_\($version)_linux_amd64.AppImage", "Lite_\($version)_windows_x64-setup.exe", "latest.json", "sbom.spdx.json"] | sort)' <<< "$ASSETS" >/dev/null
           LATEST_ID=$(jq -r 'map(select(.name == "latest.json")) | first.id // empty' <<< "$ASSETS")
           test -n "$LATEST_ID"
           gh api -H "Accept: application/octet-stream" "repos/$GITHUB_REPOSITORY/releases/assets/$LATEST_ID" > "$RUNNER_TEMP/latest.json"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.2"
+version = "0.0.3"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"


### PR DESCRIPTION
## Summary

- generate one SPDX 2.3 SBOM from Lite’s production Bun dependencies and locked Rust graph
- validate Lite identity plus Cargo and npm package URLs before uploading the compliance artifact
- block release publication until the SBOM and five existing delivery assets are present
- release the workflow as v0.0.3

## Validation

- generated and validated `sbom.spdx.json` locally with Syft 1.50.0 (691 packages; Cargo and npm purls present)
- `actionlint .github/workflows/publish.yml`
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

Closes #13

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds automated SBOM generation and release validation while bumping Lite to version 0.0.3. 📦

### 📊 Key Changes

- Added a release workflow job to generate a cross-platform SPDX 2.3 software bill of materials (SBOM).
- Installed production dependencies before SBOM generation to include both Cargo and npm package references.
- Added validation checks for:
  - The Lite package name and release version.
  - Presence of Cargo and npm dependency identifiers.
- Uploaded `sbom.spdx.json` as a release asset and updated release asset validation to require it.
- Updated release notes to inform users that each release includes a source and dependency SBOM.
- Bumped the application version from `0.0.2` to `0.0.3`, including the lockfile update.

### 🎯 Purpose & Impact

- Improves software supply-chain transparency by documenting Lite’s source and dependencies. 🔍
- Helps users and organizations audit, track, and assess release components more easily.
- Prevents publishing unless the SBOM is generated and validated successfully, increasing release reliability. ✅
- Produces an additional release asset without changing Lite’s runtime behavior.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
