### PR TITLE
Pin Syft for Bun dependency discovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,7 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           path: .
+          syft-version: v1.50.0
           upload-artifact: false
           upload-release-assets: false
       - name: Validate and upload SBOM


### PR DESCRIPTION
## Summary

- pin current Syft 1.50.0 so the release SBOM discovers Bun-installed npm packages
- keep the existing Cargo and npm PURL publication gate unchanged

## Root cause

`anchore/sbom-action@v0.24.0` defaults to Syft 1.42.3. The v0.0.3 production gate correctly rejected its SBOM because that version found Cargo packages but no Bun-installed npm packages.

## Validation

- generated SPDX 2.3 locally with Syft 1.50.0: 691 packages, 493 Cargo PURLs, 181 npm PURLs
- ran both release `jq` validation expressions
- `actionlint .github/workflows/publish.yml`
- `git diff --check`

Closes #15

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Pinned the SBOM generation workflow to Syft v1.50.0 for more consistent dependency scanning. 🔒

### 📊 Key Changes

- Updated `.github/workflows/publish.yml` to explicitly use `syft-version: v1.50.0`.
- Applied the version pin to the SBOM generation step used during publishing.
- No changes were made to application code or published package functionality.

### 🎯 Purpose & Impact

- Improves reproducibility by ensuring SBOMs are generated with the same Syft version across runs. ✅
- Reduces the risk of unexpected changes from automatic tool-version updates.
- Helps maintain more predictable security and compliance metadata for releases. 🛡️