### PR TITLE
Upload SBOM to draft release by ID

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,11 +132,16 @@ jobs:
       - name: Validate and upload SBOM
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.check.outputs.release_id }}
           TAG: ${{ needs.check.outputs.tag }}
         run: |
           jq -e --arg version "${TAG#v}" '.spdxVersion == "SPDX-2.3" and .name == "Lite" and any(.packages[]; .name == "lite" and .versionInfo == $version)' sbom.spdx.json >/dev/null
           jq -e '[.packages[].externalRefs[]? | select(.referenceType == "purl") | .referenceLocator] | any(startswith("pkg:cargo/")) and any(startswith("pkg:npm/"))' sbom.spdx.json >/dev/null
-          gh release upload "$TAG" sbom.spdx.json --clobber
+          ASSET_ID=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets" --jq 'map(select(.name == "sbom.spdx.json")) | first.id // empty')
+          if [ -n "$ASSET_ID" ]; then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/assets/$ASSET_ID"
+          fi
+          gh api --method POST "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=sbom.spdx.json" -H "Content-Type: application/json" --input sbom.spdx.json >/dev/null
 
   publish:
     needs: [check, build, sbom]


### PR DESCRIPTION
## Summary

- upload the validated SBOM through the draft release ID already owned by the check job
- replace an existing SBOM asset safely on recovery reruns
- remove the invalid dependency on a tag that does not exist until publication

## Root cause

The production SBOM passed both SPDX and Cargo/npm validation gates, but `gh release upload v0.0.3` returned `release not found` because GitHub exposes the unpublished release under an internal `untagged-*` name.

## Validation

- `actionlint .github/workflows/publish.yml`
- `git diff --check`
- deleted and replaced the 1.63 MB SBOM on the private v0.0.3 draft through the exact workflow commands

Closes #17

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔐 Improved SBOM release uploads by replacing the GitHub CLI upload command with an API-based workflow that safely refreshes existing assets.

### 📊 Key Changes

- Added the release ID to the SBOM publishing job.
- Checks whether `sbom.spdx.json` already exists on the release.
- Deletes the existing SBOM asset before uploading the newly validated file.
- Uploads the SBOM directly through the GitHub Releases API.

### 🎯 Purpose & Impact

- ✅ Prevents upload conflicts and ensures releases contain the latest SBOM.
- 🛡️ Maintains SBOM validation for SPDX 2.3 format and expected Cargo/NPM package references.
- 🚀 Makes automated publishing more reliable, especially when re-running release workflows.
- 📦 Improves software supply-chain transparency without changing the SBOM contents.