### PR TITLE
Theme the terminal and fix the usage panel crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Lite is a fast, local workspace for [Claude Code](https://code.claude.com/docs/e
 ## ✨ Features
 
 - Run Claude Code, Codex, and shell sessions side by side
-- Resume session tabs after closing Lite or restarting your computer
+- Resume session tabs automatically after closing Lite or restarting your computer
 - Authenticate once with each provider and reuse its existing local credentials
 - Browse files on demand with syntax highlighting for popular languages
 - Preview rendered Markdown safely alongside source files
 - See the active Git branch, worktree, and changed files
 - Inspect per-session context and provider usage reported by Claude or Codex
 - Install signed updates from inside Lite
-- Switch between light and dark themes
+- Switch between light and dark themes, terminal and code preview included
 
 Lite is intentionally quiet: idle means idle. It does not index your repository, watch every file, read provider tokens, or send telemetry.
 
@@ -57,7 +57,7 @@ chmod +x Lite_0.0.2_linux_amd64.AppImage
 ./Lite_0.0.2_linux_amd64.AppImage
 ```
 
-After installing 0.0.2, use the update button beside the theme switch to check for signed updates, install them, and restart Lite. Lite never checks for updates in the background.
+After installing 0.0.2, open the Lite menu in the top bar and choose **Check for updates** to install signed updates and restart Lite. Lite never checks for updates in the background.
 
 ## 🚀 First Run
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "core:window:allow-start-dragging"]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,9 @@
         "width": 1280,
         "height": 800,
         "minWidth": 900,
-        "minHeight": 600
+        "minHeight": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/src/App.css
+++ b/src/App.css
@@ -5,7 +5,83 @@
 }
 
 .xterm-viewport {
-  scrollbar-color: #3f3f46 transparent;
+  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 40%, transparent) transparent;
+}
+
+/* GitHub syntax theme driven by the --syntax-* tokens, so highlighting follows light and dark. */
+.hljs {
+  display: block;
+  overflow-x: auto;
+  color: inherit;
+  background: transparent;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: var(--syntax-keyword);
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: var(--syntax-entity);
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: var(--syntax-constant);
+}
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  color: var(--syntax-string);
+}
+.hljs-built_in,
+.hljs-symbol {
+  color: var(--syntax-variable);
+}
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  color: var(--syntax-comment);
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: var(--syntax-tag);
+}
+.hljs-section {
+  color: var(--syntax-constant);
+  font-weight: 600;
+}
+.hljs-bullet {
+  color: var(--syntax-bullet);
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: 600;
+}
+.hljs-addition {
+  color: var(--syntax-addition);
+  background-color: var(--syntax-addition-background);
+}
+.hljs-deletion {
+  color: var(--syntax-deletion);
+  background-color: var(--syntax-deletion-background);
 }
 
 .markdown-viewer h1,
@@ -50,9 +126,11 @@
 }
 .markdown-viewer pre {
   overflow: auto;
+  border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: #0d0d0d;
+  background: var(--muted);
   padding: 0.9rem;
+  font-size: 0.85em;
 }
 .markdown-viewer :not(pre) > code {
   border-radius: 0.3rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -358,17 +359,21 @@ function App() {
   return (
     <TooltipProvider>
       <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
-        <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground">
+        {/* The window buttons sit inside this bar on macOS, so it doubles as the title bar and drags the window. */}
+        <header
+          data-tauri-drag-region
+          className="flex h-11 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground in-data-[platform=macos]:pl-[86px]"
+        >
           <LiteLogomark className="size-5" />
-          <span className="text-sm font-semibold">Lite</span>
           {selected ? (
             <>
-              <span className="mx-1 h-4 w-px shrink-0 bg-border" />
               <ProviderIcon agent={selected.agent} />
               <span className="min-w-0 truncate text-xs font-medium">{selected.name}</span>
               <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">{selected.cwd}</span>
             </>
-          ) : null}
+          ) : (
+            <span className="text-sm font-semibold">Lite</span>
+          )}
           <div className="ml-auto flex shrink-0 items-center gap-0.5">
             <Tooltip>
               <TooltipTrigger
@@ -393,10 +398,10 @@ function App() {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-48">
                 {version ? (
-                  <>
+                  <DropdownMenuGroup>
                     <DropdownMenuLabel>Lite {version}</DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                  </>
+                  </DropdownMenuGroup>
                 ) : null}
                 <DropdownMenuItem onClick={() => void checkForUpdates()}>
                   <RefreshCw />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Moon, MoreHorizontal, Plus, RefreshCw, RotateCcw, SquareTerminal, Sun, X } from "lucide-react";
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { Component, lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { ClaudeLogomark, LiteLogomark, OpenAILogomark } from "@/brand-icons";
+import { LiteLogomark, ProviderIcon } from "@/brand-icons";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,20 +20,23 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Inspector } from "@/inspector";
 import { NewSessionDialog } from "@/new-session-dialog";
 import { appendOutput, clearOutput } from "@/output-store";
-import type { Session } from "@/types";
+import { applyTheme, initialTheme, type Theme } from "@/theme";
+import { agentLabels, type Session } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
-const THEME_KEY = "lite.theme";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
 type UpdateStatus = "checking" | "available" | "current" | "installing" | "error";
 
@@ -45,16 +49,23 @@ function loadSessions(): Session[] {
   }
 }
 
-function ProviderIcon({ agent }: Pick<Session, "agent">) {
-  if (agent === "claude") return <ClaudeLogomark className="size-4" />;
-  if (agent === "codex") return <OpenAILogomark className="size-4" />;
-  return <SquareTerminal className="size-4" />;
-}
+// Keeps a failing panel from taking the whole window down with it.
+class PanelBoundary extends Component<{ children: ReactNode }, { message: string }> {
+  state = { message: "" };
 
-export function initialTheme(): "light" | "dark" {
-  const saved = localStorage.getItem(THEME_KEY);
-  if (saved === "light" || saved === "dark") return saved;
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  static getDerivedStateFromError(error: unknown) {
+    return { message: String(error) };
+  }
+
+  render() {
+    if (!this.state.message) return this.props.children;
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+        <p className="text-xs font-medium">This panel stopped responding.</p>
+        <p className="text-xs text-muted-foreground">{this.state.message}</p>
+      </div>
+    );
+  }
 }
 
 function SessionRow({
@@ -86,56 +97,54 @@ function SessionRow({
 
   return (
     <div
-      className={`group flex items-center gap-1 rounded-lg pr-1 ${active ? "bg-sidebar-accent text-sidebar-accent-foreground" : "hover:bg-sidebar-accent/70"}`}
+      className={`group flex items-center rounded-lg pr-1 ${active ? "bg-sidebar-accent text-sidebar-accent-foreground" : "hover:bg-sidebar-accent/60"}`}
     >
-      {renaming ? (
-        <div className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-2">
-          <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
-            <ProviderIcon agent={session.agent} />
-          </span>
-          <span className="min-w-0 flex-1">
+      <div className="flex min-w-0 flex-1 items-center gap-2.5 py-1.5 pl-2">
+        <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
+          <ProviderIcon agent={session.agent} />
+          {starting ? (
+            <Spinner
+              className={`absolute -right-1 -bottom-1 size-3 rounded-full bg-background text-muted-foreground ring-2 ${active ? "ring-sidebar-accent" : "ring-sidebar"}`}
+            />
+          ) : (
+            <span
+              role="img"
+              className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${active ? "ring-sidebar-accent" : "ring-sidebar"} ${session.running ? "bg-emerald-500" : "bg-muted-foreground/40"}`}
+              aria-label={session.running ? "Running" : "Not running"}
+            />
+          )}
+        </span>
+        {renaming ? (
+          <span className="min-w-0 flex-1 py-0.5">
             <Input
               autoFocus
               value={name}
               className="h-6 px-1.5 text-xs"
+              aria-label="Session name"
               onChange={(event) => setName(event.target.value)}
               onBlur={saveName}
               onKeyDown={(event) => {
                 if (event.key === "Enter") saveName();
+                if (event.key === "Escape") {
+                  setName(session.name);
+                  setRenaming(false);
+                }
               }}
             />
-            <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">{session.cwd}</span>
           </span>
-        </div>
-      ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-2">
-          <button type="button" onClick={onSelect} aria-label={`Open ${session.name}`}>
-            <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
-              <ProviderIcon agent={session.agent} />
-              <span
-                className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ring-sidebar ${session.running ? "bg-emerald-500" : "bg-muted-foreground/50"}`}
-              />
-            </span>
+        ) : (
+          <button
+            type="button"
+            className="min-w-0 flex-1 py-0.5 text-left"
+            onClick={onSelect}
+            onDoubleClick={() => setRenaming(true)}
+            title={session.cwd}
+          >
+            <span className="block truncate text-xs font-medium">{session.name}</span>
+            <span className="mt-0.5 block truncate font-mono text-[10px] text-muted-foreground">{session.cwd}</span>
           </button>
-          <span className="min-w-0 flex-1">
-            <button
-              type="button"
-              className="block w-full truncate text-left text-xs font-medium hover:underline"
-              title="Rename session"
-              onClick={() => setRenaming(true)}
-            >
-              {session.name}
-            </button>
-            <button
-              type="button"
-              onClick={onSelect}
-              className="mt-0.5 block w-full truncate text-left text-[11px] text-muted-foreground"
-            >
-              {session.cwd}
-            </button>
-          </span>
-        </div>
-      )}
+        )}
+      </div>
       <DropdownMenu>
         <DropdownMenuTrigger
           render={
@@ -143,8 +152,8 @@ function SessionRow({
               variant="ghost"
               size="icon-xs"
               disabled={starting}
-              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-              aria-label="Session actions"
+              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 aria-expanded:opacity-100"
+              aria-label={`Actions for ${session.name}`}
             />
           }
         >
@@ -172,23 +181,29 @@ function App() {
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [error, setError] = useState("");
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
-  const [theme, setTheme] = useState<"light" | "dark">(initialTheme);
+  const [theme, setTheme] = useState<Theme>(initialTheme);
+  const [version, setVersion] = useState("");
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
   const [updateError, setUpdateError] = useState("");
   const runs = useRef(new Map<string, string>());
+  const resumed = useRef("");
   const selected = useMemo(() => sessions.find((session) => session.id === selectedId), [sessions, selectedId]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle("dark", theme === "dark");
-    document.documentElement.style.colorScheme = theme;
-    localStorage.setItem(THEME_KEY, theme);
+    applyTheme(theme);
   }, [theme]);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions.map((session) => ({ ...session, running: false }))));
   }, [sessions]);
+
+  useEffect(() => {
+    void getVersion()
+      .then(setVersion)
+      .catch(() => setVersion(""));
+  }, []);
 
   useEffect(() => {
     let disposed = false;
@@ -221,7 +236,7 @@ function App() {
     };
   }, []);
 
-  async function launch(session: Session, resume: boolean) {
+  const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return;
     const runId = crypto.randomUUID();
     runs.current.set(session.id, runId);
@@ -266,17 +281,20 @@ function App() {
       setSessions((current) => current.map((item) => (item.id === session.id ? { ...item, running: false } : item)));
       setError(String(reason));
     }
-  }
+  }, []);
+
+  // Opening the app, or coming back to a session, brings its provider process back on its own.
+  useEffect(() => {
+    if (!selected || selected.running || resumed.current === selected.id) return;
+    resumed.current = selected.id;
+    void launch(selected, true);
+  }, [selected, launch]);
 
   function createSession(session: Session) {
+    resumed.current = session.id;
     setSessions((current) => [...current, session]);
     setSelectedId(session.id);
     void launch(session, false);
-  }
-
-  function selectSession(session: Session) {
-    setSelectedId(session.id);
-    if (!session.running) void launch(session, true);
   }
 
   async function restartSession(session: Session) {
@@ -312,9 +330,9 @@ function App() {
     setUpdateStatus("checking");
     setUpdateError("");
     try {
-      const version = await invoke<string | null>("check_update");
-      setAvailableVersion(version ?? "");
-      setUpdateStatus(version ? "available" : "current");
+      const next = await invoke<string | null>("check_update");
+      setAvailableVersion(next ?? "");
+      setUpdateStatus(next ? "available" : "current");
     } catch (reason) {
       setUpdateError(String(reason));
       setUpdateStatus("error");
@@ -339,56 +357,85 @@ function App() {
 
   return (
     <TooltipProvider>
-      <main className="h-screen overflow-hidden bg-background text-foreground">
-        <ResizablePanelGroup orientation="horizontal">
-          <ResizablePanel defaultSize="18%" minSize="14%" maxSize="26%">
+      <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
+        <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground">
+          <LiteLogomark className="size-5" />
+          <span className="text-sm font-semibold">Lite</span>
+          {selected ? (
+            <>
+              <span className="mx-1 h-4 w-px shrink-0 bg-border" />
+              <ProviderIcon agent={selected.agent} />
+              <span className="min-w-0 truncate text-xs font-medium">{selected.name}</span>
+              <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">{selected.cwd}</span>
+            </>
+          ) : null}
+          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="relative"
+                    onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+                    aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+                  />
+                }
+              >
+                <Sun className="size-4 rotate-0 scale-100 transition-transform motion-reduce:transition-none dark:-rotate-90 dark:scale-0" />
+                <Moon className="absolute size-4 rotate-90 scale-0 transition-transform motion-reduce:transition-none dark:rotate-0 dark:scale-100" />
+              </TooltipTrigger>
+              <TooltipContent>{theme === "dark" ? "Light mode" : "Dark mode"}</TooltipContent>
+            </Tooltip>
+            <DropdownMenu>
+              <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="Lite menu" />}>
+                <MoreHorizontal />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                {version ? (
+                  <>
+                    <DropdownMenuLabel>Lite {version}</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                  </>
+                ) : null}
+                <DropdownMenuItem onClick={() => void checkForUpdates()}>
+                  <RefreshCw />
+                  Check for updates
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </header>
+        <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+          <ResizablePanel defaultSize="20%" minSize="15%" maxSize="30%">
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
-              <div className="flex h-12 items-center gap-2 border-b border-sidebar-border px-3">
-                <LiteLogomark className="size-6" />
-                <span className="text-sm font-semibold">Lite</span>
+              <div className="flex h-9 shrink-0 items-center justify-between pr-1.5 pl-3">
+                <span className="text-[11px] font-medium tracking-wide text-muted-foreground uppercase">Sessions</span>
                 <Tooltip>
                   <TooltipTrigger
                     render={
                       <Button
                         variant="ghost"
                         size="icon-xs"
-                        className="ml-auto"
-                        onClick={() => void checkForUpdates()}
-                        aria-label="Check for updates"
+                        onClick={() => setNewSessionOpen(true)}
+                        aria-label="New session"
                       />
                     }
                   >
-                    <RefreshCw />
+                    <Plus />
                   </TooltipTrigger>
-                  <TooltipContent>Check for updates</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        className="relative"
-                        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-                        aria-label="Toggle theme"
-                      />
-                    }
-                  >
-                    <Sun className="size-4 rotate-0 scale-100 transition-transform motion-reduce:transition-none dark:-rotate-90 dark:scale-0" />
-                    <Moon className="absolute size-4 rotate-90 scale-0 transition-transform motion-reduce:transition-none dark:rotate-0 dark:scale-100" />
-                  </TooltipTrigger>
-                  <TooltipContent>{theme === "dark" ? "Light mode" : "Dark mode"}</TooltipContent>
+                  <TooltipContent>New session</TooltipContent>
                 </Tooltip>
               </div>
               <ScrollArea className="min-h-0 flex-1">
-                <div className="space-y-1 p-2">
+                <div className="space-y-0.5 px-2 pb-2">
                   {sessions.map((session) => (
                     <SessionRow
                       key={session.id}
                       session={session}
                       active={session.id === selectedId}
                       starting={startingIds.has(session.id)}
-                      onSelect={() => selectSession(session)}
+                      onSelect={() => setSelectedId(session.id)}
                       onRename={(name) =>
                         setSessions((current) =>
                           current.map((item) => (item.id === session.id ? { ...item, name } : item)),
@@ -398,57 +445,44 @@ function App() {
                       onClose={() => void closeSession(session)}
                     />
                   ))}
-                  <button
-                    type="button"
-                    onClick={() => setNewSessionOpen(true)}
-                    className="flex w-full items-center gap-2.5 rounded-lg border border-dashed px-2 py-2 text-left text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                  >
-                    <span className="flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
-                      <Plus className="size-4" />
-                    </span>
-                    <span className="text-xs font-medium">New session</span>
-                  </button>
                 </div>
               </ScrollArea>
             </aside>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize="57%" minSize="38%">
+          <ResizablePanel defaultSize="55%" minSize="38%">
             <section className="flex h-full min-w-0 flex-col">
               {selected ? (
-                <>
-                  <header className="flex h-11 shrink-0 items-center gap-3 border-b px-3">
-                    <ProviderIcon agent={selected.agent} />
-                    <span className="truncate text-xs font-medium">{selected.name}</span>
-                    <span className="truncate text-xs text-muted-foreground">{selected.cwd}</span>
-                  </header>
-                  <div className="min-h-0 flex-1 bg-[#0d0d0d]">
-                    {selected.running ? (
-                      <Suspense fallback={<div className="h-full bg-[#0d0d0d]" />}>
-                        <TerminalView sessionId={selected.id} />
-                      </Suspense>
-                    ) : startingIds.has(selected.id) ? (
-                      <div className="flex h-full items-center justify-center text-sm text-zinc-400">Starting…</div>
-                    ) : (
-                      <button
-                        type="button"
-                        className="flex h-full w-full flex-col items-center justify-center gap-3 text-zinc-400"
-                        onClick={() => void launch(selected, true)}
-                      >
-                        <RotateCcw className="size-5" />
-                        <span className="text-sm">Resume session</span>
-                      </button>
-                    )}
-                  </div>
-                </>
+                <div className="min-h-0 flex-1">
+                  {selected.running ? (
+                    <Suspense fallback={<div className="h-full bg-background" />}>
+                      <TerminalView sessionId={selected.id} theme={theme} />
+                    </Suspense>
+                  ) : startingIds.has(selected.id) ? (
+                    <div className="flex h-full flex-col items-center justify-center gap-3">
+                      <Spinner className="size-5 text-muted-foreground" />
+                      <p className="text-xs text-muted-foreground">Starting {agentLabels[selected.agent]}…</p>
+                    </div>
+                  ) : (
+                    <div className="flex h-full flex-col items-center justify-center gap-3">
+                      <p className="text-xs text-muted-foreground">This session is not running.</p>
+                      <Button variant="outline" size="sm" onClick={() => void launch(selected, true)}>
+                        <RotateCcw />
+                        Resume session
+                      </Button>
+                    </div>
+                  )}
+                </div>
               ) : (
                 <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
                   <div className="flex size-12 items-center justify-center rounded-2xl border bg-muted">
                     <SquareTerminal className="size-5" />
                   </div>
                   <div>
-                    <h1 className="text-sm font-medium">Start light</h1>
-                    <p className="mt-1 text-xs text-muted-foreground">Choose a folder and open your first session.</p>
+                    <h1 className="text-sm font-medium">Start a session</h1>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Pick a project folder and open Claude Code, Codex, or your shell.
+                    </p>
                   </div>
                   <Button onClick={() => setNewSessionOpen(true)}>
                     <Plus />
@@ -457,7 +491,18 @@ function App() {
                 </div>
               )}
               {error ? (
-                <div className="border-t bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>
+                <div className="flex shrink-0 items-start gap-2 border-t bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  <span className="min-w-0 flex-1">{error}</span>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-destructive hover:bg-destructive/10"
+                    onClick={() => setError("")}
+                    aria-label="Dismiss message"
+                  >
+                    <X />
+                  </Button>
+                </div>
               ) : null}
             </section>
           </ResizablePanel>
@@ -465,8 +510,10 @@ function App() {
             <>
               <ResizableHandle />
               <ResizablePanel defaultSize="25%" minSize="18%" maxSize="40%">
-                <aside className="h-full">
-                  <Inspector key={selected.id} session={selected} />
+                <aside className="h-full border-l">
+                  <PanelBoundary key={selected.id}>
+                    <Inspector session={selected} />
+                  </PanelBoundary>
                 </aside>
               </ResizablePanel>
             </>
@@ -487,7 +534,7 @@ function App() {
               </DialogDescription>
             </DialogHeader>
             {updateStatus === "checking" || updateStatus === "installing" ? (
-              <RefreshCw className="mx-auto size-5 animate-spin text-muted-foreground motion-reduce:animate-none" />
+              <Spinner className="mx-auto size-5 text-muted-foreground" />
             ) : null}
             {updateStatus === "available" ? (
               <DialogFooter>
@@ -510,7 +557,7 @@ function App() {
           </DialogContent>
         </Dialog>
         <NewSessionDialog open={newSessionOpen} onOpenChange={setNewSessionOpen} onCreate={createSession} />
-      </main>
+      </div>
     </TooltipProvider>
   );
 }

--- a/src/brand-icons.tsx
+++ b/src/brand-icons.tsx
@@ -1,5 +1,15 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import { SquareTerminal } from "lucide-react";
+
+import type { Agent } from "@/types";
+
+export const ProviderIcon = ({ agent, className = "size-4" }: { agent: Agent; className?: string }) => {
+  if (agent === "claude") return <ClaudeLogomark className={className} />;
+  if (agent === "codex") return <OpenAILogomark className={className} />;
+  return <SquareTerminal className={className} />;
+};
+
 export const LiteLogomark = ({ className = "size-4" }: { className?: string }) => (
   <svg className={className} viewBox="0 0 640 640" role="img" aria-label="Lite">
     <title>Lite</title>

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -22,7 +22,6 @@ import yaml from "highlight.js/lib/languages/yaml";
 import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import "highlight.js/styles/github-dark.css";
 
 const languages = {
   bash,
@@ -119,7 +118,7 @@ export default function CodePreview({ path, source }: { path: string; source: st
     );
   }
   return (
-    <pre className="min-h-full overflow-auto bg-[#0d0d0d] p-5 text-[13px] leading-5 text-zinc-200">
+    <pre className="min-h-full overflow-auto p-4 font-mono text-[12.5px] leading-5">
       <HighlightedCode source={source} language={extensionLanguages[extension]} />
     </pre>
   );

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,21 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+"use client";
+
+import { Loader2Icon } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin motion-reduce:animate-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,14 +12,14 @@ function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
       {...props}
     />
   );
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-8 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -53,10 +53,10 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className,
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -88,6 +88,19 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  /* GitHub light syntax colors, shared by the code preview and the terminal palette */
+  --syntax-keyword: #d73a49;
+  --syntax-entity: #6f42c1;
+  --syntax-constant: #005cc5;
+  --syntax-string: #032f62;
+  --syntax-variable: #e36209;
+  --syntax-comment: #6a737d;
+  --syntax-tag: #22863a;
+  --syntax-bullet: #735c0f;
+  --syntax-addition: #22863a;
+  --syntax-addition-background: #f0fff4;
+  --syntax-deletion: #b31d28;
+  --syntax-deletion-background: #ffeef0;
 }
 
 .dark {
@@ -122,6 +135,19 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  /* GitHub dark syntax colors */
+  --syntax-keyword: #ff7b72;
+  --syntax-entity: #d2a8ff;
+  --syntax-constant: #79c0ff;
+  --syntax-string: #a5d6ff;
+  --syntax-variable: #ffa657;
+  --syntax-comment: #8b949e;
+  --syntax-tag: #7ee787;
+  --syntax-bullet: #f2cc60;
+  --syntax-addition: #aff5b4;
+  --syntax-addition-background: #033a16;
+  --syntax-deletion: #ffdcd7;
+  --syntax-deletion-background: #67060c;
 }
 
 @layer base {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1,31 +1,32 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { ChevronRight, File, FileCode2, Folder, FolderTree, Gauge, GitBranch, RefreshCw, X } from "lucide-react";
+import { ChevronRight, File, Folder, GitBranch, RefreshCw, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { DirectoryCursor, DirectoryListing, FileEntry, GitStatus, Session } from "@/types";
 
 const CodePreview = lazy(() => import("@/code-preview"));
 
+// Every optional field arrives from Serde as null, never as a missing key.
 interface UsageWindow {
   label: string;
   usedPercent: number;
-  resetsAt?: number;
-  windowMinutes?: number;
+  resetsAt: number | null;
+  windowMinutes: number | null;
 }
 
 interface UsageSnapshot {
-  contextUsedPercent?: number;
-  contextWindow?: number;
-  contextTokens?: number;
-  costUsd?: number;
-  lifetimeTokens?: number;
+  contextUsedPercent: number | null;
+  contextWindow: number | null;
+  contextTokens: number | null;
+  costUsd: number | null;
+  lifetimeTokens: number | null;
   windows: UsageWindow[];
 }
 
@@ -34,12 +35,22 @@ const formatNumber = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 1,
 });
 
+function Loading({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+      <Spinner className="size-3.5" />
+      {label}
+    </div>
+  );
+}
+
 function Meter({ value }: { value: number }) {
+  const bounded = Math.max(0, Math.min(100, value));
   return (
     <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
       <div
-        className="h-full rounded-full bg-foreground transition-[width]"
-        style={{ width: `${Math.max(0, Math.min(100, value))}%` }}
+        className={`h-full rounded-full transition-[width] ${bounded >= 90 ? "bg-destructive" : "bg-foreground"}`}
+        style={{ width: `${bounded}%` }}
       />
     </div>
   );
@@ -83,7 +94,7 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
 
   function rows(path: string, depth = 0): React.ReactNode {
     const listing = children[path];
-    if (!listing) return null;
+    if (!listing) return loadingPaths.has(path) ? <Loading label="Reading folder…" /> : null;
     return (
       <>
         {listing.entries.map((entry) => (
@@ -178,18 +189,18 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   if (selected) {
     return (
       <div className="flex h-full min-h-0 flex-col">
-        <div className="flex h-10 shrink-0 items-center gap-2 border-b px-2">
-          <FileCode2 className="size-4 text-muted-foreground" />
-          <span className="min-w-0 flex-1 truncate text-xs font-medium">{selected.name}</span>
+        <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2">
+          <File className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate font-mono text-xs">{selected.name}</span>
           <Button variant="ghost" size="icon-xs" onClick={() => setSelected(null)} aria-label="Close file">
             <X />
           </Button>
         </div>
         <ScrollArea className="min-h-0 flex-1">
           {error ? (
-            <div className="p-4 text-xs text-muted-foreground">{error}</div>
+            <div className="p-3 text-xs text-muted-foreground">{error}</div>
           ) : (
-            <Suspense fallback={<div className="p-4 text-xs text-muted-foreground">Opening file…</div>}>
+            <Suspense fallback={<Loading label="Opening file…" />}>
               <CodePreview path={selected.path} source={source} />
             </Suspense>
           )}
@@ -207,13 +218,17 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
 function GitPanel({ rootId }: { rootId: string }) {
   const [status, setStatus] = useState<GitStatus | null>();
   const [error, setError] = useState("");
+  const [reading, setReading] = useState(false);
 
   const refresh = useCallback(async () => {
     setError("");
+    setReading(true);
     try {
       setStatus(await invoke<GitStatus | null>("git_status", { rootId }));
     } catch (reason) {
       setError(String(reason));
+    } finally {
+      setReading(false);
     }
   }, [rootId]);
 
@@ -222,47 +237,62 @@ function GitPanel({ rootId }: { rootId: string }) {
   }, [refresh]);
 
   return (
-    <div className="h-full overflow-auto p-3 text-xs">
-      <div className="mb-3 flex items-center justify-between">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b px-3 text-xs">
         <span className="font-medium">Repository</span>
-        <Button variant="ghost" size="icon-xs" onClick={() => void refresh()} aria-label="Refresh Git status">
-          <RefreshCw />
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          disabled={reading}
+          onClick={() => void refresh()}
+          aria-label="Refresh Git status"
+        >
+          {reading ? <Spinner /> : <RefreshCw />}
         </Button>
       </div>
-      {error ? (
-        <p className="text-destructive">{error}</p>
-      ) : status === null ? (
-        <p className="text-muted-foreground">This folder is not a Git repository.</p>
-      ) : status === undefined ? (
-        <p className="text-muted-foreground">Reading Git status…</p>
-      ) : (
-        <>
-          <div className="space-y-2 rounded-lg border p-3">
-            <div className="flex items-center gap-2">
-              <GitBranch className="size-3.5" />
-              <span className="truncate font-medium">{status.branch}</span>
-            </div>
-            <p className="truncate text-muted-foreground" title={status.worktree}>
-              {status.worktree}
-            </p>
-            <Badge variant={status.changes.length ? "secondary" : "outline"}>
-              {status.changes.length
-                ? `${status.changes.length}${status.changesTruncated ? "+" : ""} changed`
-                : "Clean"}
-            </Badge>
-          </div>
-          {status.changes.length ? (
-            <div className="mt-4 space-y-1">
-              <p className="mb-2 font-medium">Changes</p>
-              {status.changes.map((change) => (
-                <div key={change} className="truncate rounded-md px-2 py-1.5 hover:bg-muted">
-                  {change}
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="p-3 text-xs">
+          {error ? (
+            <p className="text-destructive">{error}</p>
+          ) : status === undefined ? (
+            <Loading label="Reading Git status…" />
+          ) : status === null ? (
+            <p className="text-muted-foreground">This folder is not a Git repository.</p>
+          ) : (
+            <>
+              <div className="space-y-2 rounded-lg border p-3">
+                <div className="flex items-center gap-2">
+                  <GitBranch className="size-3.5 shrink-0" />
+                  <span className="truncate font-mono font-medium">{status.branch}</span>
                 </div>
-              ))}
-            </div>
-          ) : null}
-        </>
-      )}
+                <p className="truncate font-mono text-muted-foreground" title={status.worktree}>
+                  {status.worktree}
+                </p>
+                <Badge variant={status.changes.length ? "secondary" : "outline"}>
+                  {status.changes.length
+                    ? `${status.changes.length}${status.changesTruncated ? "+" : ""} changed`
+                    : "Clean"}
+                </Badge>
+              </div>
+              {status.changes.length ? (
+                <div className="mt-4">
+                  <p className="mb-2 font-medium">Changes</p>
+                  {status.changes.map((change) => (
+                    <div key={change} className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted">
+                      <span className="w-5 shrink-0 font-mono text-[11px] text-muted-foreground">
+                        {change.slice(0, 2).trim()}
+                      </span>
+                      <span className="truncate font-mono" title={change.slice(3)}>
+                        {change.slice(3)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      </ScrollArea>
     </div>
   );
 }
@@ -270,13 +300,11 @@ function GitPanel({ rootId }: { rootId: string }) {
 function UsagePanel({ session }: { session: Session }) {
   const [usage, setUsage] = useState<UsageSnapshot | null>();
   const [error, setError] = useState("");
+  const [reading, setReading] = useState(false);
 
   const refresh = useCallback(async () => {
     setError("");
-    if (session.agent === "shell") {
-      setUsage(null);
-      return;
-    }
+    setReading(true);
     try {
       setUsage(
         await invoke<UsageSnapshot | null>("read_usage", {
@@ -286,106 +314,112 @@ function UsagePanel({ session }: { session: Session }) {
       );
     } catch (reason) {
       setError(String(reason));
+    } finally {
+      setReading(false);
     }
   }, [session.agent, session.id]);
 
   useEffect(() => {
-    void refresh();
-  }, [refresh]);
+    if (session.agent === "shell") setUsage(null);
+    else void refresh();
+  }, [refresh, session.agent]);
 
   return (
-    <div className="space-y-4 p-3 text-xs">
-      <div className="flex items-center justify-between">
-        <p className="font-medium">Usage</p>
-        {session.agent !== "shell" ? (
-          <Button variant="ghost" size="icon-xs" onClick={() => void refresh()} aria-label="Refresh usage">
-            <RefreshCw />
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b px-3 text-xs">
+        <span className="font-medium">Usage</span>
+        {session.agent === "shell" ? null : (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            disabled={reading}
+            onClick={() => void refresh()}
+            aria-label="Refresh usage"
+          >
+            {reading ? <Spinner /> : <RefreshCw />}
           </Button>
-        ) : null}
+        )}
       </div>
-      {error ? (
-        <p className="text-destructive">{error}</p>
-      ) : session.agent === "shell" ? (
-        <div className="rounded-lg border p-3 text-muted-foreground">Usage is not available for shell sessions.</div>
-      ) : usage === undefined ? (
-        <p className="text-muted-foreground">Reading provider usage…</p>
-      ) : usage === null ? (
-        <div className="rounded-lg border p-3 text-muted-foreground">
-          Available after the first {session.agent === "claude" ? "Claude response" : "provider update"}.
-        </div>
-      ) : (
-        <>
-          {usage.contextUsedPercent !== undefined ? (
-            <div className="rounded-lg border p-3">
-              <div className="flex justify-between">
-                <span>Session context</span>
-                <span className="tabular-nums">{usage.contextUsedPercent.toFixed(0)}%</span>
-              </div>
-              <Meter value={usage.contextUsedPercent} />
-              {usage.contextTokens !== undefined ? (
-                <p className="mt-2 text-muted-foreground">
-                  {formatNumber.format(usage.contextTokens)}
-                  {usage.contextWindow ? ` of ${formatNumber.format(usage.contextWindow)}` : ""} tokens
-                </p>
-              ) : null}
-              {usage.costUsd !== undefined ? (
-                <p className="mt-1 text-muted-foreground">${usage.costUsd.toFixed(2)} session cost</p>
-              ) : null}
-            </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-3 p-3 text-xs">
+          {error ? (
+            <p className="text-destructive">{error}</p>
+          ) : session.agent === "shell" ? (
+            <p className="text-muted-foreground">Shell sessions report no provider usage.</p>
+          ) : usage === undefined ? (
+            <Loading label="Reading provider usage…" />
+          ) : usage === null ? (
+            <p className="text-muted-foreground">
+              Usage appears after {session.agent === "claude" ? "Claude" : "the provider"} reports its first update.
+            </p>
           ) : (
-            <div className="rounded-lg border p-3 text-muted-foreground">
-              Per-session context is not reported by the {session.agent === "codex" ? "Codex CLI" : "provider yet"}.
-            </div>
-          )}
-          {usage.lifetimeTokens !== undefined ? (
-            <div className="rounded-lg border p-3">
-              <p>Provider total</p>
-              <p className="mt-1 text-lg font-medium tabular-nums">
-                {formatNumber.format(usage.lifetimeTokens)} tokens
-              </p>
-            </div>
-          ) : null}
-          {usage.windows.map((window) => (
-            <div key={`${window.label}-${window.windowMinutes ?? ""}`} className="rounded-lg border p-3">
-              <div className="flex justify-between gap-2">
-                <span className="truncate">{window.label}</span>
-                <span className="tabular-nums">{window.usedPercent.toFixed(0)}%</span>
-              </div>
-              <Meter value={window.usedPercent} />
-              {window.resetsAt ? (
-                <p className="mt-2 text-muted-foreground">Resets {new Date(window.resetsAt * 1000).toLocaleString()}</p>
+            <>
+              {usage.contextUsedPercent != null ? (
+                <div className="rounded-lg border p-3">
+                  <div className="flex justify-between">
+                    <span>Session context</span>
+                    <span className="tabular-nums">{usage.contextUsedPercent.toFixed(0)}%</span>
+                  </div>
+                  <Meter value={usage.contextUsedPercent} />
+                  {usage.contextTokens != null ? (
+                    <p className="mt-2 text-muted-foreground tabular-nums">
+                      {formatNumber.format(usage.contextTokens)}
+                      {usage.contextWindow ? ` of ${formatNumber.format(usage.contextWindow)}` : ""} tokens
+                    </p>
+                  ) : null}
+                  {usage.costUsd != null ? (
+                    <p className="mt-1 text-muted-foreground tabular-nums">${usage.costUsd.toFixed(2)} session cost</p>
+                  ) : null}
+                </div>
+              ) : (
+                <p className="text-muted-foreground">
+                  {session.agent === "codex" ? "The Codex CLI" : "This provider"} does not report per-session context.
+                </p>
+              )}
+              {usage.windows.map((window) => (
+                <div key={`${window.label}-${window.windowMinutes ?? ""}`} className="rounded-lg border p-3">
+                  <div className="flex justify-between gap-2">
+                    <span className="truncate">{window.label}</span>
+                    <span className="tabular-nums">{window.usedPercent.toFixed(0)}%</span>
+                  </div>
+                  <Meter value={window.usedPercent} />
+                  {window.resetsAt != null ? (
+                    <p className="mt-2 text-muted-foreground">
+                      Resets {new Date(window.resetsAt * 1000).toLocaleString()}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+              {usage.lifetimeTokens != null ? (
+                <div className="rounded-lg border p-3">
+                  <p className="text-muted-foreground">Provider total</p>
+                  <p className="mt-1 text-lg font-medium tabular-nums">
+                    {formatNumber.format(usage.lifetimeTokens)} tokens
+                  </p>
+                </div>
               ) : null}
-            </div>
-          ))}
-        </>
-      )}
+            </>
+          )}
+        </div>
+      </ScrollArea>
     </div>
   );
 }
 
 export function Inspector({ session }: { session: Session }) {
   return (
-    <Tabs defaultValue="files" className="h-full gap-0">
-      <div className="flex h-11 shrink-0 items-center border-b px-2">
-        <TabsList variant="line" className="h-8">
-          <Tooltip>
-            <TooltipTrigger render={<TabsTrigger value="files" className="size-8" aria-label="Files" />}>
-              <FolderTree />
-            </TooltipTrigger>
-            <TooltipContent>Files and code preview</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger render={<TabsTrigger value="git" className="size-8" aria-label="Git" />}>
-              <GitBranch />
-            </TooltipTrigger>
-            <TooltipContent>Git branch and changes</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger render={<TabsTrigger value="usage" className="size-8" aria-label="Usage" />}>
-              <Gauge />
-            </TooltipTrigger>
-            <TooltipContent>Context and usage limits</TooltipContent>
-          </Tooltip>
+    <Tabs defaultValue="files" className="h-full min-h-0 gap-0">
+      <div className="flex h-11 shrink-0 items-center border-b px-3">
+        <TabsList variant="line" className="h-8 gap-4">
+          <TabsTrigger value="files" className="px-0 text-xs">
+            Files
+          </TabsTrigger>
+          <TabsTrigger value="git" className="px-0 text-xs">
+            Git
+          </TabsTrigger>
+          <TabsTrigger value="usage" className="px-0 text-xs">
+            Usage
+          </TabsTrigger>
         </TabsList>
       </div>
       <TabsContent value="files" className="min-h-0 overflow-hidden">
@@ -394,7 +428,7 @@ export function Inspector({ session }: { session: Session }) {
       <TabsContent value="git" className="min-h-0 overflow-hidden">
         <GitPanel rootId={session.rootId} />
       </TabsContent>
-      <TabsContent value="usage" className="min-h-0 overflow-auto">
+      <TabsContent value="usage" className="min-h-0 overflow-hidden">
         <UsagePanel session={session} />
       </TabsContent>
     </Tabs>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,9 @@ import "./index.css";
 
 applyTheme(initialTheme());
 
+// macOS draws its window buttons over the top bar, so the bar reserves room for them there and nowhere else.
+if (navigator.userAgent.includes("Macintosh")) document.documentElement.dataset.platform = "macos";
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,11 @@
 
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App, { initialTheme } from "./App";
+import App from "./App";
+import { applyTheme, initialTheme } from "./theme";
 import "./index.css";
 
-const theme = initialTheme();
-document.documentElement.classList.toggle("dark", theme === "dark");
-document.documentElement.style.colorScheme = theme;
+applyTheme(initialTheme());
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -1,10 +1,10 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { FolderOpen, TerminalSquare } from "lucide-react";
+import { FolderOpen } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { ClaudeLogomark, OpenAILogomark } from "@/brand-icons";
+import { ProviderIcon } from "@/brand-icons";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,32 +15,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import type { Agent, Session } from "@/types";
+import { type Agent, agentLabels, type Session } from "@/types";
 
-const agents: {
-  id: Agent;
-  label: string;
-  description: string;
-  icon: React.ReactNode;
-}[] = [
-  {
-    id: "claude",
-    label: "Claude Code",
-    description: "Use your Anthropic account",
-    icon: <ClaudeLogomark className="size-5" />,
-  },
-  {
-    id: "codex",
-    label: "Codex",
-    description: "Use your OpenAI account",
-    icon: <OpenAILogomark className="size-5" />,
-  },
-  {
-    id: "shell",
-    label: "Shell",
-    description: "Open your default shell",
-    icon: <TerminalSquare className="size-5" />,
-  },
+const agents: { id: Agent; description: string }[] = [
+  { id: "claude", description: "Use your Anthropic account" },
+  { id: "codex", description: "Use your OpenAI account" },
+  { id: "shell", description: "Open your default shell" },
 ];
 
 interface DirectoryGrant {
@@ -126,11 +106,12 @@ export function NewSessionDialog({
             <button
               key={option.id}
               type="button"
+              aria-pressed={agent === option.id}
               onClick={() => setAgent(option.id)}
               className={`flex min-h-24 flex-col items-start gap-2 rounded-xl border p-3 text-left transition-colors ${agent === option.id ? "border-foreground bg-muted" : "hover:bg-muted/60"}`}
             >
-              {option.icon}
-              <span className="text-sm font-medium">{option.label}</span>
+              <ProviderIcon agent={option.id} className="size-5" />
+              <span className="text-sm font-medium">{agentLabels[option.id]}</span>
               <span className="text-xs leading-4 text-muted-foreground">{option.description}</span>
             </button>
           ))}
@@ -139,6 +120,7 @@ export function NewSessionDialog({
           <Input
             value={directory?.path ?? ""}
             readOnly
+            className="font-mono text-xs"
             placeholder="Choose a project folder"
             aria-label="Project folder"
           />

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -2,14 +2,66 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { FitAddon } from "@xterm/addon-fit";
-import { Terminal } from "@xterm/xterm";
+import { type ITheme, Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 
 import { subscribeOutput } from "@/output-store";
+import type { Theme } from "@/theme";
 
-export function TerminalView({ sessionId }: { sessionId: string }) {
+// Surface colors follow the app tokens; ANSI colors follow GitHub light and dark, matching the code preview.
+const themes: Record<Theme, ITheme> = {
+  light: {
+    background: "#ffffff",
+    foreground: "#0a0a0a",
+    cursor: "#0a0a0a",
+    cursorAccent: "#ffffff",
+    selectionBackground: "#0969da33",
+    black: "#24292f",
+    red: "#cf222e",
+    green: "#116329",
+    yellow: "#4d2d00",
+    blue: "#0969da",
+    magenta: "#8250df",
+    cyan: "#1b7c83",
+    white: "#6e7781",
+    brightBlack: "#57606a",
+    brightRed: "#a40e26",
+    brightGreen: "#1a7f37",
+    brightYellow: "#633c01",
+    brightBlue: "#218bff",
+    brightMagenta: "#a475f9",
+    brightCyan: "#3192aa",
+    brightWhite: "#8c959f",
+  },
+  dark: {
+    background: "#0a0a0a",
+    foreground: "#fafafa",
+    cursor: "#fafafa",
+    cursorAccent: "#0a0a0a",
+    selectionBackground: "#58a6ff40",
+    black: "#484f58",
+    red: "#ff7b72",
+    green: "#3fb950",
+    yellow: "#d29922",
+    blue: "#58a6ff",
+    magenta: "#bc8cff",
+    cyan: "#39c5cf",
+    white: "#b1bac4",
+    brightBlack: "#6e7681",
+    brightRed: "#ffa198",
+    brightGreen: "#56d364",
+    brightYellow: "#e3b341",
+    brightBlue: "#79c0ff",
+    brightMagenta: "#d2a8ff",
+    brightCyan: "#56d4dd",
+    brightWhite: "#ffffff",
+  },
+};
+
+export function TerminalView({ sessionId, theme }: { sessionId: string; theme: Theme }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -21,13 +73,8 @@ export function TerminalView({ sessionId }: { sessionId: string }) {
       fontSize: 13,
       lineHeight: 1.25,
       scrollback: 5000,
-      theme: {
-        background: "#0d0d0d",
-        foreground: "#e5e5e5",
-        cursor: "#f5f5f5",
-        selectionBackground: "#3f3f46",
-      },
     });
+    terminalRef.current = terminal;
     const fit = new FitAddon();
     terminal.loadAddon(fit);
     terminal.open(container);
@@ -56,8 +103,14 @@ export function TerminalView({ sessionId }: { sessionId: string }) {
       input.dispose();
       unsubscribe();
       terminal.dispose();
+      terminalRef.current = null;
     };
   }, [sessionId]);
 
-  return <div ref={containerRef} className="h-full w-full bg-[#0d0d0d] p-3" />;
+  // Applied in the same commit as the effect above, so a new terminal is painted with the current theme.
+  useEffect(() => {
+    if (terminalRef.current) terminalRef.current.options.theme = themes[theme];
+  }, [theme]);
+
+  return <div ref={containerRef} className="h-full w-full bg-background p-3" />;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,17 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+const THEME_KEY = "lite.theme";
+
+export type Theme = "light" | "dark";
+
+export function initialTheme(): Theme {
+  const saved = localStorage.getItem(THEME_KEY);
+  if (saved === "light" || saved === "dark") return saved;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+  document.documentElement.style.colorScheme = theme;
+  localStorage.setItem(THEME_KEY, theme);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,12 @@
 
 export type Agent = "claude" | "codex" | "shell";
 
+export const agentLabels: Record<Agent, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+  shell: "Shell",
+};
+
 export interface Session {
   id: string;
   agent: Agent;


### PR DESCRIPTION
## Why

Opening the inspector's context/usage tab took down the whole app, and light mode only reached the chrome: the terminal, file preview, and syntax highlighting stayed dark inside a white window.

## What changed

**Usage panel crash.** Serde serializes every `Option` field as `null`, but the panel guarded with `!== undefined` and then called `.toFixed()` — `null !== undefined` is true, so any Codex session (which reports no per-session context) threw during render and unmounted the app. The usage types now say `number | null`, so TypeScript enforces the guards, and a small `PanelBoundary` keeps a future render bug in an inspector panel from blanking the window.

**Inspector layout.** Base UI marks orientation with `data-orientation="horizontal"`, but the vendored Tabs component branched on `data-horizontal`, which never matches. The root never became a column, so the three icons rendered as a rail to the left of the panel with dead space beneath them. Fixed the variants in `components/ui/tabs.tsx`; Files / Git / Usage now sit above the content as labeled tabs across the full width, and the tooltips they needed are gone.

**Theme.** The terminal takes its surface from the app tokens and its ANSI palette from GitHub light and dark, and repaints live on toggle. Syntax highlighting moved from the imported `github-dark.css` to `--syntax-*` tokens carrying GitHub's own light and dark colors, so the code preview and Markdown code blocks follow the theme too.

**Top bar.** A single app bar spans the window: identity on the left, the active session and its path next to it, theme switch and a Lite menu on the right. The refresh icon is gone — updates live under **Check for updates** in that menu, alongside the running version. The sidebar loses its own header row and gains a Sessions group label with a `+` action.

**Sessions.** A session that is not live resumes on its own when it is selected and when the app opens; a failed start leaves a Resume button rather than retrying in a loop. Clicking a session name selects it instead of starting a rename (double-click or the row menu renames). Session start, Git, and usage reads use a shadcn `Spinner` in place of bare "Starting…" text.

## Verification

`bun run check`, `cargo fmt --check`, and `cargo check` pass. Checked in a `bun run tauri dev` window against a live Codex session: the Usage tab renders (the rate limit at 100% turns the meter destructive) instead of blanking the app, the tabs sit above the panel content, and both themes were exercised end to end including the terminal and a highlighted source file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
