### PR TITLE
Launch provider CLIs from the user PATH

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -931,19 +931,30 @@ fn stop_codex_server(server: &CodexServer) {
 }
 
 #[cfg(unix)]
+fn account_shell() -> Option<String> {
+    let output = if cfg!(target_os = "macos") {
+        Command::new("/usr/bin/id").arg("-P").output().ok()?
+    } else {
+        let uid = Command::new("/usr/bin/id").arg("-u").output().ok()?;
+        Command::new("/usr/bin/getent")
+            .args(["passwd", String::from_utf8(uid.stdout).ok()?.trim()])
+            .output()
+            .ok()?
+    };
+    String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .rsplit(':')
+        .next()
+        .filter(|shell| !shell.is_empty())
+        .map(str::to_owned)
+}
+
+#[cfg(unix)]
 fn user_path() -> Option<String> {
     let shell = std::env::var("SHELL")
         .ok()
-        .or_else(|| {
-            let output = Command::new("/usr/bin/id").arg("-P").output().ok()?;
-            String::from_utf8(output.stdout)
-                .ok()?
-                .trim()
-                .rsplit(':')
-                .next()
-                .filter(|shell| !shell.is_empty())
-                .map(str::to_owned)
-        })
+        .or_else(account_shell)
         .unwrap_or_else(|| "/bin/sh".into());
     Command::new(shell)
         .args(["-lic", "printf %s \"$PATH\""])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -933,21 +933,32 @@ fn stop_codex_server(server: &CodexServer) {
 // An interactive login shell is what loads the configuration that puts version-manager directories on
 // PATH, so it is the only lookup that finds a CLI installed through nvm. Bash reads its login profile
 // instead of its rc file when it is both, and nvm installs into the rc file, so Bash sources that file
-// itself. A NUL separates the PATH from whatever the startup files printed ahead of it.
+// itself. NULs fence the PATH off from whatever startup files print ahead of it and exit traps print
+// after it.
 #[cfg(unix)]
-fn user_path() -> Option<String> {
-    Command::new(CommandBuilder::new_default_prog().get_shell())
+fn shell_path(shell: &str) -> Option<String> {
+    Command::new(shell)
         .args([
             "-lic",
-            "[ -n \"$BASH_VERSION\" ] && [ -f \"$HOME/.bashrc\" ] && . \"$HOME/.bashrc\"; printf '\\0%s' \"$PATH\"",
+            "[ -n \"$BASH_VERSION\" ] && [ -f \"$HOME/.bashrc\" ] && . \"$HOME/.bashrc\"; printf '\\0%s\\0' \"$PATH\"",
         ])
         .output()
         .ok()
         .filter(|output| output.status.success())
-        .map(|output| {
-            let output = String::from_utf8_lossy(&output.stdout);
-            output.rsplit('\0').next().unwrap_or_default().to_owned()
+        .and_then(|output| {
+            let text = String::from_utf8_lossy(&output.stdout);
+            text.split('\0')
+                .nth(1)
+                .filter(|path| !path.is_empty())
+                .map(str::to_owned)
         })
+}
+
+// An account shell that does not speak this command leaves nothing usable, so the search falls back to
+// the POSIX shell rather than losing every provider CLI.
+#[cfg(unix)]
+fn user_path() -> Option<String> {
+    shell_path(&CommandBuilder::new_default_prog().get_shell()).or_else(|| shell_path("/bin/sh"))
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -931,32 +931,8 @@ fn stop_codex_server(server: &CodexServer) {
 }
 
 #[cfg(unix)]
-fn account_shell() -> Option<String> {
-    let output = if cfg!(target_os = "macos") {
-        Command::new("/usr/bin/id").arg("-P").output().ok()?
-    } else {
-        let uid = Command::new("/usr/bin/id").arg("-u").output().ok()?;
-        Command::new("/usr/bin/getent")
-            .args(["passwd", String::from_utf8(uid.stdout).ok()?.trim()])
-            .output()
-            .ok()?
-    };
-    String::from_utf8(output.stdout)
-        .ok()?
-        .trim()
-        .rsplit(':')
-        .next()
-        .filter(|shell| !shell.is_empty())
-        .map(str::to_owned)
-}
-
-#[cfg(unix)]
 fn user_path() -> Option<String> {
-    let shell = std::env::var("SHELL")
-        .ok()
-        .or_else(account_shell)
-        .unwrap_or_else(|| "/bin/sh".into());
-    Command::new(shell)
+    Command::new(CommandBuilder::new_default_prog().get_shell())
         .args(["-lic", "printf %s \"$PATH\""])
         .output()
         .ok()
@@ -1101,7 +1077,8 @@ async fn delete_api_key(app: AppHandle, name: String) -> Result<(), String> {
 
 // A launched app inherits a bare PATH, and the PATH given to a child is not used to find the program
 // itself, so anything Lite runs has to be located in the user's own PATH first and run by full path.
-fn find_executable(name: &str, path: &str) -> Option<PathBuf> {
+fn resolve_executable(name: &str) -> Option<PathBuf> {
+    let path = user_path()?;
     std::env::split_paths(&path).find_map(|directory| {
         #[cfg(windows)]
         {
@@ -1116,21 +1093,6 @@ fn find_executable(name: &str, path: &str) -> Option<PathBuf> {
             candidate.is_file().then_some(candidate)
         }
     })
-}
-
-fn resolve_executable(name: &str) -> Option<PathBuf> {
-    user_path().and_then(|path| find_executable(name, &path))
-}
-
-fn cli_command(name: &str) -> Result<CommandBuilder, String> {
-    let (executable, path) = user_path()
-        .and_then(|path| find_executable(name, &path).map(|executable| (executable, path)))
-        .ok_or_else(|| {
-            format!("Could not find the {name} CLI in your PATH. Install it, then reopen this tab.")
-        })?;
-    let mut command = CommandBuilder::new(executable);
-    command.env("PATH", path);
-    Ok(command)
 }
 
 fn executable_exists(name: &str) -> bool {
@@ -1263,7 +1225,7 @@ fn agent_command(
 ) -> Result<CommandBuilder, String> {
     let mut command = match agent {
         "claude" => {
-            let mut command = cli_command("claude")?;
+            let mut command = CommandBuilder::new("claude");
             if resume {
                 command.args(["--resume", session_id]);
             } else {
@@ -1272,7 +1234,7 @@ fn agent_command(
             command
         }
         "codex" => {
-            let mut command = cli_command("codex")?;
+            let mut command = CommandBuilder::new("codex");
             // DeepSeek is selected per launch so the default Codex provider stays whatever the user set.
             if provider == Some("deepseek") {
                 if saved_api_key(app, agent, provider).is_some() {
@@ -1304,21 +1266,18 @@ fn agent_command(
             // Only an exact id resumes. `--continue` would reopen whatever ran last in the directory,
             // which two tabs there would both land on, and it creates no entry for discovery to record,
             // so the tab could never learn which session it is showing.
-            let mut command = cli_command("kimi")?;
+            let mut command = CommandBuilder::new("kimi");
             if let Some(provider_session_id) = provider_session_id {
                 command.args(["--session", provider_session_id]);
             }
             command
         }
-        "shell" => {
-            let mut command = CommandBuilder::new_default_prog();
-            if let Some(path) = user_path() {
-                command.env("PATH", path);
-            }
-            command
-        }
+        "shell" => CommandBuilder::new_default_prog(),
         _ => return Err("Unknown session type".into()),
     };
+    if let Some(path) = user_path() {
+        command.env("PATH", path);
+    }
     // The key reaches the CLI through the variable it already reads, and only for this session.
     if let Some((_, variable)) = api_key_env(agent, provider)
         && let Some(key) = saved_api_key(app, agent, provider)
@@ -1330,24 +1289,27 @@ fn agent_command(
 
 // Each CLI owns its sign-in and opens the browser itself, so Lite only runs the command and shows it.
 fn login_command(agent: &str) -> Result<CommandBuilder, String> {
-    let command = match agent {
+    let mut command = match agent {
         "claude" => {
-            let mut command = cli_command("claude")?;
+            let mut command = CommandBuilder::new("claude");
             command.args(["auth", "login"]);
             command
         }
         "codex" => {
-            let mut command = cli_command("codex")?;
+            let mut command = CommandBuilder::new("codex");
             command.arg("login");
             command
         }
         "kimi" => {
-            let mut command = cli_command("kimi")?;
+            let mut command = CommandBuilder::new("kimi");
             command.arg("login");
             command
         }
         _ => return Err("This provider signs in with an API key".into()),
     };
+    if let Some(path) = user_path() {
+        command.env("PATH", path);
+    }
     Ok(command)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::Mutex,
+    sync::{Mutex, OnceLock},
     thread,
     time::Duration,
 };
@@ -930,14 +930,26 @@ fn stop_codex_server(server: &CodexServer) {
     }
 }
 
+// An interactive login shell is what loads the configuration that puts version-manager directories on
+// PATH, so it is the only lookup that finds a CLI installed through nvm. It costs a shell startup and
+// the PATH cannot change under a running app, so the answer is resolved once. A NUL separates the PATH
+// from anything the interactive startup files printed ahead of it.
 #[cfg(unix)]
 fn user_path() -> Option<String> {
-    Command::new(CommandBuilder::new_default_prog().get_shell())
-        .args(["-lic", "printf %s \"$PATH\""])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+    static USER_PATH: OnceLock<Option<String>> = OnceLock::new();
+    USER_PATH
+        .get_or_init(|| {
+            Command::new(CommandBuilder::new_default_prog().get_shell())
+                .args(["-lic", "printf '\\0%s' \"$PATH\""])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .map(|output| {
+                    let output = String::from_utf8_lossy(&output.stdout);
+                    output.rsplit('\0').next().unwrap_or_default().to_owned()
+                })
+        })
+        .clone()
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::{Mutex, OnceLock},
+    sync::Mutex,
     thread,
     time::Duration,
 };
@@ -931,25 +931,23 @@ fn stop_codex_server(server: &CodexServer) {
 }
 
 // An interactive login shell is what loads the configuration that puts version-manager directories on
-// PATH, so it is the only lookup that finds a CLI installed through nvm. It costs a shell startup and
-// the PATH cannot change under a running app, so the answer is resolved once. A NUL separates the PATH
-// from anything the interactive startup files printed ahead of it.
+// PATH, so it is the only lookup that finds a CLI installed through nvm. Bash reads its login profile
+// instead of its rc file when it is both, and nvm installs into the rc file, so Bash sources that file
+// itself. A NUL separates the PATH from whatever the startup files printed ahead of it.
 #[cfg(unix)]
 fn user_path() -> Option<String> {
-    static USER_PATH: OnceLock<Option<String>> = OnceLock::new();
-    USER_PATH
-        .get_or_init(|| {
-            Command::new(CommandBuilder::new_default_prog().get_shell())
-                .args(["-lic", "printf '\\0%s' \"$PATH\""])
-                .output()
-                .ok()
-                .filter(|output| output.status.success())
-                .map(|output| {
-                    let output = String::from_utf8_lossy(&output.stdout);
-                    output.rsplit('\0').next().unwrap_or_default().to_owned()
-                })
+    Command::new(CommandBuilder::new_default_prog().get_shell())
+        .args([
+            "-lic",
+            "[ -n \"$BASH_VERSION\" ] && [ -f \"$HOME/.bashrc\" ] && . \"$HOME/.bashrc\"; printf '\\0%s' \"$PATH\"",
+        ])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| {
+            let output = String::from_utf8_lossy(&output.stdout);
+            output.rsplit('\0').next().unwrap_or_default().to_owned()
         })
-        .clone()
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -932,9 +932,21 @@ fn stop_codex_server(server: &CodexServer) {
 
 #[cfg(unix)]
 fn user_path() -> Option<String> {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    let shell = std::env::var("SHELL")
+        .ok()
+        .or_else(|| {
+            let output = Command::new("/usr/bin/id").arg("-P").output().ok()?;
+            String::from_utf8(output.stdout)
+                .ok()?
+                .trim()
+                .rsplit(':')
+                .next()
+                .filter(|shell| !shell.is_empty())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "/bin/sh".into());
     Command::new(shell)
-        .args(["-lc", "printf %s \"$PATH\""])
+        .args(["-lic", "printf %s \"$PATH\""])
         .output()
         .ok()
         .filter(|output| output.status.success())
@@ -1078,8 +1090,7 @@ async fn delete_api_key(app: AppHandle, name: String) -> Result<(), String> {
 
 // A launched app inherits a bare PATH, and the PATH given to a child is not used to find the program
 // itself, so anything Lite runs has to be located in the user's own PATH first and run by full path.
-fn resolve_executable(name: &str) -> Option<PathBuf> {
-    let path = user_path()?;
+fn find_executable(name: &str, path: &str) -> Option<PathBuf> {
     std::env::split_paths(&path).find_map(|directory| {
         #[cfg(windows)]
         {
@@ -1094,6 +1105,21 @@ fn resolve_executable(name: &str) -> Option<PathBuf> {
             candidate.is_file().then_some(candidate)
         }
     })
+}
+
+fn resolve_executable(name: &str) -> Option<PathBuf> {
+    user_path().and_then(|path| find_executable(name, &path))
+}
+
+fn cli_command(name: &str) -> Result<CommandBuilder, String> {
+    let (executable, path) = user_path()
+        .and_then(|path| find_executable(name, &path).map(|executable| (executable, path)))
+        .ok_or_else(|| {
+            format!("Could not find the {name} CLI in your PATH. Install it, then reopen this tab.")
+        })?;
+    let mut command = CommandBuilder::new(executable);
+    command.env("PATH", path);
+    Ok(command)
 }
 
 fn executable_exists(name: &str) -> bool {
@@ -1226,7 +1252,7 @@ fn agent_command(
 ) -> Result<CommandBuilder, String> {
     let mut command = match agent {
         "claude" => {
-            let mut command = CommandBuilder::new("claude");
+            let mut command = cli_command("claude")?;
             if resume {
                 command.args(["--resume", session_id]);
             } else {
@@ -1235,7 +1261,7 @@ fn agent_command(
             command
         }
         "codex" => {
-            let mut command = CommandBuilder::new("codex");
+            let mut command = cli_command("codex")?;
             // DeepSeek is selected per launch so the default Codex provider stays whatever the user set.
             if provider == Some("deepseek") {
                 if saved_api_key(app, agent, provider).is_some() {
@@ -1267,18 +1293,21 @@ fn agent_command(
             // Only an exact id resumes. `--continue` would reopen whatever ran last in the directory,
             // which two tabs there would both land on, and it creates no entry for discovery to record,
             // so the tab could never learn which session it is showing.
-            let mut command = CommandBuilder::new("kimi");
+            let mut command = cli_command("kimi")?;
             if let Some(provider_session_id) = provider_session_id {
                 command.args(["--session", provider_session_id]);
             }
             command
         }
-        "shell" => CommandBuilder::new_default_prog(),
+        "shell" => {
+            let mut command = CommandBuilder::new_default_prog();
+            if let Some(path) = user_path() {
+                command.env("PATH", path);
+            }
+            command
+        }
         _ => return Err("Unknown session type".into()),
     };
-    if let Some(path) = user_path() {
-        command.env("PATH", path);
-    }
     // The key reaches the CLI through the variable it already reads, and only for this session.
     if let Some((_, variable)) = api_key_env(agent, provider)
         && let Some(key) = saved_api_key(app, agent, provider)
@@ -1290,27 +1319,24 @@ fn agent_command(
 
 // Each CLI owns its sign-in and opens the browser itself, so Lite only runs the command and shows it.
 fn login_command(agent: &str) -> Result<CommandBuilder, String> {
-    let mut command = match agent {
+    let command = match agent {
         "claude" => {
-            let mut command = CommandBuilder::new("claude");
+            let mut command = cli_command("claude")?;
             command.args(["auth", "login"]);
             command
         }
         "codex" => {
-            let mut command = CommandBuilder::new("codex");
+            let mut command = cli_command("codex")?;
             command.arg("login");
             command
         }
         "kimi" => {
-            let mut command = CommandBuilder::new("kimi");
+            let mut command = cli_command("kimi")?;
             command.arg("login");
             command
         }
         _ => return Err("This provider signs in with an API key".into()),
     };
-    if let Some(path) = user_path() {
-        command.env("PATH", path);
-    }
     Ok(command)
 }
 


### PR DESCRIPTION
Finder launches Lite without shell-managed PATH entries, so provider CLIs installed through tools such as NVM can fail to start.

| before: bare GUI PATH | after: Codex running |
|:--:|:--:|
| <img width="1200" alt="Codex fails to start because Lite cannot find it in PATH" src="https://github.com/user-attachments/assets/82c25753-75e9-41c8-b47b-4532bc103c29" /> | <img width="1200" alt="Codex running successfully in Lite" src="https://github.com/user-attachments/assets/dca98251-d8ee-455c-8772-1804a9c077bb" /> |

```diff
- Command::new(shell).args(["-lc", ...])
+ Command::new(CommandBuilder::new_default_prog().get_shell()).args(["-lic", ...])
```

- reuses the PTY account-shell lookup
- loads interactive shell PATH configuration
- fixes #23