### PR TITLE
Fix session names, Git resolution, and DeepSeek model metadata

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -951,13 +951,14 @@ fn user_path() -> Option<String> {
 // bundle and not the data directory. A key is handed to a session through the environment variable its
 // CLI already reads, so nothing is copied into provider configuration.
 // Codex only knows the models in its own catalog, and it warns and guesses the limits for any other
-// one. It reads a replacement catalog from a file, so the installed catalog is read back and the
-// DeepSeek model appended to it: cloning an entry keeps whatever shape that Codex version expects, and
-// keeping the built-in models leaves the rest of Codex working. Every failure here returns None and
-// simply leaves the warning in place, because a catalog Codex cannot parse would stop it from starting.
+// one. It reads a replacement catalog from a file, so the bundled catalog is read back and the DeepSeek
+// model appended to it: cloning an entry keeps whatever shape that Codex version expects, and keeping
+// the built-in models leaves the rest of Codex working. The bundled catalog is asked for by name so a
+// launch never waits on Codex refreshing its models over the network. Every failure here returns None
+// and leaves the warning in place, because a catalog Codex cannot parse would stop it from starting.
 fn deepseek_catalog(app: &AppHandle) -> Option<PathBuf> {
     let output = Command::new(resolve_executable("codex")?)
-        .args(["debug", "models"])
+        .args(["debug", "models", "--bundled"])
         .output()
         .ok()
         .filter(|output| output.status.success())?;
@@ -1312,10 +1313,11 @@ fn agent_command(
                     command.args(["-c", "model_provider=\"deepseek\""]);
                     command.args(["-c", &format!("model=\"{DEEPSEEK_MODEL}\"")]);
                     if let Some(catalog) = deepseek_catalog(app) {
-                        command.args([
-                            "-c",
-                            &format!("model_catalog_json=\"{}\"", path_text(&catalog)),
-                        ]);
+                        // A Windows path is full of backslashes, which TOML reads as escapes.
+                        let catalog = path_text(&catalog)
+                            .replace('\\', "\\\\")
+                            .replace('"', "\\\"");
+                        command.args(["-c", &format!("model_catalog_json=\"{catalog}\"")]);
                     }
                 } else if deepseek_profile_exists(app) {
                     command.args(["--profile", DEEPSEEK_PROFILE]);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1246,6 +1246,20 @@ fn codex_declares_deepseek(app: &AppHandle) -> bool {
         .any(|line| line.trim() == "[model_providers.deepseek]")
 }
 
+// A catalog is a replacement rather than a merge, so one the user configured is left to win.
+fn codex_declares_catalog(app: &AppHandle) -> bool {
+    let Ok(home) = codex_home(app) else {
+        return false;
+    };
+    let Ok(file) = fs::File::open(home.join("config.toml")) else {
+        return false;
+    };
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .any(|line| line.trim_start().starts_with("model_catalog_json"))
+}
+
 fn deepseek_profile_exists(app: &AppHandle) -> bool {
     codex_home(app).is_ok_and(|home| {
         home.join(format!("{DEEPSEEK_PROFILE}.config.toml"))
@@ -1374,7 +1388,10 @@ fn agent_command(
                     }
                     command.args(["-c", "model_provider=\"deepseek\""]);
                     command.args(["-c", &format!("model=\"{DEEPSEEK_MODEL}\"")]);
-                    if let Some(catalog) = deepseek_catalog(app) {
+                    if let Some(catalog) = (!codex_declares_catalog(app))
+                        .then(|| deepseek_catalog(app))
+                        .flatten()
+                    {
                         // A Windows path is full of backslashes, which TOML reads as escapes.
                         let catalog = path_text(&catalog)
                             .replace('\\', "\\\\")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1299,16 +1299,22 @@ fn agent_command(
             let mut command = CommandBuilder::new("codex");
             // DeepSeek is selected per launch so the default Codex provider stays whatever the user set.
             if provider == Some("deepseek") {
-                if saved_api_key(app, agent, provider).is_some() {
-                    // A key held by Lite defines the provider inline and is read from the environment,
-                    // so no Codex configuration file has to exist or be written.
-                    for override_value in [
-                        "model_providers.deepseek.name=\"deepseek\"",
-                        "model_providers.deepseek.base_url=\"https://api.deepseek.com/\"",
-                        "model_providers.deepseek.wire_api=\"responses\"",
-                        "model_providers.deepseek.env_key=\"DEEPSEEK_API_KEY\"",
-                    ] {
-                        command.args(["-c", override_value]);
+                let key = saved_api_key(app, agent, provider).is_some();
+                if !key && deepseek_profile_exists(app) {
+                    // A profile the user wrote owns the whole model configuration, catalog included.
+                    command.args(["--profile", DEEPSEEK_PROFILE]);
+                } else {
+                    if key {
+                        // A key held by Lite defines the provider inline and is read from the
+                        // environment, so no Codex configuration file has to exist or be written.
+                        for override_value in [
+                            "model_providers.deepseek.name=\"deepseek\"",
+                            "model_providers.deepseek.base_url=\"https://api.deepseek.com/\"",
+                            "model_providers.deepseek.wire_api=\"responses\"",
+                            "model_providers.deepseek.env_key=\"DEEPSEEK_API_KEY\"",
+                        ] {
+                            command.args(["-c", override_value]);
+                        }
                     }
                     command.args(["-c", "model_provider=\"deepseek\""]);
                     command.args(["-c", &format!("model=\"{DEEPSEEK_MODEL}\"")]);
@@ -1319,11 +1325,6 @@ fn agent_command(
                             .replace('"', "\\\"");
                         command.args(["-c", &format!("model_catalog_json=\"{catalog}\"")]);
                     }
-                } else if deepseek_profile_exists(app) {
-                    command.args(["--profile", DEEPSEEK_PROFILE]);
-                } else {
-                    command.args(["-c", "model_provider=\"deepseek\""]);
-                    command.args(["-c", &format!("model=\"{DEEPSEEK_MODEL}\"")]);
                 }
             }
             if let Some(provider_session_id) = provider_session_id {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -950,6 +950,66 @@ fn user_path() -> Option<String> {
 // CLIs already do with their own credentials, and it survives updates because the updater replaces the
 // bundle and not the data directory. A key is handed to a session through the environment variable its
 // CLI already reads, so nothing is copied into provider configuration.
+// Codex only knows the models in its own catalog, and it warns and guesses the limits for any other
+// one. It reads a replacement catalog from a file, so the installed catalog is read back and the
+// DeepSeek model appended to it: cloning an entry keeps whatever shape that Codex version expects, and
+// keeping the built-in models leaves the rest of Codex working. Every failure here returns None and
+// simply leaves the warning in place, because a catalog Codex cannot parse would stop it from starting.
+fn deepseek_catalog(app: &AppHandle) -> Option<PathBuf> {
+    let output = Command::new(resolve_executable("codex")?)
+        .args(["debug", "models"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())?;
+    let mut catalog: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let models = catalog.get_mut("models")?.as_array_mut()?;
+    if models
+        .iter()
+        .any(|model| model.get("slug").and_then(serde_json::Value::as_str) == Some(DEEPSEEK_MODEL))
+    {
+        return None;
+    }
+    let mut model = models.first()?.clone();
+    let entry = model.as_object_mut()?;
+    for (key, value) in [
+        ("slug", serde_json::json!(DEEPSEEK_MODEL)),
+        ("display_name", serde_json::json!("DeepSeek-V4-Flash")),
+        (
+            "description",
+            serde_json::json!("DeepSeek V4 Flash, served by the DeepSeek API."),
+        ),
+        ("context_window", serde_json::json!(1_048_576)),
+        ("max_context_window", serde_json::json!(1_048_576)),
+        ("default_reasoning_level", serde_json::json!("high")),
+        ("visibility", serde_json::json!("hide")),
+        ("input_modalities", serde_json::json!(["text"])),
+        // Capabilities and cache keys that belong to the model this entry was cloned from.
+        ("comp_hash", serde_json::Value::Null),
+        ("availability_nux", serde_json::Value::Null),
+        ("upgrade", serde_json::Value::Null),
+        ("tool_mode", serde_json::Value::Null),
+        ("multi_agent_version", serde_json::Value::Null),
+        ("use_responses_lite", serde_json::json!(false)),
+        ("supports_search_tool", serde_json::json!(false)),
+        ("additional_speed_tiers", serde_json::json!([])),
+        ("service_tiers", serde_json::json!([])),
+    ] {
+        if entry.contains_key(key) {
+            entry.insert(key.to_owned(), value);
+        }
+    }
+    models.push(model);
+    let path = app.path().app_data_dir().ok()?.join("codex-models.json");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).ok()?;
+    }
+    let text = serde_json::to_string(&catalog).ok()?;
+    AtomicFile::new(&path, AllowOverwrite)
+        .write(|file| file.write_all(text.as_bytes()))
+        .ok()?;
+    Some(path)
+}
+
 fn api_keys_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(app
         .path()
@@ -1251,6 +1311,12 @@ fn agent_command(
                     }
                     command.args(["-c", "model_provider=\"deepseek\""]);
                     command.args(["-c", &format!("model=\"{DEEPSEEK_MODEL}\"")]);
+                    if let Some(catalog) = deepseek_catalog(app) {
+                        command.args([
+                            "-c",
+                            &format!("model_catalog_json=\"{}\"", path_text(&catalog)),
+                        ]);
+                    }
                 } else if deepseek_profile_exists(app) {
                     command.args(["--profile", DEEPSEEK_PROFILE]);
                 } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -223,8 +223,8 @@ fn is_sensitive_path(root: &Path, path: &Path) -> bool {
     })
 }
 
-fn command_output(directory: &Path, args: &[&str]) -> Result<String, String> {
-    let output = Command::new(resolve_executable("git").unwrap_or_else(|| "git".into()))
+fn command_output(git: &Path, directory: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(git)
         .arg("-C")
         .arg(path_text(directory))
         .args(args)
@@ -1856,12 +1856,14 @@ async fn read_text_file(
 #[tauri::command]
 async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<GitStatus>, String> {
     let path = root_path(&roots, &root_id)?;
-    let root = match command_output(&path, &["rev-parse", "--show-toplevel"]) {
+    // Locating Git runs a login shell, so one refresh resolves it once rather than once per command.
+    let git = resolve_executable("git").unwrap_or_else(|| "git".into());
+    let root = match command_output(&git, &path, &["rev-parse", "--show-toplevel"]) {
         Ok(root) => root,
         Err(_) => return Ok(None),
     };
-    let branch = command_output(&path, &["branch", "--show-current"])?;
-    let mut child = Command::new(resolve_executable("git").unwrap_or_else(|| "git".into()))
+    let branch = command_output(&git, &path, &["branch", "--show-current"])?;
+    let mut child = Command::new(&git)
         .arg("-C")
         .arg(path_text(&path))
         .args(["status", "--short"])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -957,8 +957,13 @@ fn user_path() -> Option<String> {
 // launch never waits on Codex refreshing its models over the network. Every failure here returns None
 // and leaves the warning in place, because a catalog Codex cannot parse would stop it from starting.
 fn deepseek_catalog(app: &AppHandle) -> Option<PathBuf> {
-    let output = Command::new(resolve_executable("codex")?)
-        .args(["debug", "models", "--bundled"])
+    let mut probe = Command::new(resolve_executable("codex")?);
+    probe.args(["debug", "models", "--bundled"]);
+    // The CLI is a Node launcher, so without the user PATH its shebang cannot find Node.
+    if let Some(path) = user_path() {
+        probe.env("PATH", path);
+    }
+    let output = probe
         .output()
         .ok()
         .filter(|output| output.status.success())?;
@@ -994,6 +999,24 @@ fn deepseek_catalog(app: &AppHandle) -> Option<PathBuf> {
         ("supports_search_tool", serde_json::json!(false)),
         ("support_verbosity", serde_json::json!(false)),
         ("default_verbosity", serde_json::Value::Null),
+        ("supports_image_detail_original", serde_json::json!(false)),
+        (
+            "supports_reasoning_summary_parameter",
+            serde_json::json!(false),
+        ),
+        ("default_reasoning_summary", serde_json::json!("none")),
+        ("web_search_tool_type", serde_json::json!("text")),
+        (
+            "include_skills_usage_instructions",
+            serde_json::json!(false),
+        ),
+        (
+            "include_plugin_usage_instructions",
+            serde_json::json!(false),
+        ),
+        ("include_apps_usage_instructions", serde_json::json!(false)),
+        // DeepSeek documents parallel tool calls, and the entry states that rather than inheriting it.
+        ("supports_parallel_tool_calls", serde_json::json!(true)),
         ("additional_speed_tiers", serde_json::json!([])),
         ("service_tiers", serde_json::json!([])),
     ] {
@@ -1001,20 +1024,17 @@ fn deepseek_catalog(app: &AppHandle) -> Option<PathBuf> {
             entry.insert(key.to_owned(), value);
         }
     }
-    // Reasoning levels are the cloned model's own capability, and DeepSeek documents low, high, and
-    // max. Filtering rather than replacing keeps the descriptions Codex already uses and can only ever
-    // drop a level, so the entry never advertises an effort the provider would be sent and reject.
-    if let Some(levels) = entry
-        .get_mut("supported_reasoning_levels")
-        .and_then(serde_json::Value::as_array_mut)
-    {
-        levels.retain(|level| {
-            matches!(
-                level.get("effort").and_then(serde_json::Value::as_str),
-                Some("low" | "high" | "max")
-            )
-        });
-    }
+    // Reasoning levels describe the provider, not the model this entry was cloned from, so they are
+    // stated rather than inherited: DeepSeek documents these three and a template missing one of them
+    // would otherwise leave it unreachable.
+    entry.insert(
+        "supported_reasoning_levels".to_owned(),
+        serde_json::json!([
+            {"effort": "low", "description": "Fast responses with lighter reasoning"},
+            {"effort": "high", "description": "Greater reasoning depth for complex problems"},
+            {"effort": "max", "description": "Maximum reasoning depth for the hardest problems"},
+        ]),
+    );
     models.push(model);
     let path = app.path().app_data_dir().ok()?.join("codex-models.json");
     if let Some(parent) = path.parent() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -992,12 +992,28 @@ fn deepseek_catalog(app: &AppHandle) -> Option<PathBuf> {
         ("multi_agent_version", serde_json::Value::Null),
         ("use_responses_lite", serde_json::json!(false)),
         ("supports_search_tool", serde_json::json!(false)),
+        ("support_verbosity", serde_json::json!(false)),
+        ("default_verbosity", serde_json::Value::Null),
         ("additional_speed_tiers", serde_json::json!([])),
         ("service_tiers", serde_json::json!([])),
     ] {
         if entry.contains_key(key) {
             entry.insert(key.to_owned(), value);
         }
+    }
+    // Reasoning levels are the cloned model's own capability, and DeepSeek documents low, high, and
+    // max. Filtering rather than replacing keeps the descriptions Codex already uses and can only ever
+    // drop a level, so the entry never advertises an effort the provider would be sent and reject.
+    if let Some(levels) = entry
+        .get_mut("supported_reasoning_levels")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        levels.retain(|level| {
+            matches!(
+                level.get("effort").and_then(serde_json::Value::as_str),
+                Some("low" | "high" | "max")
+            )
+        });
     }
     models.push(model);
     let path = app.path().app_data_dir().ok()?.join("codex-models.json");

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -63,7 +63,7 @@ const themes: Record<Theme, ITheme> = {
 // A control sequence is an escape followed by a string terminator for OSC and DCS, a final byte for
 // CSI and SS3, or a single byte for the rest.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
-const SEQUENCES = /\x1b(?:[\]P][\s\S]*?(?:\x07|\x1b\\)|\[[\d;?]*[ -/]*[@-~]|O[@-~]|[\s\S])/g;
+const SEQUENCES = /\x1b(?:[\]P][\s\S]*?(?:\x07|\x1b\\)|\[[\x30-\x3f]*[ -/]*[@-~]|O[@-~]|[\s\S])/g;
 
 const FONT_SIZE_KEY = "lite.terminal.fontSize";
 const MIN_FONT_SIZE = 9;

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -113,7 +113,7 @@ export function TerminalView({
     terminal.open(container);
     const unsubscribe = subscribeOutput(sessionId, (data) => terminal.write(data));
     // What the user types before the first Enter is the closest thing a session has to a subject.
-    // The terminal answers the program's cursor, focus, and colour queries on this same channel and
+    // The terminal answers the program's cursor, focus, and color queries on this same channel and
     // those replies are printable, so a chunk carrying an escape is never someone typing.
     let typed = "";
     const input = terminal.onData((data) => {

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -113,16 +113,19 @@ export function TerminalView({
     terminal.open(container);
     const unsubscribe = subscribeOutput(sessionId, (data) => terminal.write(data));
     // What the user types before the first Enter is the closest thing a session has to a subject.
+    // The terminal answers the program's cursor, focus, and colour queries on this same channel and
+    // those replies are printable, so a chunk carrying an escape is never someone typing.
     let typed = "";
     const input = terminal.onData((data) => {
-      for (const character of data) {
-        if (character === "\r" || character === "\n") {
-          const line = typed.trim();
-          typed = "";
-          if (line) promptRef.current(line);
-        } else if (character === "\u007f") typed = typed.slice(0, -1);
-        else if (character >= " ") typed += character;
-      }
+      if (!data.includes("\u001b"))
+        for (const character of data) {
+          if (character === "\r" || character === "\n") {
+            const line = typed.trim();
+            typed = "";
+            if (line) promptRef.current(line);
+          } else if (character === "\u007f") typed = typed.slice(0, -1);
+          else if (character >= " ") typed += character;
+        }
       void invoke("write_session", {
         sessionId,
         data: Array.from(new TextEncoder().encode(data)),

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -60,6 +60,11 @@ const themes: Record<Theme, ITheme> = {
   },
 };
 
+// A control sequence is an escape followed by a string terminator for OSC and DCS, a final byte for
+// CSI and SS3, or a single byte for the rest.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
+const SEQUENCES = /\x1b(?:[\]P][\s\S]*?(?:\x07|\x1b\\)|\[[\d;?]*[ -/]*[@-~]|O[@-~]|[\s\S])/g;
+
 const FONT_SIZE_KEY = "lite.terminal.fontSize";
 const MIN_FONT_SIZE = 9;
 const MAX_FONT_SIZE = 24;
@@ -113,19 +118,19 @@ export function TerminalView({
     terminal.open(container);
     const unsubscribe = subscribeOutput(sessionId, (data) => terminal.write(data));
     // What the user types before the first Enter is the closest thing a session has to a subject.
-    // The terminal answers the program's cursor, focus, and color queries on this same channel and
-    // those replies are printable, so a chunk carrying an escape is never someone typing.
+    // Typing, pasting, and the terminal's own answers to the program's cursor, focus, and color
+    // queries all arrive here, and an answer is printable once its escape is dropped, so the escape
+    // sequences are removed and only what a person actually typed is left to read.
     let typed = "";
     const input = terminal.onData((data) => {
-      if (!data.includes("\u001b"))
-        for (const character of data) {
-          if (character === "\r" || character === "\n") {
-            const line = typed.trim();
-            typed = "";
-            if (line) promptRef.current(line);
-          } else if (character === "\u007f") typed = typed.slice(0, -1);
-          else if (character >= " ") typed += character;
-        }
+      for (const character of data.replace(SEQUENCES, "")) {
+        if (character === "\r" || character === "\n") {
+          const line = typed.trim();
+          typed = "";
+          if (line) promptRef.current(line);
+        } else if (character === "\u007f") typed = typed.slice(0, -1);
+        else if (character >= " ") typed += character;
+      }
       void invoke("write_session", {
         sessionId,
         data: Array.from(new TextEncoder().encode(data)),

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -65,6 +65,11 @@ const themes: Record<Theme, ITheme> = {
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const SEQUENCES = /\x1b(?:[\]P][\s\S]*?(?:\x07|\x1b\\)|\[[\x30-\x3f]*[ -/]*[@-~]|O[@-~]|[\s\S])/g;
 
+// The same sequence introduced but not yet terminated. A lone escape is deliberately not one of these:
+// it is the Escape key, and holding it back would swallow the next character typed.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
+const PARTIAL = /\x1b(?:[\]P](?:(?!\x07|\x1b\\)[\s\S])*|\[[\x30-\x3f]*[ -/]*|O)$/;
+
 const FONT_SIZE_KEY = "lite.terminal.fontSize";
 const MIN_FONT_SIZE = 9;
 const MAX_FONT_SIZE = 24;
@@ -122,8 +127,13 @@ export function TerminalView({
     // queries all arrive here, and an answer is printable once its escape is dropped, so the escape
     // sequences are removed and only what a person actually typed is left to read.
     let typed = "";
+    // An event can end mid-sequence, so an unfinished tail waits for the rest instead of being read.
+    let pending = "";
     const input = terminal.onData((data) => {
-      for (const character of data.replace(SEQUENCES, "")) {
+      const buffer = pending + data;
+      const partial = buffer.match(PARTIAL);
+      pending = partial?.[0] ?? "";
+      for (const character of buffer.slice(0, partial?.index ?? buffer.length).replace(SEQUENCES, "")) {
         if (character === "\r" || character === "\n") {
           const line = typed.trim();
           typed = "";


### PR DESCRIPTION
Three fixes to the Codex session experience.

### Session names took the terminal's replies

`onData` carries typing, paste, and the answers the terminal sends back when the program queries it. Codex asks on startup, and each answer is printable once the leading escape is dropped by the `character >= " "` filter, so a reply accumulated into the subject line and the first Enter committed it — producing titles such as `[I[1;1R]10;rgb:0a0a/0a0a/0a0a\]11;rgb:ff…`.

Control sequences are now removed before the accumulator reads the event. Replaying the exact chunks:

```
before: "[I[1;1R]10;rgb:0a0a/0a0a/0a0a\]11;rgb:ff…"
after:  "review this repo"
```

Stripping rather than skipping the event matters because a paste arrives as `ESC[200~text ESC[201~` in one chunk, and the CSI parameter range is `\x30-\x3f`, so a device-attributes reply (`ESC[>0;276;0c`) or an SGR mouse report (`ESC[<0;10;5M`, which Codex enables) would otherwise leak. Verified across 14 cases: startup replies, DA1/DA2, mouse, bracketed paste, paste with an embedded arrow, SS3, OSC by ST and by BEL, DCS, bare Escape, Alt chords, backspace, plain typing.

### One Git refresh resolved Git three times

Locating a CLI runs an interactive login shell. `git_status` called `command_output` twice and spawned once, so a single refresh paid for three of them. It now resolves once and reuses the path.

### Codex guessed DeepSeek's limits

Codex only knows the models in its own catalog and warns for any other, defaulting to fallback metadata:

> ⚠ Model metadata for `deepseek-v4-flash` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.

The flag is set purely by catalog lookup, so `model_context_window` cannot clear it and `model_max_output_tokens` does not exist in current Codex. Only a catalog does. Rather than vendoring one, Lite reads back the installed catalog with `codex debug models`, appends a DeepSeek entry cloned from an existing one, and points `model_catalog_json` at the result in its own data folder.

Cloning keeps whatever shape that Codex version expects, and keeping the built-in models means the rest of Codex still works — a replacement catalog otherwise takes them away. Capability and cache fields belonging to the cloned model are reset, and the context window is DeepSeek's documented 1M.

Because a catalog Codex cannot parse would stop it from starting, every failure returns `None` and leaves the warning in place instead. Verified against Codex 0.147.0: the written file loads and reports `deepseek-v4-flash` alongside all eight built-ins with `context_window` 1048576, and a missing binary, non-JSON output, and a non-zero exit each skip the flag.

- fixes the escape debris in new Codex session names

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds reliable DeepSeek model discovery in Codex, improves terminal input tracking, and streamlines Git executable handling. 🚀

### 📊 Key Changes

- 🧠 Generates a Codex model catalog entry for DeepSeek V4 Flash by extending Codex’s bundled catalog with the required model settings and capabilities.
- ⚙️ Respects user-defined Codex model catalogs and DeepSeek profiles, allowing existing user configuration to take precedence.
- 🔑 Continues supporting Lite-managed DeepSeek API keys through launch-time configuration without modifying Codex provider files.
- 💻 Resolves the Git executable once per status check instead of repeatedly searching for it.
- 🖥️ Filters terminal escape sequences from typed session titles and safely handles sequences split across output events.

### 🎯 Purpose & Impact

- ✅ DeepSeek launches through Codex with fewer model recognition warnings and more accurate context, reasoning, and capability metadata.
- 🛡️ User-configured Codex settings remain authoritative, reducing the risk of Lite unexpectedly overriding custom catalogs or profiles.
- ⚡ Git status checks become slightly more efficient and consistent, especially in environments where Git requires PATH setup.
- ✨ Terminal session subjects become cleaner by excluding cursor, focus, color, and other control-sequence responses while preserving normal user input.