### PR TITLE
Name the build in the window and check for updates from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Useful checks:
 
 ```bash
 bun run check       # Biome and native TypeScript checks
+bun run local       # App bundle you can double-click, marked as a local build
 bun run tauri build # Native installer for the current operating system
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,7 @@ bun run tauri dev
 
 ```bash
 bun run check       # Biome 与原生 TypeScript 检查
+bun run local       # 可直接双击运行的应用包，并标记为本地构建
 bun run tauri build # 为当前操作系统构建原生安装包
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsgo --noEmit && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "local": "tauri build --bundles app --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'",
     "check": "bun run lint && bun run typecheck",
     "format": "biome check --write .",
     "lint": "biome check . --diagnostic-level=error",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.4"
+version = "0.0.5"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,7 +1,22 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+use std::process::Command;
+
 fn main() {
-    // Whether the release workflow built this decides the local badge, so a change rebuilds.
+    // The release workflow builds an official version, and anything else came off a working tree, so
+    // it is stamped with the commit it was built from and says so in the window.
     println!("cargo:rerun-if-env-changed=GITHUB_ACTIONS");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    if std::env::var_os("GITHUB_ACTIONS").is_none()
+        && let Some(commit) = Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        && !commit.is_empty()
+    {
+        println!("cargo:rustc-env=LITE_COMMIT={commit}");
+    }
     tauri_build::build()
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 fn main() {
+    // Whether the release workflow built this decides the local badge, so a change rebuilds.
+    println!("cargo:rerun-if-env-changed=GITHUB_ACTIONS");
     tauri_build::build()
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -17,6 +17,12 @@ fn main() {
         && !commit.is_empty()
     {
         println!("cargo:rustc-env=LITE_COMMIT={commit}");
+        // Where it was built, so it can ask that tree whether it has moved on.
+        if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR")
+            && let Some(repo) = std::path::Path::new(&manifest).parent()
+        {
+            println!("cargo:rustc-env=LITE_REPO={}", repo.display());
+        }
     }
     tauri_build::build()
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,22 +2,29 @@
 
 use std::process::Command;
 
+fn git(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
 fn main() {
-    // The release workflow builds an official version, and anything else came off a working tree, so
-    // it is stamped with the commit it was built from and says so in the window.
     println!("cargo:rerun-if-env-changed=GITHUB_ACTIONS");
     println!("cargo:rerun-if-changed=../.git/HEAD");
+    // When the build was made, which for a release the workflow builds is the day it was published.
+    if let Some(date) = git(&["log", "-1", "--format=%cs"]) {
+        println!("cargo:rustc-env=LITE_DATE={date}");
+    }
+    // A release is what the workflow builds, and anything else came off a working tree, so it carries
+    // the commit it was built from and the tree it can ask whether that tree has moved on.
     if std::env::var_os("GITHUB_ACTIONS").is_none()
-        && let Some(commit) = Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .output()
-            .ok()
-            .filter(|output| output.status.success())
-            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
-        && !commit.is_empty()
+        && let Some(commit) = git(&["rev-parse", "--short", "HEAD"])
     {
         println!("cargo:rustc-env=LITE_COMMIT={commit}");
-        // Where it was built, so it can ask that tree whether it has moved on.
         if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR")
             && let Some(repo) = std::path::Path::new(&manifest).parent()
         {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1967,6 +1967,13 @@ fn stop_runtime(app: &AppHandle) {
     stop_codex_server(&app.state::<CodexServer>());
 }
 
+// A release is built by the publish workflow, so a build made without it came off someone's machine
+// and says so in the window, where an unlabelled copy is otherwise indistinguishable from an install.
+#[tauri::command]
+fn local_build() -> bool {
+    option_env!("GITHUB_ACTIONS").is_none()
+}
+
 #[tauri::command]
 async fn check_update(app: AppHandle) -> Result<Option<String>, String> {
     app.updater_builder()
@@ -2034,7 +2041,8 @@ pub fn run() {
             save_api_key,
             delete_api_key,
             check_update,
-            install_update
+            install_update,
+            local_build
         ])
         .build(tauri::generate_context!())
         .expect("error while building Lite")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1970,6 +1970,17 @@ fn stop_runtime(app: &AppHandle) {
 // A local build shares its name, version, and data folder with an install, so it names the commit it
 // came from instead of the version it would otherwise be mistaken for. A release returns nothing and
 // the window shows its version.
+// A release cannot update a local build, and installing one would replace the very build being tried
+// out, so a local build asks the working tree it came from whether that tree has moved on instead.
+#[tauri::command]
+fn local_update() -> Result<Option<String>, String> {
+    let built = option_env!("LITE_COMMIT").ok_or("This is not a local build")?;
+    let repo = option_env!("LITE_REPO").ok_or("This build did not record where it came from")?;
+    let head = command_output(Path::new(repo), &["rev-parse", "--short", "HEAD"])
+        .map_err(|_| format!("Could not read {repo}"))?;
+    Ok((head != built).then_some(head))
+}
+
 #[tauri::command]
 fn local_commit() -> Option<&'static str> {
     option_env!("LITE_COMMIT")
@@ -2043,7 +2054,8 @@ pub fn run() {
             delete_api_key,
             check_update,
             install_update,
-            local_commit
+            local_commit,
+            local_update
         ])
         .build(tauri::generate_context!())
         .expect("error while building Lite")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1981,6 +1981,12 @@ fn local_update() -> Result<Option<String>, String> {
     Ok((head != built).then_some(head))
 }
 
+// When this build was made, which for a release is the day it was published.
+#[tauri::command]
+fn build_date() -> Option<&'static str> {
+    option_env!("LITE_DATE")
+}
+
 #[tauri::command]
 fn local_commit() -> Option<&'static str> {
     option_env!("LITE_COMMIT")
@@ -2055,6 +2061,7 @@ pub fn run() {
             check_update,
             install_update,
             local_commit,
+            build_date,
             local_update
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1967,11 +1967,12 @@ fn stop_runtime(app: &AppHandle) {
     stop_codex_server(&app.state::<CodexServer>());
 }
 
-// A release is built by the publish workflow, so a build made without it came off someone's machine
-// and says so in the window, where an unlabelled copy is otherwise indistinguishable from an install.
+// A local build shares its name, version, and data folder with an install, so it names the commit it
+// came from instead of the version it would otherwise be mistaken for. A release returns nothing and
+// the window shows its version.
 #[tauri::command]
-fn local_build() -> bool {
-    option_env!("GITHUB_ACTIONS").is_none()
+fn local_commit() -> Option<&'static str> {
+    option_env!("LITE_COMMIT")
 }
 
 #[tauri::command]
@@ -2042,7 +2043,7 @@ pub fn run() {
             delete_api_key,
             check_update,
             install_update,
-            local_build
+            local_commit
         ])
         .build(tauri::generate_context!())
         .expect("error while building Lite")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2100,7 +2100,8 @@ fn stop_runtime(app: &AppHandle) {
 fn local_update() -> Result<Option<String>, String> {
     let built = option_env!("LITE_COMMIT").ok_or("This is not a local build")?;
     let repo = option_env!("LITE_REPO").ok_or("This build did not record where it came from")?;
-    let head = command_output(Path::new(repo), &["rev-parse", "--short", "HEAD"])
+    let git = resolve_executable("git").unwrap_or_else(|| "git".into());
+    let head = command_output(&git, Path::new(repo), &["rev-parse", "--short", "HEAD"])
         .map_err(|_| format!("Could not read {repo}"))?;
     Ok((head != built).then_some(head))
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,22 @@ import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
+// The version is known from the start, so the badge shows it throughout and only its colour waits on
+// the answer: grey while asking, which is quieter than a spinner that would resize a chip this small.
+const BADGE_VARIANT = {
+  checking: "secondary",
+  current: "success",
+  behind: "warning",
+  unknown: "outline",
+} as const;
+
+const RELEASE_NOTE = {
+  checking: "",
+  current: " · up to date",
+  behind: " · an update is available",
+  unknown: "",
+} as const;
+
 type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installing" | "error";
 
 function loadSessions(): Session[] {
@@ -254,9 +270,10 @@ function App() {
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
-  const [commit, setCommit] = useState("");
+  // Undefined until asked: an empty string is a release, anything else is the commit it was built from.
+  const [commit, setCommit] = useState<string>();
   const [built, setBuilt] = useState("");
-  const [behind, setBehind] = useState<boolean>();
+  const [release, setRelease] = useState<"checking" | "current" | "behind" | "unknown">("checking");
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
@@ -328,16 +345,34 @@ function App() {
       .then((value) => setBuilt(value ?? ""))
       .catch(() => setBuilt(""));
     void invoke<string | null>("local_commit")
-      .then((value) => {
-        setCommit(value ?? "");
-        // A local build is never the released one, so only a release asks whether it is behind.
-        if (value) return;
-        return invoke<string | null>("check_update")
-          .then((next) => setBehind(Boolean(next)))
-          .catch(() => setBehind(undefined));
-      })
+      .then((value) => setCommit(value ?? ""))
       .catch(() => setCommit(""));
   }, []);
+
+  // Only a release can be behind a release. Asking costs a network round trip that is never worth
+  // delaying a paint or a restored session for, so it waits for the window to go idle and is dropped
+  // if the window goes away first.
+  useEffect(() => {
+    if (commit !== "") return;
+    let cancelled = false;
+    const check = () => {
+      if (cancelled) return;
+      void invoke<string | null>("check_update")
+        .then((next) => {
+          if (!cancelled) setRelease(next ? "behind" : "current");
+        })
+        .catch(() => {
+          if (!cancelled) setRelease("unknown");
+        });
+    };
+    const idle = typeof window.requestIdleCallback === "function";
+    const handle = idle ? window.requestIdleCallback(check, { timeout: 10000 }) : window.setTimeout(check, 3000);
+    return () => {
+      cancelled = true;
+      if (idle) window.cancelIdleCallback(handle);
+      else window.clearTimeout(handle);
+    };
+  }, [commit]);
 
   useEffect(() => {
     let disposed = false;
@@ -539,7 +574,7 @@ function App() {
               <TooltipTrigger
                 render={
                   <Badge
-                    variant={commit ? "error" : behind === undefined ? "outline" : behind ? "warning" : "success"}
+                    variant={commit ? "error" : BADGE_VARIANT[release]}
                     render={<button type="button" onClick={() => void checkForUpdates()} />}
                   >
                     {commit || version}
@@ -552,11 +587,7 @@ function App() {
                 ) : (
                   <span className="flex flex-col gap-0.5">
                     <span>
-                      {behind === undefined
-                        ? `Lite ${version}`
-                        : behind
-                          ? `Lite ${version} · an update is available`
-                          : `Lite ${version} · up to date`}
+                      {`Lite ${version}${RELEASE_NOTE[release]}`}
                       {built ? ` · released ${built}` : ""}
                     </span>
                     <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,7 +136,7 @@ function SessionRow({
             <Input
               autoFocus
               value={name}
-              className="h-6 px-1.5 text-xs"
+              className="px-1.5"
               aria-label="Session name"
               onChange={(event) => setName(event.target.value)}
               onBlur={saveName}
@@ -255,6 +255,8 @@ function App() {
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
   const [commit, setCommit] = useState("");
+  const [built, setBuilt] = useState("");
+  const [behind, setBehind] = useState<boolean>();
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
@@ -322,8 +324,18 @@ function App() {
     void getVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
+    void invoke<string | null>("build_date")
+      .then((value) => setBuilt(value ?? ""))
+      .catch(() => setBuilt(""));
     void invoke<string | null>("local_commit")
-      .then((value) => setCommit(value ?? ""))
+      .then((value) => {
+        setCommit(value ?? "");
+        // A local build is never the released one, so only a release asks whether it is behind.
+        if (value) return;
+        return invoke<string | null>("check_update")
+          .then((next) => setBehind(Boolean(next)))
+          .catch(() => setBehind(undefined));
+      })
       .catch(() => setCommit(""));
   }, []);
 
@@ -517,22 +529,49 @@ function App() {
         {/* The window buttons sit inside this bar on macOS, so it doubles as the title bar and drags the window. */}
         <header
           data-tauri-drag-region
-          className="flex h-11 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground in-data-[titlebar=overlay]:pl-[86px]"
+          className="flex h-9 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground in-data-[titlebar=overlay]:pl-[86px]"
         >
           <LiteLogomark className="size-5" />
-          {/* A local build names its commit; a release names the version it is, and either checks for a
-              newer one, which is the question a version in a window is usually being asked. */}
+          {/* A local build names its commit and is red, so it is never mistaken for the installed copy.
+              A release names its version and says at a glance whether it is the current one. */}
           {commit || version ? (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <Badge variant="outline" render={<button type="button" onClick={() => void checkForUpdates()} />}>
+                  <Badge
+                    variant={commit ? "error" : behind === undefined ? "outline" : behind ? "warning" : "success"}
+                    render={<button type="button" onClick={() => void checkForUpdates()} />}
+                  >
                     {commit || version}
                   </Badge>
                 }
               />
               <TooltipContent>
-                {commit ? `Local build ${commit} · check for updates` : "Check for updates"}
+                {commit ? (
+                  `Local build${built ? ` from ${built}` : ""} · click to compare with your working tree`
+                ) : (
+                  <span className="flex flex-col gap-0.5">
+                    <span>
+                      {behind === undefined
+                        ? `Lite ${version}`
+                        : behind
+                          ? `Lite ${version} · an update is available`
+                          : `Lite ${version} · up to date`}
+                      {built ? ` · released ${built}` : ""}
+                    </span>
+                    <button
+                      type="button"
+                      className="underline underline-offset-2"
+                      onClick={() =>
+                        void invoke("open_url", {
+                          url: `https://github.com/ultralytics/lite/releases/tag/v${version}`,
+                        })
+                      }
+                    >
+                      View this release on GitHub
+                    </button>
+                  </span>
+                )}
               </TooltipContent>
             </Tooltip>
           ) : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
-type UpdateStatus = "checking" | "available" | "current" | "installing" | "error";
+type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installing" | "error";
 
 function loadSessions(): Session[] {
   try {
@@ -485,9 +485,10 @@ function App() {
     setUpdateStatus("checking");
     setUpdateError("");
     try {
-      const next = await invoke<string | null>("check_update");
+      // A release would replace this build rather than update it, so a local build asks its own tree.
+      const next = await invoke<string | null>(commit ? "local_update" : "check_update");
       setAvailableVersion(next ?? "");
-      setUpdateStatus(next ? "available" : "current");
+      setUpdateStatus(next ? (commit ? "rebuild" : "available") : "current");
     } catch (reason) {
       setUpdateError(String(reason));
       setUpdateStatus("error");
@@ -718,11 +719,22 @@ function App() {
             <DialogHeader>
               <DialogTitle>Lite updates</DialogTitle>
               <DialogDescription aria-live="polite">
-                {updateStatus === "checking" ? "Checking GitHub for the latest release…" : null}
+                {updateStatus === "checking"
+                  ? commit
+                    ? "Comparing this build with the tree it was built from…"
+                    : "Checking GitHub for the latest release…"
+                  : null}
                 {updateStatus === "available"
                   ? `Lite ${availableVersion} is ready. Updating stops running sessions; their tabs resume after restart.`
                   : null}
-                {updateStatus === "current" ? "You have the latest version of Lite." : null}
+                {updateStatus === "rebuild"
+                  ? `This build is ${commit} and the tree is now ${availableVersion}. Run bun run local to rebuild.`
+                  : null}
+                {updateStatus === "current"
+                  ? commit
+                    ? "This build matches the tree it was built from."
+                    : "You have the latest version of Lite."
+                  : null}
                 {updateStatus === "installing" ? "Downloading and installing the update…" : null}
                 {updateStatus === "error" ? `Update failed: ${updateError}` : null}
               </DialogDescription>
@@ -738,7 +750,7 @@ function App() {
                 <Button onClick={() => void installUpdate()}>Install and restart</Button>
               </DialogFooter>
             ) : null}
-            {updateStatus === "current" ? (
+            {updateStatus === "current" || updateStatus === "rebuild" ? (
               <DialogFooter>
                 <Button onClick={() => changeUpdateOpen(false)}>Done</Button>
               </DialogFooter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
-// The version is known from the start, so the badge shows it throughout and only its colour waits on
+// The version is known from the start, so the badge shows it throughout and only its color waits on
 // the answer: grey while asking, which is quieter than a spinner that would resize a chip this small.
 const BADGE_VARIANT = {
   checking: "secondary",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,7 +254,7 @@ function App() {
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
-  const [local, setLocal] = useState(false);
+  const [commit, setCommit] = useState("");
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
@@ -322,9 +322,9 @@ function App() {
     void getVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
-    void invoke<boolean>("local_build")
-      .then(setLocal)
-      .catch(() => setLocal(false));
+    void invoke<string | null>("local_commit")
+      .then((value) => setCommit(value ?? ""))
+      .catch(() => setCommit(""));
   }, []);
 
   useEffect(() => {
@@ -519,11 +519,21 @@ function App() {
           className="flex h-11 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground in-data-[titlebar=overlay]:pl-[86px]"
         >
           <LiteLogomark className="size-5" />
-          {/* An unlabelled local build is indistinguishable from an install, and they share a data folder. */}
-          {local ? (
-            <Badge variant="outline" className="font-mono text-[10px] tracking-wide uppercase">
-              Local
-            </Badge>
+          {/* A local build names its commit; a release names the version it is, and either checks for a
+              newer one, which is the question a version in a window is usually being asked. */}
+          {commit || version ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Badge variant="outline" render={<button type="button" onClick={() => void checkForUpdates()} />}>
+                    {commit || version}
+                  </Badge>
+                }
+              />
+              <TooltipContent>
+                {commit ? `Local build ${commit} · check for updates` : "Check for updates"}
+              </TooltipContent>
+            </Tooltip>
           ) : null}
           {selected ? (
             <>
@@ -560,7 +570,9 @@ function App() {
               <DropdownMenuContent align="end" className="w-48">
                 {version ? (
                   <DropdownMenuGroup>
-                    <DropdownMenuLabel>{local ? `Lite ${version} · local build` : `Lite ${version}`}</DropdownMenuLabel>
+                    <DropdownMenuLabel>
+                      {commit ? `Lite ${version} · local ${commit}` : `Lite ${version}`}
+                    </DropdownMenuLabel>
                     <DropdownMenuSeparator />
                   </DropdownMenuGroup>
                 ) : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import { Component, lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { LiteLogomark, ProviderIcon } from "@/brand-icons";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -253,6 +254,7 @@ function App() {
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
+  const [local, setLocal] = useState(false);
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
@@ -320,6 +322,9 @@ function App() {
     void getVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
+    void invoke<boolean>("local_build")
+      .then(setLocal)
+      .catch(() => setLocal(false));
   }, []);
 
   useEffect(() => {
@@ -514,6 +519,12 @@ function App() {
           className="flex h-11 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground in-data-[titlebar=overlay]:pl-[86px]"
         >
           <LiteLogomark className="size-5" />
+          {/* An unlabelled local build is indistinguishable from an install, and they share a data folder. */}
+          {local ? (
+            <Badge variant="outline" className="font-mono text-[10px] tracking-wide uppercase">
+              Local
+            </Badge>
+          ) : null}
           {selected ? (
             <>
               <Separator orientation="vertical" className="mx-1 h-4" />
@@ -549,7 +560,7 @@ function App() {
               <DropdownMenuContent align="end" className="w-48">
                 {version ? (
                   <DropdownMenuGroup>
-                    <DropdownMenuLabel>Lite {version}</DropdownMenuLabel>
+                    <DropdownMenuLabel>{local ? `Lite ${version} · local build` : `Lite ${version}`}</DropdownMenuLabel>
                     <DropdownMenuSeparator />
                   </DropdownMenuGroup>
                 ) : null}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,9 +1,13 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+"use client";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
+import { GlobeIcon, LockIcon } from "lucide-react";
 
+import { SEMANTIC_BADGE_CLASSES } from "@/lib/semantic-styles";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
@@ -15,6 +19,11 @@ const badgeVariants = cva(
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        success: SEMANTIC_BADGE_CLASSES.success,
+        warning: SEMANTIC_BADGE_CLASSES.warning,
+        error: SEMANTIC_BADGE_CLASSES.error,
+        info: SEMANTIC_BADGE_CLASSES.info,
+        purple: SEMANTIC_BADGE_CLASSES.purple,
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
@@ -26,12 +35,9 @@ const badgeVariants = cva(
   },
 );
 
-function Badge({
-  className,
-  variant = "default",
-  render,
-  ...props
-}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+type BadgeProps = useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>;
+
+function Badge({ className, variant = "default", render, ...props }: BadgeProps) {
   return useRender({
     defaultTagName: "span",
     props: mergeProps<"span">(
@@ -48,4 +54,35 @@ function Badge({
   });
 }
 
-export { Badge, badgeVariants };
+function VisibilityBadge({
+  visibility,
+  iconOnly = false,
+  overlay = false,
+  className,
+}: {
+  visibility: "public" | "private" | undefined;
+  iconOnly?: boolean;
+  overlay?: boolean;
+  className?: string;
+}) {
+  if (!visibility) return null;
+  const isPublic = visibility === "public";
+  const Icon = isPublic ? GlobeIcon : LockIcon;
+
+  return (
+    <Badge
+      variant={isPublic ? "secondary" : "outline"}
+      className={cn(
+        "capitalize",
+        iconOnly && "px-1 py-0",
+        overlay && "border-white/30 bg-white/20 text-white",
+        className,
+      )}
+    >
+      <Icon />
+      {iconOnly ? null : visibility}
+    </Badge>
+  );
+}
+
+export { Badge, type BadgeProps, badgeVariants, VisibilityBadge };

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,53 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import { cva } from "class-variance-authority";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        outline:
+          "border-border bg-background text-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "text-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        "destructive-outline":
+          "border-destructive/30 bg-background text-destructive hover:bg-destructive/10 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-input/30 dark:focus-visible:ring-destructive/40",
+        "destructive-ghost":
+          "text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+        "icon-ghost":
+          "text-muted-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        success:
+          "bg-success text-white hover:bg-success/80 focus-visible:border-success/40 focus-visible:ring-success/20 dark:focus-visible:ring-success/40",
+        warning:
+          "bg-amber-600 text-white hover:bg-amber-700 focus-visible:border-amber-500 focus-visible:ring-amber-200 dark:hover:bg-amber-500 dark:focus-visible:ring-amber-400/30",
+        error:
+          "bg-red-600 text-white hover:bg-red-700 focus-visible:border-red-500 focus-visible:ring-red-200 dark:hover:bg-red-500 dark:focus-visible:ring-red-400/30",
+        info: "bg-sky-600 text-white hover:bg-sky-700 focus-visible:border-sky-500 focus-visible:ring-sky-200 dark:hover:bg-sky-500 dark:focus-visible:ring-sky-400/30",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export { buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,52 +1,33 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import { Button as ButtonPrimitive } from "@base-ui/react/button";
-import { cva, type VariantProps } from "class-variance-authority";
+"use client";
 
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import type { VariantProps } from "class-variance-authority";
+import type { ReactNode } from "react";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
-        outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
-        destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-);
+type ButtonProps = ButtonPrimitive.Props & VariantProps<typeof buttonVariants>;
 
-function Button({
-  className,
-  variant = "default",
-  size = "default",
-  ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+function Button({ className, variant = "default", size = "default", ...props }: ButtonProps) {
   return <ButtonPrimitive data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />;
 }
 
-export { Button, buttonVariants };
+function ActionIconButton({
+  tooltip,
+  tooltipSide,
+  variant = "icon-ghost",
+  size = "icon",
+  ...props
+}: ButtonProps & { tooltip: ReactNode; tooltipSide?: "top" | "right" | "bottom" | "left" }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<Button variant={variant} size={size} {...props} />} />
+      <TooltipContent side={tooltipSide}>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export { ActionIconButton, Button, type ButtonProps };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -5,8 +5,10 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
 import type * as React from "react";
-import { Button } from "@/components/ui/button";
+import { OVERLAY, Z } from "@/lib/design-tokens";
 import { cn } from "@/lib/utils";
+import { Button } from "./button";
+import { PageOverlay } from "./page-overlay";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -29,7 +31,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        `fixed inset-0 isolate ${Z.overlay} ${OVERLAY.blur} duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0`,
         className,
       )}
       {...props}
@@ -37,42 +39,70 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
   );
 }
 
+const DIALOG_SIZES = {
+  sm: "sm:max-w-sm",
+  md: "sm:max-w-md",
+  lg: "sm:max-w-lg",
+  xl: "sm:max-w-xl",
+  "2xl": "sm:max-w-2xl",
+  "3xl": "sm:max-w-3xl",
+  full: "sm:max-w-[95vw]",
+} as const;
+
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
+  size = "md",
   ...props
 }: DialogPrimitive.Popup.Props & {
+  overlayClassName?: string;
   showCloseButton?: boolean;
+  size?: keyof typeof DIALOG_SIZES;
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Popup
-        data-slot="dialog-content"
-        className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Popup>
+      <PageOverlay visible variant="blur" className={overlayClassName}>
+        <DialogPrimitive.Popup
+          data-slot="dialog-content"
+          className={cn(
+            `relative ${Z.overlay} flex max-h-[85vh] w-full max-w-[calc(100%-2rem)] flex-col overflow-hidden rounded-xl bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 [&>form]:flex [&>form]:min-h-0 [&>form]:flex-1 [&>form]:flex-col`,
+            DIALOG_SIZES[size],
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
+            >
+              <XIcon aria-hidden="true" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Popup>
+      </PageOverlay>
     </DialogPortal>
   );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="dialog-header" className={cn("flex flex-col gap-2", className)} {...props} />;
+  return (
+    <div data-slot="dialog-header" className={cn("flex shrink-0 flex-col gap-2 px-4 pt-4", className)} {...props} />
+  );
+}
+
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-body"
+      className={cn("min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*]:min-w-0", className)}
+      {...props}
+    />
+  );
 }
 
 function DialogFooter({
@@ -87,7 +117,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "flex shrink-0 flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -123,6 +153,7 @@ function DialogDescription({ className, ...props }: DialogPrimitive.Description.
 
 export {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -5,6 +5,7 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import type * as React from "react";
+import { Z } from "@/lib/design-tokens";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
@@ -30,7 +31,7 @@ function DropdownMenuContent({
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
-        className="isolate z-50 outline-none"
+        className={cn("isolate outline-none", Z.popover)}
         align={align}
         alignOffset={alignOffset}
         side={side}
@@ -39,7 +40,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95",
+            `max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95 ${Z.popover}`,
             className,
           )}
           {...props}

--- a/src/components/ui/page-overlay.tsx
+++ b/src/components/ui/page-overlay.tsx
@@ -1,0 +1,197 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+"use client";
+
+import type * as React from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { OVERLAY, Z } from "@/lib/design-tokens";
+import { cn } from "@/lib/utils";
+
+const useIsoLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/** Selector for interactive elements - prevents closing overlay when clicking buttons, links, etc. */
+export const INTERACTIVE_SELECTOR =
+  'button, a, input, select, textarea, label, [role="button"], [role="link"], [role="menuitem"], [role="switch"], [role="checkbox"], [role="radio"], [role="tab"], [role="option"]';
+
+/** Get the header height for positioning below it */
+function getHeaderHeight(): number {
+  const inset = document.querySelector('main[data-slot="sidebar-inset"]');
+  if (inset) {
+    const header = inset.querySelector("header");
+    if (header) {
+      // getBoundingClientRect().bottom is relative to viewport - can be negative when scrolled
+      // Clamp to 0 so overlay never positions above viewport top
+      return Math.max(0, header.getBoundingClientRect().bottom);
+    }
+  }
+  return 0;
+}
+
+/** Get the target sidebar width based on its state (collapsed or expanded) */
+function getSidebarWidth(): number {
+  const sidebar = document.querySelector('[data-slot="sidebar"]');
+  if (!sidebar) return 0;
+
+  const state = sidebar.getAttribute("data-state");
+  const collapsible = sidebar.getAttribute("data-collapsible");
+
+  // Get rem base size for conversion (default 16px)
+  const remBase = Number.parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+
+  // Sidebar widths from sidebar.tsx: SIDEBAR_WIDTH = "16rem", SIDEBAR_WIDTH_ICON = "3rem"
+  if (state === "collapsed" && collapsible === "icon") {
+    return 3 * remBase; // 3rem = 48px at 16px base
+  }
+  return 16 * remBase; // 16rem = 256px at 16px base
+}
+
+/**
+ * PageOverlay renders an overlay positioned exactly within the page content area,
+ * excluding the sidebar and header.
+ *
+ * It calculates the exact bounds of the content area and positions itself precisely,
+ * ensuring it doesn't cover the sidebar or header.
+ *
+ * Use this for:
+ * - Dialog backdrops (blurred backgrounds)
+ * - Dropzone overlays
+ * - Fullscreen chart/media viewers
+ * - Any modal-like UI that should cover the page but not sidebar/header
+ *
+ * @example
+ * ```tsx
+ * <PageOverlay visible={isDragging} variant="dropzone">
+ *   <UploadIcon />
+ *   <p>Drop files here</p>
+ * </PageOverlay>
+ * ```
+ */
+export function PageOverlay({
+  visible,
+  variant = "default",
+  inset = 0,
+  children,
+  className,
+  onClick,
+}: {
+  /** Whether the overlay is visible */
+  visible: boolean;
+  /** Visual variant of the overlay */
+  variant?: "default" | "blur" | "dropzone" | "fullscreen" | "viewer";
+  /** Inset from edges in pixels (default: 0, dropzone default: 16) */
+  inset?: number;
+  /** Content to display centered in the overlay */
+  children?: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+  /** Click handler (e.g., to close on backdrop click) */
+  onClick?: () => void;
+}) {
+  // Apply default inset for dropzone variant
+  const effectiveInset = inset || (variant === "dropzone" ? 16 : 0);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [sidebarWidth, setSidebarWidth] = useState(0);
+  const [mounted, setMounted] = useState(false);
+  const sidebarWidthRef = useRef(sidebarWidth);
+  const headerHeightRef = useRef(headerHeight);
+  sidebarWidthRef.current = sidebarWidth;
+  headerHeightRef.current = headerHeight;
+
+  useIsoLayoutEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useIsoLayoutEffect(() => {
+    if (!visible) return;
+
+    const updateDimensions = () => {
+      setHeaderHeight(getHeaderHeight());
+      setSidebarWidth(getSidebarWidth());
+    };
+
+    // Close on click outside overlay bounds (sidebar, header, etc.)
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (!onClick) return;
+
+      // Don't close if clicking on an interactive element (buttons, links, etc.)
+      if (e.target instanceof HTMLElement && e.target.closest(INTERACTIVE_SELECTOR)) return;
+
+      // Check if click is in the sidebar area (left of the overlay) or header (above)
+      const { clientX: x, clientY: y } = e;
+      if (x < sidebarWidthRef.current || y < headerHeightRef.current) {
+        onClick();
+      }
+    };
+
+    // Lock body scroll when overlay is visible
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    updateDimensions();
+    window.addEventListener("resize", updateDimensions);
+    document.addEventListener("mousedown", handleOutsideClick);
+
+    // Watch for sidebar state changes (collapsed/expanded) using MutationObserver
+    // This fires immediately when data-state attribute changes, before CSS transition starts
+    const sidebar = document.querySelector('[data-slot="sidebar"]');
+    const mutationObserver = sidebar
+      ? new MutationObserver(() => {
+          setSidebarWidth(getSidebarWidth());
+        })
+      : null;
+    if (sidebar && mutationObserver) {
+      mutationObserver.observe(sidebar, { attributes: true, attributeFilter: ["data-state"] });
+    }
+
+    return () => {
+      window.removeEventListener("resize", updateDimensions);
+      document.removeEventListener("mousedown", handleOutsideClick);
+      mutationObserver?.disconnect();
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [visible, onClick]);
+
+  if (!visible || !mounted) return null;
+
+  const variantStyles = {
+    default: OVERLAY.default,
+    blur: OVERLAY.blur,
+    dropzone: OVERLAY.dropzone,
+    fullscreen: OVERLAY.fullscreen,
+    viewer: OVERLAY.viewer,
+  };
+
+  // Position using calculated sidebar width - updates immediately when sidebar state changes
+  // The sidebar animates its width, we animate our left position to match
+  const overlay = (
+    <div
+      className={cn(
+        `fixed ${Z.overlay}`,
+        variantStyles[variant],
+        "animate-in fade-in-0 duration-200",
+        // Transition left to match sidebar animation (200ms ease-linear)
+        "transition-[left] duration-200 ease-linear",
+        className,
+      )}
+      style={{
+        top: headerHeight + effectiveInset,
+        left: sidebarWidth + effectiveInset,
+        right: effectiveInset,
+        bottom: effectiveInset,
+      }}
+    >
+      {onClick && (
+        <button
+          type="button"
+          className="absolute inset-0 z-10 bg-transparent border-none p-0 m-0 cursor-pointer"
+          aria-label="Close overlay"
+          onClick={onClick}
+        />
+      )}
+      <div className="relative z-20 h-full w-full flex items-center justify-center">{children}</div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -3,7 +3,6 @@
 "use client";
 
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
-
 import { cn } from "@/lib/utils";
 
 function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.Props) {
@@ -28,7 +27,7 @@ function ScrollBar({ className, orientation = "vertical", ...props }: ScrollArea
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        "flex touch-none p-px transition-colors select-none data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:border-t data-[orientation=horizontal]:border-t-transparent data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2.5 data-[orientation=vertical]:border-l data-[orientation=vertical]:border-l-transparent",
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
         className,
       )}
       {...props}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,5 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+"use client";
+
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 
 import { cn } from "@/lib/utils";

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,18 +1,90 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { Loader2Icon } from "lucide-react";
+
+import { OVERLAY } from "@/lib/design-tokens";
 import { cn } from "@/lib/utils";
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
-    <Loader2Icon
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
-  );
-}
+const SPINNER_SIZES = {
+  sm: "h-4 w-4",
+  md: "h-6 w-6",
+  lg: "h-8 w-8",
+  xl: "h-12 w-12",
+} as const;
 
-export { Spinner };
+type SpinnerSize = keyof typeof SPINNER_SIZES;
+
+type SpinnerProps = {
+  /** Size of the spinner icon */
+  size?: SpinnerSize;
+  /** Label text below spinner (pass null to hide) */
+  label?: string | null;
+  /** Description text below label */
+  description?: string;
+  /** Additional className for the container */
+  className?: string;
+  /** Show as overlay with backdrop */
+  overlay?: boolean;
+  /** Use fixed positioning for full-screen overlay */
+  fullScreen?: boolean;
+  /** Conditionally show/hide the spinner */
+  show?: boolean;
+  /** Center in container with padding (for page/section loading states) */
+  centered?: boolean;
+};
+
+/**
+ * Unified loading spinner component.
+ *
+ * @example
+ * // Simple centered spinner (page loading)
+ * <Spinner centered />
+ *
+ * // With label
+ * <Spinner label="Loading data..." />
+ *
+ * // Small inline spinner
+ * <Spinner size="sm" />
+ *
+ * // Full-screen overlay
+ * <Spinner overlay fullScreen label="Processing..." />
+ */
+export function Spinner({
+  size = "lg",
+  label,
+  description,
+  className,
+  overlay,
+  fullScreen,
+  show = true,
+  centered = false,
+}: SpinnerProps) {
+  if (!show) return null;
+
+  const content = (
+    <div className={cn("flex flex-col items-center gap-3 text-center", className)}>
+      <Loader2Icon
+        data-slot="spinner"
+        role="status"
+        aria-label="Loading"
+        className={cn("animate-spin text-muted-foreground", SPINNER_SIZES[size])}
+      />
+      {(label || description) && (
+        <div className="space-y-1">
+          {label ? <p className="text-base font-semibold text-primary">{label}</p> : null}
+          {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+        </div>
+      )}
+    </div>
+  );
+
+  if (centered) {
+    return <div className="flex items-center justify-center py-12">{content}</div>;
+  }
+
+  if (!overlay) return content;
+
+  const overlayClass = fullScreen ? "fixed inset-0 z-50" : "absolute inset-x-0 top-0 z-30 h-screen max-h-full";
+
+  return <div className={cn(overlayClass, "flex items-center justify-center", OVERLAY.dialog)}>{content}</div>;
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,14 +12,14 @@ function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
+      className={cn("group/tabs flex min-w-0 max-w-full gap-8 data-horizontal:flex-col", className)}
       {...props}
     />
   );
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-8 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit max-w-full items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-horizontal/tabs:justify-start group-data-horizontal/tabs:overflow-x-auto group-data-horizontal/tabs:overscroll-x-contain group-data-horizontal/tabs:touch-pan-x group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col sm:group-data-horizontal/tabs:overflow-visible data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -53,10 +53,10 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className,
       )}
       {...props}
@@ -66,7 +66,11 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
 
 function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
-    <TabsPrimitive.Panel data-slot="tabs-content" className={cn("flex-1 text-sm outline-none", className)} {...props} />
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("min-w-0 max-w-full flex-1 text-sm outline-none", className)}
+      {...props}
+    />
   );
 }
 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,7 +1,5 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-"use client";
-
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cva, type VariantProps } from "class-variance-authority";
 
@@ -12,14 +10,17 @@ function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn("group/tabs flex min-w-0 max-w-full gap-8 data-horizontal:flex-col", className)}
+      // Base UI reports orientation only as data-orientation, and the variants below key off the
+      // shorter attribute, so it is set here instead of rewriting every class shadcn ships.
+      {...{ [`data-${orientation}`]: "" }}
+      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
       {...props}
     />
   );
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit max-w-full items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-horizontal/tabs:justify-start group-data-horizontal/tabs:overflow-x-auto group-data-horizontal/tabs:overscroll-x-contain group-data-horizontal/tabs:touch-pan-x group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col sm:group-data-horizontal/tabs:overflow-visible data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -66,11 +67,7 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
 
 function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
-    <TabsPrimitive.Panel
-      data-slot="tabs-content"
-      className={cn("min-w-0 max-w-full flex-1 text-sm outline-none", className)}
-      {...props}
-    />
+    <TabsPrimitive.Panel data-slot="tabs-content" className={cn("flex-1 text-sm outline-none", className)} {...props} />
   );
 }
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
+import { Z } from "@/lib/design-tokens";
 import { cn } from "@/lib/utils";
 
 function TooltipProvider({ delay = 0, ...props }: TooltipPrimitive.Provider.Props) {
@@ -35,12 +36,12 @@ function TooltipContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="isolate z-50"
+        className={cn("isolate", Z.tooltip)}
       >
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            `inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 ${Z.tooltip}`,
             className,
           )}
           {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,7 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -71,6 +72,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.723 0.219 142.136);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -119,6 +121,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.871 0.15 154.449);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -174,8 +174,6 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   const [selected, setSelected] = useState<FileEntry | null>(null);
   const [source, setSource] = useState("");
   const [error, setError] = useState("");
-  // Nothing here watches the disk, so rereading is the user's call and rebuilding the tree does it.
-  const [reading, setReading] = useState(0);
 
   async function openFile(entry: FileEntry) {
     setSelected(entry);
@@ -212,19 +210,8 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   }
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex h-9 shrink-0 items-center justify-between border-b px-3 text-xs">
-        <span className="font-medium">Files</span>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          onClick={() => setReading((count) => count + 1)}
-          aria-label="Reread this folder"
-        >
-          <RefreshCw />
-        </Button>
-      </div>
       <ScrollArea className="min-h-0 flex-1">
-        <FileTree key={reading} root={root} rootId={rootId} onOpen={(entry) => void openFile(entry)} />
+        <FileTree root={root} rootId={rootId} onOpen={(entry) => void openFile(entry)} />
       </ScrollArea>
     </div>
   );
@@ -233,17 +220,13 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
 function GitPanel({ rootId }: { rootId: string }) {
   const [status, setStatus] = useState<GitStatus | null>();
   const [error, setError] = useState("");
-  const [reading, setReading] = useState(false);
 
   const refresh = useCallback(async () => {
     setError("");
-    setReading(true);
     try {
       setStatus(await invoke<GitStatus | null>("git_status", { rootId }));
     } catch (reason) {
       setError(String(reason));
-    } finally {
-      setReading(false);
     }
   }, [rootId]);
 
@@ -253,18 +236,6 @@ function GitPanel({ rootId }: { rootId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex h-9 shrink-0 items-center justify-between border-b px-3 text-xs">
-        <span className="font-medium">Repository</span>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          disabled={reading}
-          onClick={() => void refresh()}
-          aria-label="Refresh Git status"
-        >
-          {reading ? <Spinner /> : <RefreshCw />}
-        </Button>
-      </div>
       <ScrollArea className="min-h-0 flex-1">
         <div className="p-3 text-xs">
           {error ? (
@@ -325,11 +296,9 @@ function missingUsage(session: Session): string {
 function UsagePanel({ session }: { session: Session }) {
   const [usage, setUsage] = useState<UsageSnapshot | null>();
   const [error, setError] = useState("");
-  const [reading, setReading] = useState(false);
 
   const refresh = useCallback(async () => {
     setError("");
-    setReading(true);
     try {
       setUsage(
         await invoke<UsageSnapshot | null>("read_usage", {
@@ -340,8 +309,6 @@ function UsagePanel({ session }: { session: Session }) {
       );
     } catch (reason) {
       setError(String(reason));
-    } finally {
-      setReading(false);
     }
   }, [session.agent, session.provider, session.id]);
 
@@ -351,20 +318,6 @@ function UsagePanel({ session }: { session: Session }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex h-9 shrink-0 items-center justify-between border-b px-3 text-xs">
-        <span className="font-medium">Usage</span>
-        {session.agent === "shell" ? null : (
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            disabled={reading}
-            onClick={() => void refresh()}
-            aria-label="Refresh usage"
-          >
-            {reading ? <Spinner /> : <RefreshCw />}
-          </Button>
-        )}
-      </div>
       <ScrollArea className="min-h-0 flex-1">
         <div className="space-y-3 p-3 text-xs">
           {error ? (
@@ -428,29 +381,38 @@ function UsagePanel({ session }: { session: Session }) {
 }
 
 export function Inspector({ session }: { session: Session }) {
+  const [tab, setTab] = useState("files");
+  // A tab already names the panel it shows, so the panel does not name itself again. One button beside
+  // the tabs rereads whichever is open, by rebuilding it, and only that one ever reads the disk.
+  const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
+
   return (
-    <Tabs defaultValue="files" className="h-full min-h-0 gap-0">
-      <div className="flex h-11 shrink-0 items-center border-b px-3">
-        <TabsList variant="line" className="h-8 gap-4">
-          <TabsTrigger value="files" className="px-0 text-xs">
-            Files
-          </TabsTrigger>
-          <TabsTrigger value="git" className="px-0 text-xs">
-            Git
-          </TabsTrigger>
-          <TabsTrigger value="usage" className="px-0 text-xs">
-            Usage
-          </TabsTrigger>
+    <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
+      <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
+        <TabsList variant="line">
+          <TabsTrigger value="files">Files</TabsTrigger>
+          <TabsTrigger value="git">Git</TabsTrigger>
+          <TabsTrigger value="usage">Usage</TabsTrigger>
         </TabsList>
+        {tab === "usage" && session.agent === "shell" ? null : (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
+            aria-label="Refresh"
+          >
+            <RefreshCw />
+          </Button>
+        )}
       </div>
       <TabsContent value="files" className="min-h-0 overflow-hidden">
-        <FilesPanel root={session.cwd} rootId={session.rootId} />
+        <FilesPanel key={reload.files} root={session.cwd} rootId={session.rootId} />
       </TabsContent>
       <TabsContent value="git" className="min-h-0 overflow-hidden">
-        <GitPanel rootId={session.rootId} />
+        <GitPanel key={reload.git} rootId={session.rootId} />
       </TabsContent>
       <TabsContent value="usage" className="min-h-0 overflow-hidden">
-        <UsagePanel session={session} />
+        <UsagePanel key={reload.usage} session={session} />
       </TabsContent>
     </Tabs>
   );

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1,7 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { ChevronRight, File, Folder, GitBranch, RefreshCw, X } from "lucide-react";
+import { ChartNoAxesColumn, ChevronRight, File, Folder, GitBranch, RefreshCw, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -390,9 +390,15 @@ export function Inspector({ session }: { session: Session }) {
     <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
         <TabsList variant="line">
-          <TabsTrigger value="files">Files</TabsTrigger>
-          <TabsTrigger value="git">Git</TabsTrigger>
-          <TabsTrigger value="usage">Usage</TabsTrigger>
+          <TabsTrigger value="files" aria-label="Files">
+            <Folder />
+          </TabsTrigger>
+          <TabsTrigger value="git" aria-label="Git">
+            <GitBranch />
+          </TabsTrigger>
+          <TabsTrigger value="usage" aria-label="Usage">
+            <ChartNoAxesColumn />
+          </TabsTrigger>
         </TabsList>
         {tab === "usage" && session.agent === "shell" ? null : (
           <Button

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -1,0 +1,212 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+/**
+ * Color conversion utilities for the ColorPicker component.
+ * Provides HSV/RGB/Hex conversions for spectrum-based color selection.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type RGB = { r: number; g: number; b: number };
+export type HSV = { h: number; s: number; v: number };
+
+// ============================================================================
+// Hex Utilities
+// ============================================================================
+
+/**
+ * Parse hex color to RGB object.
+ * @param hex - Hex color string (with or without #)
+ * @returns RGB object or null if invalid
+ */
+export function hexToRgbObject(hex: string): RGB | null {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return null;
+  return {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16),
+  };
+}
+
+/**
+ * Convert RGB values to hex string.
+ * @returns Hex string with # prefix (e.g., "#6366f1")
+ */
+export function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) =>
+    Math.round(Math.max(0, Math.min(255, n)))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Linearly interpolate between two hex colors.
+ * @param ratio - 0 returns `from`, 1 returns `to`
+ */
+export function interpolateHexColor(from: string, to: string, ratio: number): string {
+  const start = hexToRgbObject(from);
+  const end = hexToRgbObject(to);
+  if (!start || !end) return from;
+  return rgbToHex(
+    start.r + (end.r - start.r) * ratio,
+    start.g + (end.g - start.g) * ratio,
+    start.b + (end.b - start.b) * ratio,
+  );
+}
+
+/**
+ * Validate hex color format.
+ * @param hex - Hex color string to validate
+ * @returns True if valid 3 or 6 character hex color
+ */
+export function isValidHex(hex: string): boolean {
+  return /^#?([a-f\d]{3}|[a-f\d]{6})$/i.test(hex);
+}
+
+/**
+ * Normalize hex color (add # prefix, expand 3-char to 6-char).
+ * @param hex - Hex color string
+ * @returns Normalized hex string with # prefix
+ */
+export function normalizeHex(hex: string): string {
+  let h = hex.replace("#", "");
+  if (h.length === 3) {
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  return `#${h.toLowerCase()}`;
+}
+
+// ============================================================================
+// HSV/RGB Conversions
+// ============================================================================
+
+/**
+ * Convert RGB to HSV.
+ * @returns HSV object with h: 0-360, s: 0-100, v: 0-100
+ */
+export function rgbToHsv(r: number, g: number, b: number): HSV {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+
+  let h = 0;
+  const s = max === 0 ? 0 : d / max;
+  const v = max;
+
+  if (max !== min) {
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return { h: h * 360, s: s * 100, v: v * 100 };
+}
+
+/**
+ * Convert HSV to RGB.
+ * @param h - Hue (0-360)
+ * @param s - Saturation (0-100)
+ * @param v - Value/Brightness (0-100)
+ * @returns RGB object with values 0-255
+ */
+export function hsvToRgb(h: number, s: number, v: number): RGB {
+  h /= 360;
+  s /= 100;
+  v /= 100;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  const i = Math.floor(h * 6);
+  const f = h * 6 - i;
+  const p = v * (1 - s);
+  const q = v * (1 - f * s);
+  const t = v * (1 - (1 - f) * s);
+
+  switch (i % 6) {
+    case 0:
+      r = v;
+      g = t;
+      b = p;
+      break;
+    case 1:
+      r = q;
+      g = v;
+      b = p;
+      break;
+    case 2:
+      r = p;
+      g = v;
+      b = t;
+      break;
+    case 3:
+      r = p;
+      g = q;
+      b = v;
+      break;
+    case 4:
+      r = t;
+      g = p;
+      b = v;
+      break;
+    case 5:
+      r = v;
+      g = p;
+      b = q;
+      break;
+  }
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+}
+
+// ============================================================================
+// Contrast Utilities
+// ============================================================================
+
+/**
+ * Calculate relative luminance for contrast calculation.
+ * @returns Luminance value 0-1
+ */
+function getLuminance(r: number, g: number, b: number): number {
+  const [rs, gs, bs] = [r, g, b].map((c) => {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+}
+
+/**
+ * Determine if white text should be used on a color background.
+ * @param hex - Background color as hex string
+ * @returns True if white text provides better contrast
+ */
+export function shouldUseWhiteText(hex: string): boolean {
+  const rgb = hexToRgbObject(hex);
+  if (!rgb) return true;
+  return getLuminance(rgb.r, rgb.g, rgb.b) < 0.5;
+}

--- a/src/lib/design-tokens.ts
+++ b/src/lib/design-tokens.ts
@@ -1,0 +1,535 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import { interpolateHexColor } from "./color-utils";
+
+/**
+ * Convert hex color to RGB string for use in rgba().
+ * @param hex - Hex color string (with or without #)
+ * @param fallback - Fallback RGB values if parsing fails (default: slate gray)
+ * @returns RGB values as comma-separated string (e.g., "100, 116, 139")
+ */
+export function hexToRgb(hex: string, fallback = "100, 116, 139"): string {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return fallback;
+  return `${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(result[3], 16)}`;
+}
+
+export type ThemeColor = { light: string; dark: string };
+
+// 20 colors from Tailwind palette to support charts with many series (MAX_PIE_ITEMS=20)
+export const THEME_COLORS = {
+  // Primary colors (Tailwind palette)
+  indigo: { light: "#6366f1", dark: "#a5b4ff" },
+  green: { light: "#22c55e", dark: "#86efac" },
+  orange: { light: "#f97316", dark: "#fdba74" },
+  cyan: { light: "#06b6d4", dark: "#67e8f9" },
+  yellow: { light: "#eab308", dark: "#fde047" },
+  red: { light: "#ef4444", dark: "#fca5a5" },
+  violet: { light: "#8b5cf6", dark: "#c4b5fd" },
+  sky: { light: "#0ea5e9", dark: "#7dd3fc" },
+  pink: { light: "#f472b6", dark: "#f9a8d4" },
+  teal: { light: "#14b8a6", dark: "#5eead4" },
+  blue: { light: "#3b82f6", dark: "#60a5fa" },
+  emerald: { light: "#10b981", dark: "#34d399" },
+  amber: { light: "#f59e0b", dark: "#fbbf24" },
+  rose: { light: "#f43f5e", dark: "#fb7185" },
+  purple: { light: "#a855f7", dark: "#c084fc" },
+  fuchsia: { light: "#c026d3", dark: "#e879f9" },
+  lime: { light: "#84cc16", dark: "#a3e635" },
+  slate: { light: "#64748b", dark: "#94a3b8" },
+  stone: { light: "#78716c", dark: "#a8a29e" },
+  zinc: { light: "#71717a", dark: "#a1a1aa" },
+} as const;
+
+export const PROJECT_ICON_COLORS = [
+  "red",
+  "orange",
+  "yellow",
+  "lime",
+  "green",
+  "teal",
+  "cyan",
+  "blue",
+  "indigo",
+  "violet",
+  "purple",
+  "pink",
+  "fuchsia",
+  "rose",
+  "slate",
+] as const;
+
+export const PROJECT_ICON_DEFAULT_COLOR = "slate" as const;
+
+export function getProjectIconFallbackColor(name: string) {
+  return name
+    ? PROJECT_ICON_COLORS[[...name].reduce((sum, ch) => sum + ch.charCodeAt(0), 0) % PROJECT_ICON_COLORS.length]
+    : PROJECT_ICON_DEFAULT_COLOR;
+}
+
+// Official Ultralytics brand colors (from ultralytics.com/brand)
+export const BRAND_COLORS = {
+  // Primary
+  darkBlue: "#111F68",
+  brightBlue: "#042AFF",
+  neonYellow: "#E1FF25",
+  neonPink: "#FF64DA",
+  lightGrey: "#F3F3F3",
+  white: "#FFFFFF",
+  black: "#0b0b0f", // Near black for text
+  // Secondary
+  aquaBlue: "#00FFFF",
+  lightBlue: "#ACF9FF",
+  neonGreen: "#76FFD6",
+  grey: "#CCCCCC",
+  darkGrey: "#9E9E9E",
+  // Logo
+  cyan: "#63D7EB",
+  logoDarkBlue: "#1323A5",
+  logoGrey: "#EAEDF4",
+  // Bounding box palette (for visualizations)
+  bbox: ["#0BDBEB", "#00DFB7", "#FF6FDD", "#CCED00", "#00F344", "#BD00FF", "#00B4FF", "#DD00BA"],
+} as const;
+
+// Official brand gradient — used by gradient CTAs on every public app.
+export const BRAND_GRADIENT = `linear-gradient(105deg, ${BRAND_COLORS.darkBlue} 0%, ${BRAND_COLORS.brightBlue} 45%, ${BRAND_COLORS.neonGreen} 100%)`;
+
+// Stops of BRAND_GRADIENT, used to sample a per-item accent color along the brand gradient
+// (e.g. timeline nodes/pills on the /yolo and /roadmap pages).
+const BRAND_GRADIENT_STOPS = [
+  { color: BRAND_COLORS.darkBlue, position: 0 },
+  { color: BRAND_COLORS.brightBlue, position: 0.45 },
+  { color: BRAND_COLORS.neonGreen, position: 1 },
+] as const;
+
+// Sample the brand gradient at `index / (count - 1)`, returning a hex accent for that position.
+export function brandGradientColor(index: number, count: number): string {
+  const position = count <= 1 ? 0 : index / (count - 1);
+  const endIndex = BRAND_GRADIENT_STOPS.findIndex((stop) => stop.position >= position);
+  const end = BRAND_GRADIENT_STOPS[endIndex === -1 ? BRAND_GRADIENT_STOPS.length - 1 : endIndex];
+  const start = BRAND_GRADIENT_STOPS[Math.max(0, (endIndex === -1 ? BRAND_GRADIENT_STOPS.length - 1 : endIndex) - 1)];
+  const span = end.position - start.position;
+  return interpolateHexColor(start.color, end.color, span ? (position - start.position) / span : 0);
+}
+
+// Soft pastel hero gradient — used on www marketing hero sections (home, brand, license, customers, partners, about).
+export const BRAND_HERO_GRADIENT = `radial-gradient(at 0% 100%, ${BRAND_COLORS.aquaBlue}55 0%, transparent 45%), radial-gradient(at 100% 0%, ${BRAND_COLORS.neonPink}55 0%, transparent 45%), radial-gradient(at 50% 50%, ${BRAND_COLORS.lightBlue}66 0%, transparent 60%)`;
+
+// Horizontal brand background gradient (aqua → bright blue → neon pink) — used on www brand/design-system banners.
+export const BRAND_BACKGROUND_GRADIENT = `linear-gradient(90deg, ${BRAND_COLORS.aquaBlue} 0%, ${BRAND_COLORS.brightBlue} 50%, ${BRAND_COLORS.neonPink} 100%)`;
+
+const ULTRALYTICS_CLASS_COLORS = [
+  "#042aff",
+  "#0bdbeb",
+  "#f3f3f3",
+  "#00dfb7",
+  "#111f68",
+  "#ff6fdd",
+  "#ff444f",
+  "#cced00",
+  "#00f344",
+  "#bd00ff",
+  "#00b4ff",
+  "#dd00ba",
+  "#00ffff",
+  "#26c000",
+  "#01ffb3",
+  "#7d24ff",
+  "#7b0068",
+  "#ff1b6c",
+  "#fc6d2f",
+  "#a2ff0b",
+] as const;
+
+const ULTRALYTICS_POSE_COLORS = [
+  "#ff8000",
+  "#ff9933",
+  "#ffb266",
+  "#e6e600",
+  "#ff99ff",
+  "#99ccff",
+  "#ff66ff",
+  "#ff33ff",
+  "#66b2ff",
+  "#3399ff",
+  "#ff9999",
+  "#ff6666",
+  "#ff3333",
+  "#99ff99",
+  "#66ff66",
+  "#33ff33",
+  "#00ff00",
+  "#0000ff",
+  "#ff0000",
+  "#ffffff",
+] as const;
+
+export const ULTRALYTICS_CLASS_PALETTE = {
+  colors: ULTRALYTICS_CLASS_COLORS,
+  get: (index: number) => ULTRALYTICS_CLASS_COLORS[index % ULTRALYTICS_CLASS_COLORS.length],
+} as const;
+
+export const ULTRALYTICS_POSE_PALETTE = {
+  colors: ULTRALYTICS_POSE_COLORS,
+  get: (index: number) => ULTRALYTICS_POSE_COLORS[index % ULTRALYTICS_POSE_COLORS.length],
+} as const;
+
+// UI colors for text, borders, and backgrounds (Tailwind gray/slate palette)
+export const UI_COLORS = {
+  // Text colors
+  text: { light: "#1f2937", dark: "#f9fafb" }, // gray-800 / gray-50
+  textMuted: { light: "#6b7280", dark: "#9ca3af" }, // gray-500 / gray-400
+  // Border/line colors
+  border: { light: "#e5e7eb", dark: "#374151" }, // gray-200 / gray-700
+  borderStrong: { light: "#d1d5db", dark: "#4b5563" }, // gray-300 / gray-600
+  // Background colors
+  bg: { light: "#ffffff", dark: "#1f2937" }, // white / gray-800
+  bgMuted: { light: "#f9fafb", dark: "#111827" }, // gray-50 / gray-900
+  bgDeep: { light: "#f1f5f9", dark: "#020617" }, // slate-100 / slate-950 (Tailwind dark mode)
+  // ECharts tooltip overlay colors (dark background, always used regardless of app theme)
+  tooltip: {
+    bg: "rgba(0, 0, 0, 0.85)",
+    text: "rgba(255, 255, 255, 1)",
+    textMuted: "rgba(255, 255, 255, 0.7)",
+    textFaint: "rgba(255, 255, 255, 0.5)",
+  },
+} as const;
+
+// Chart color palettes derived from THEME_COLORS (20 colors)
+const PALETTE_ORDER = [
+  "indigo",
+  "green",
+  "orange",
+  "cyan",
+  "yellow",
+  "red",
+  "violet",
+  "sky",
+  "pink",
+  "teal",
+  "blue",
+  "emerald",
+  "amber",
+  "rose",
+  "purple",
+  "fuchsia",
+  "lime",
+  "slate",
+  "stone",
+  "zinc",
+] as const;
+
+export const CHART_COLORS = {
+  // Default palette (alias for paletteLight, used by ECharts)
+  palette: PALETTE_ORDER.map((key) => THEME_COLORS[key].light),
+
+  // Light mode palette (20 colors from THEME_COLORS)
+  paletteLight: PALETTE_ORDER.map((key) => THEME_COLORS[key].light),
+
+  // Dark mode palette (20 colors from THEME_COLORS)
+  paletteDark: PALETTE_ORDER.map((key) => THEME_COLORS[key].dark),
+
+  // Full ThemeColor objects (for Recharts components needing light/dark theming)
+  paletteTheme: PALETTE_ORDER.map((key) => THEME_COLORS[key]),
+
+  // Semantic colors for specific data types
+  primary: THEME_COLORS.indigo.light,
+  success: THEME_COLORS.green.light,
+  warning: THEME_COLORS.amber.light,
+  danger: THEME_COLORS.red.light,
+  info: THEME_COLORS.cyan.light,
+
+  // Dashboard-specific colors (analytics) - ThemeColor objects for Recharts
+  signups: THEME_COLORS.cyan,
+  models: THEME_COLORS.pink,
+  datasets: THEME_COLORS.emerald,
+  projects: THEME_COLORS.violet,
+  plans: THEME_COLORS.amber,
+
+  // Highlight/emphasis color
+  highlight: THEME_COLORS.amber.light,
+  highlightBorder: THEME_COLORS.amber.dark,
+
+  // Equity/compensation chart colors
+  salary: THEME_COLORS.blue,
+  signingBonus: THEME_COLORS.amber,
+  equityGain: THEME_COLORS.green,
+  vestedValue: THEME_COLORS.indigo,
+  selectedBar: THEME_COLORS.green.light,
+
+  // Reference line colors
+  referenceLine: { stroke: "#94a3b8", fill: "#475569" },
+
+  // System metrics colors (status dashboard)
+  cpu: THEME_COLORS.indigo,
+  ram: THEME_COLORS.green,
+  gpuUsage: THEME_COLORS.cyan,
+  gpuMemory: THEME_COLORS.violet,
+  gpuTemp: THEME_COLORS.orange,
+  networkRecv: THEME_COLORS.green,
+  networkSent: THEME_COLORS.indigo,
+  diskRead: THEME_COLORS.cyan,
+  diskWrite: THEME_COLORS.orange,
+
+  // Analytics colors
+  messages: THEME_COLORS.indigo,
+  threads: THEME_COLORS.green,
+  calls: THEME_COLORS.cyan,
+  minutes: THEME_COLORS.green,
+  count: THEME_COLORS.indigo,
+} as const;
+
+/** Get chart palette based on theme */
+export const getChartPalette = (isDark: boolean) => (isDark ? CHART_COLORS.paletteDark : CHART_COLORS.paletteLight);
+
+/** Convert ThemeColor to ChartConfig theme format */
+export const chartTheme = (color: ThemeColor) => ({ theme: color });
+
+/**
+ * Pre-built chart series configs for common metrics.
+ * Use in ChartContainer config: { cpu: CHART_SERIES.cpu }
+ */
+export const CHART_SERIES = {
+  // System metrics (status dashboard)
+  cpu: { label: "CPU", ...chartTheme(THEME_COLORS.indigo) },
+  ram: { label: "RAM", ...chartTheme(THEME_COLORS.green) },
+  gpuUsage: { label: "GPU Compute", ...chartTheme(THEME_COLORS.cyan) },
+  gpuMemory: { label: "GPU Memory", ...chartTheme(THEME_COLORS.violet) },
+  gpuTemp: { label: "GPU Temp", ...chartTheme(THEME_COLORS.orange) },
+  networkRecv: { label: "Download", ...chartTheme(THEME_COLORS.green) },
+  networkSent: { label: "Upload", ...chartTheme(THEME_COLORS.indigo) },
+  diskRead: { label: "Read", ...chartTheme(THEME_COLORS.cyan) },
+  diskWrite: { label: "Write", ...chartTheme(THEME_COLORS.orange) },
+  // Analytics metrics (chat, gong dashboards)
+  messages: { label: "Messages", ...chartTheme(THEME_COLORS.indigo) },
+  threads: { label: "Threads", ...chartTheme(THEME_COLORS.green) },
+  count: { label: "Count", ...chartTheme(THEME_COLORS.indigo) },
+  calls: { label: "Calls", ...chartTheme(THEME_COLORS.cyan) },
+  minutes: { label: "Minutes", ...chartTheme(THEME_COLORS.green) },
+  // Time-based patterns
+  hourly: { label: "Calls", ...chartTheme(THEME_COLORS.cyan) },
+  weekday: { label: "Calls", ...chartTheme(THEME_COLORS.orange) },
+  duration: { label: "Calls", ...chartTheme(THEME_COLORS.yellow) },
+} as const;
+
+// Chart styling constants
+export const CHART_STYLE = {
+  radius: 6,
+  barRadius: 6,
+  barRadiusStart: [0, 6, 6, 0] as [number, number, number, number],
+  pieCornerRadius: 6,
+  animationDuration: 500,
+  animationDurationUpdate: 500,
+} as const;
+
+/**
+ * Model chart line colors - 20 visually distinct colors ordered for maximum differentiation.
+ * First 2-3 colors (blue/red/green) are maximally different for common 2-3 model comparisons.
+ */
+export const MODEL_CHART_PALETTE = {
+  colors: [
+    "#2563eb", // blue
+    "#dc2626", // red
+    "#16a34a", // green
+    "#9333ea", // purple
+    "#ea580c", // orange
+    "#0891b2", // cyan
+    "#be123c", // rose
+    "#4f46e5", // indigo
+    "#ca8a04", // yellow
+    "#0d9488", // teal
+    "#7c3aed", // violet
+    "#db2777", // pink
+    "#65a30d", // lime
+    "#0284c7", // sky
+    "#c2410c", // burnt orange
+    "#7e22ce", // deep purple
+    "#059669", // emerald
+    "#b91c1c", // dark red
+    "#1d4ed8", // royal blue
+    "#a16207", // amber
+  ] as const,
+  get: (index: number) =>
+    MODEL_CHART_PALETTE.colors[
+      index % MODEL_CHART_PALETTE.colors.length
+    ] as (typeof MODEL_CHART_PALETTE.colors)[number],
+} as const;
+
+// Text colors for charts
+export const CHART_TEXT = {
+  default: "#808080",
+  light: "#0f172a",
+  dark: "#e5e7eb",
+} as const;
+
+// Chart.js specific theme colors
+export const CHARTJS_THEME = {
+  light: { title: "#1f2937", axis: "#6b7280", grid: "rgba(209, 213, 219, 0.4)" },
+  dark: { title: "#f9fafb", axis: "#9ca3af", grid: "rgba(55, 65, 81, 0.25)" },
+  crosshair: "rgba(107, 114, 128, 0.5)",
+} as const;
+
+// Tooltip theme based on dark mode
+export const getTooltipTheme = (isDark: boolean) => ({
+  backgroundColor: isDark ? UI_COLORS.bgDeep.dark : UI_COLORS.bgMuted.light,
+  borderColor: isDark ? UI_COLORS.bg.dark : UI_COLORS.border.light,
+  textStyle: {
+    color: CHART_TEXT.default,
+    textBorderColor: "transparent",
+    textBorderWidth: 0,
+    textShadowColor: "transparent",
+  },
+});
+
+// Common ECharts base config
+export const ECHART_COMMON = {
+  backgroundColor: "transparent",
+  animationDuration: CHART_STYLE.animationDuration,
+  animationDurationUpdate: CHART_STYLE.animationDurationUpdate,
+} as const;
+
+// Base text style for ECharts
+export const getBaseTextStyle = (color: string = CHART_TEXT.default) => ({
+  color,
+  textBorderColor: "transparent",
+  textBorderWidth: 0,
+  textShadowColor: "transparent",
+});
+
+// ============================================================================
+// Component Tokens
+// ============================================================================
+
+// StatCard variant styles
+export const STAT_CARD_VARIANTS = {
+  default: {
+    card: "border-primary/10 bg-gradient-to-br from-primary/5 via-background to-background",
+    beforeCircle:
+      "before:pointer-events-none before:absolute before:right-[-20%] before:top-[-40%] before:size-52 before:rounded-full before:bg-primary/10",
+    afterCircle:
+      "after:pointer-events-none after:absolute after:right-[-5%] after:top-[-10%] after:size-32 after:rounded-full after:bg-primary/10",
+  },
+  warning: {
+    card: "border-amber-500/50 bg-amber-500/5 dark:bg-amber-500/10",
+  },
+  error: {
+    card: "border-red-500/50 bg-red-500/5 dark:bg-red-500/10",
+  },
+} as const;
+
+// Grid layout defaults
+export const GRID_DEFAULTS = {
+  columns: 6,
+  cellHeight: 175,
+  gap: 8,
+} as const;
+
+// ============================================================================
+// Z-Index Layers
+// ============================================================================
+
+/**
+ * Z-index layers (Tailwind classes) — one ascending scale so stacking is reason-about-able:
+ * overlay (50) < sidebar (60) < cookieBanner (65) < banner (80) < chatWidget (85) <
+ * popover (90) < tooltip (95) < lightbox (100) < toast (110).
+ * Use these instead of raw z-* classes on layered chrome.
+ */
+export const Z = {
+  /** Dialogs, sheets, page overlays */
+  overlay: "z-50",
+  /** Sticky app sidebar */
+  sidebar: "z-[60]",
+  /** Cookie-consent banner */
+  cookieBanner: "z-[65]",
+  /** Announcement banner */
+  banner: "z-[80]",
+  /** Ask-AI chat launcher pill, drag ghost, and floating panel */
+  chatWidget: "z-[85]",
+  /** Popovers, dropdown menus, context menus, hover cards — portaled to the body, so they must
+      out-rank every piece of page chrome they can open from (banner, sidebar, chat panel) */
+  popover: "z-[90]",
+  /** Tooltips — always on top of page chrome */
+  tooltip: "z-[95]",
+  /** Image-lightbox chrome (close/nav/zoom/metadata) layered over its own media inside a PageOverlay */
+  lightbox: "z-[100]",
+  /** Toast notifications — above overlays and all floating page chrome */
+  toast: "z-[110]",
+} as const;
+
+// ============================================================================
+// Blur & Overlay Tokens
+// ============================================================================
+
+/**
+ * Unified glass blur effect — backdrop blur with saturation boost.
+ * Use this instead of inline backdrop-blur-* classes.
+ * CSS equivalent: `backdrop-filter: blur(8px) saturate(120%) brightness(1.01);`
+ */
+export const BLUR = "backdrop-blur backdrop-saturate-[1.2] backdrop-brightness-[1.01]";
+
+/**
+ * Pre-built overlay styles combining background + blur.
+ * Use these for common overlay patterns.
+ */
+export const OVERLAY = {
+  /** Default semi-transparent overlay */
+  default: "bg-background/60",
+  /** Blur overlay — semi-transparent with glass effect */
+  blur: `bg-background/60 ${BLUR}`,
+  /** Standard dialog/modal backdrop */
+  dialog: `bg-background/80 ${BLUR}`,
+  /** Dropzone overlay — uses glass effect */
+  get dropzone() {
+    return this.glass;
+  },
+  /** Fullscreen content overlay */
+  fullscreen: `bg-background/70 ${BLUR}`,
+  /** Processing/loading overlay with blurred content */
+  processing: "blur-sm opacity-60 pointer-events-none",
+  /** Dark viewer backdrop (for images/media) */
+  viewer: `bg-black/85 ${BLUR}`,
+  /** Directional dark overlay for readable text on hero photography */
+  hero: "bg-gradient-to-r from-black/75 via-black/50 to-black/25",
+  /** Floating UI elements (tooltips, popovers) */
+  floating: `bg-background/95 ${BLUR}`,
+  /** Semi-transparent header/footer bars */
+  bar: `bg-background/90 ${BLUR}`,
+  /** Frosted glass panels (sidebars, dropdowns over images) */
+  glass: `bg-background/60 ${BLUR} border border-border/50`,
+} as const;
+
+// ============================================================================
+// OpenGraph Image Tokens
+// ============================================================================
+
+/**
+ * Centralized colors for OpenGraph (social sharing) images.
+ * OG images render with a fixed palette for consistent appearance across platforms.
+ * Use these instead of hardcoded hex colors in opengraph-image.tsx files.
+ */
+export const OG_COLORS = {
+  /** Standard gradient for all OG images */
+  gradient: "linear-gradient(135deg, #FF64DA 0%, #042AFF 50%, #0BDBEB 100%)",
+  /** Gradual directional overlay keeps OG text readable without obscuring photography on the right */
+  photoOverlay:
+    "linear-gradient(90deg, rgba(0, 0, 0, 0.82) 0%, rgba(0, 0, 0, 0.58) 38%, rgba(0, 0, 0, 0.24) 68%, rgba(0, 0, 0, 0.08) 100%)",
+
+  // Text colors
+  /** Primary text color (white) */
+  text: "#ffffff",
+  /** Secondary text color (white 70%) */
+  textMuted: "rgba(255, 255, 255, 0.7)",
+  /** Label/subtitle text (white 80%) */
+  textLabel: "rgba(255, 255, 255, 0.8)",
+  /** Footnote text (white 60%) */
+  textFaint: "rgba(255, 255, 255, 0.6)",
+
+  // Surfaces and borders
+  surface: "rgba(255, 255, 255, 0.1)",
+  surfaceStrong: "rgba(255, 255, 255, 0.15)",
+  surfaceSolid: "rgba(255, 255, 255, 0.2)",
+  border: "rgba(255, 255, 255, 0.3)",
+  strokeMuted: "rgba(255, 255, 255, 0.6)",
+  strokeStrong: "rgba(255, 255, 255, 0.8)",
+  strokeFaint: "rgba(255, 255, 255, 0.5)",
+} as const;

--- a/src/lib/semantic-styles.ts
+++ b/src/lib/semantic-styles.ts
@@ -1,0 +1,82 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+export type SemanticTone = "neutral" | "success" | "warning" | "error" | "info" | "purple";
+
+export const SEMANTIC_SURFACE_CLASSES = {
+  neutral: "border-border bg-muted/40 text-foreground",
+  success: "border-success/20 bg-success/10 text-success",
+  warning:
+    "border-amber-400/50 bg-amber-50/60 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400",
+  error: "border-destructive/30 bg-destructive/10 text-destructive dark:border-destructive/20",
+  info: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:border-sky-500/20 dark:text-sky-400",
+  purple: "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:border-violet-500/20 dark:text-violet-400",
+} as const satisfies Record<SemanticTone, string>;
+
+export const SEMANTIC_CARD_TONE_CLASSES = {
+  neutral: "",
+  success: "border-success/20 bg-success/5 dark:bg-success/10",
+  warning:
+    "border-amber-400/50 bg-amber-50/60 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100",
+  error: "border-destructive/30 bg-destructive/5 dark:border-destructive/20 dark:bg-destructive/10",
+  info: "border-sky-500/30 bg-sky-500/5 dark:border-sky-500/20 dark:bg-sky-500/10",
+  purple: "border-violet-500/30 bg-violet-500/5 dark:border-violet-500/20 dark:bg-violet-500/10",
+} as const satisfies Record<SemanticTone, string>;
+
+export const SEMANTIC_TEXT_CLASSES = {
+  neutral: "text-muted-foreground",
+  success: "text-success",
+  warning: "text-amber-600 dark:text-amber-400",
+  error: "text-destructive",
+  info: "text-sky-600 dark:text-sky-400",
+  purple: "text-violet-600 dark:text-violet-400",
+} as const satisfies Record<SemanticTone, string>;
+
+export const SEMANTIC_ICON_SURFACE_CLASSES = {
+  neutral: "bg-muted text-muted-foreground",
+  success: "bg-success/15 text-success",
+  warning: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  error: "bg-destructive/15 text-destructive",
+  info: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+  purple: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
+} as const satisfies Record<SemanticTone, string>;
+
+export const SEMANTIC_BADGE_CLASSES = {
+  neutral: "border-transparent bg-secondary text-secondary-foreground",
+  success: "border-transparent bg-success/10 text-success",
+  warning: "border-transparent bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400",
+  error: "border-transparent bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400",
+  info: "border-transparent bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-400",
+  purple: "border-transparent bg-violet-100 text-violet-700 dark:bg-violet-500/20 dark:text-violet-400",
+} as const satisfies Record<SemanticTone, string>;
+
+export const SEMANTIC_BADGE_VARIANTS = {
+  neutral: "secondary",
+  success: "success",
+  warning: "warning",
+  error: "error",
+  info: "info",
+  purple: "purple",
+} as const satisfies Record<SemanticTone, "secondary" | "success" | "warning" | "error" | "info" | "purple">;
+
+const ACTIVITY_ACTION_TONES = {
+  cancelled: "error",
+  completed: "success",
+  created: "success",
+  deleted: "error",
+  failed: "error",
+  granted: "purple",
+  invited: "info",
+  joined: "info",
+  removed: "error",
+  restored: "success",
+  revoked: "warning",
+  shared: "info",
+  started: "info",
+  trashed: "error",
+  updated: "info",
+  uploaded: "success",
+} as const satisfies Record<string, SemanticTone>;
+
+export function getActivityActionTone(action: string): SemanticTone {
+  return ACTIVITY_ACTION_TONES[action as keyof typeof ACTIVITY_ACTION_TONES] ?? "neutral";
+}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -195,7 +195,7 @@ export function NewSessionDialog({
         <div className="flex gap-2">
           <Input
             value={path}
-            className="min-w-0 flex-1 font-mono text-xs"
+            className="min-w-0 flex-1 font-mono"
             placeholder="Type or choose a project folder"
             aria-label="Project folder"
             onChange={(event) => setPath(event.target.value)}

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -166,7 +166,7 @@ export function SettingsDialog({
                         autoFocus={editing.has(option.id)}
                         type={revealed.has(option.id) ? "text" : "password"}
                         value={draft}
-                        className="min-w-0 flex-1 pr-8 font-mono text-xs"
+                        className="min-w-0 flex-1 pr-8 font-mono"
                         placeholder="Paste a key"
                         aria-label={`${option.label} API key`}
                         onChange={(event) => setDrafts((current) => ({ ...current, [option.id]: event.target.value }))}


### PR DESCRIPTION
A local build carries the same name, version, icon, and data folder as an installed copy, so nothing in the window tells them apart — and the two share `~/Library/Application Support/com.ultralytics.lite`, so sessions and keys show up in both.

The title bar now names the build, and clicking it asks the right question for that kind of build.

| build | badge | clicking it |
|:--|:--|:--|
| local | `eebb68f` | compares against the tree it was built from |
| release | `0.0.4` | checks GitHub for a newer release |

A release cannot update a local build: the updater would install over it and replace the very build being tried out, and both report the same version anyway. So a local build asks its own working tree whether that tree has moved on, and says which commit to rebuild from. `build.rs` stamps the commit and the repository path, and only when the publish workflow is not the one building, so a release carries neither and falls back to the version it is — worth surfacing early on, because the version is what tells someone they are behind.

Showing the version is also the reason the badge is a button: the question being asked of a version in a window is usually whether there is a newer one.

Behaviour verified against the four states:

```
build matches tree        -> "This build matches the tree it was built from."
build behind tree         -> "This build is eebb68f and the tree is now ac71546."
tree deleted or moved     -> "Could not read <path>"
release build             -> never reaches the local path
```

`bun run local` builds a double-clickable bundle. It skips the updater artifact, which otherwise fails the whole command with `TAURI_SIGNING_PRIVATE_KEY`, and skips the dmg. About 35 seconds warm on an M-series Mac; `bun run tauri dev` remains the fast loop for iterating.

- uses the generated `Badge` and the existing `checkForUpdates`, with no styling overrides

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Adds local-build awareness, improved update handling, and a broader UI design-system refresh for Ultralytics Lite.

### 📊 Key Changes

- 🛠️ Added `bun run local` to create a directly launchable local app bundle without updater artifacts.
- 🔖 Bumped the Lite application version from `0.0.4` to `0.0.5`.
- 🔄 Added local-build metadata, including build date, source commit, and repository path.
- ✅ Improved update checks:
  - Release builds check GitHub for new versions.
  - Local builds compare themselves with the source repository and recommend rebuilding when changes are detected.
  - The application header now displays version or commit information with update status badges.
- 🎨 Expanded the UI component system with:
  - Semantic badge and button variants.
  - Reusable action-icon buttons, visibility badges, spinners, dialogs, and page overlays.
  - Centralized design tokens for colors, overlays, chart palettes, and z-index layers.
  - New color conversion and accessibility utilities.
- 🧭 Refined dialog, dropdown, tooltip, tabs, scroll-area, and overlay behavior for improved layering, responsiveness, and consistency.
- 📂 Simplified the Inspector interface with icon-based tabs and one shared refresh control for Files, Git, and Usage panels.
- 📚 Updated English and Chinese README files with the new local-build command.

### 🎯 Purpose & Impact

- 🧪 Makes it easier for developers to build and test Lite locally without confusing local builds with installed releases.
- 🔍 Helps users quickly identify the running build and determine whether a local rebuild or official update is available.
- ✨ Improves visual consistency, accessibility, and maintainability across the application through reusable UI patterns and centralized styling.
- 🖥️ Provides cleaner dialogs and overlays that better respect the app header and sidebar while improving scrolling and stacking behavior.
- ⚡ Simplifies Inspector workflows by consolidating refresh actions and reducing redundant panel controls.
- ⚠️ Local update detection depends on Git being available and the original source repository remaining accessible on the machine.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
