### PR TITLE
Give Codex requests a read timeout on Windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -673,29 +673,38 @@ fn codex_requests_once(
     endpoint: &str,
     requests: &[(u64, &str, serde_json::Value)],
 ) -> Result<HashMap<u64, serde_json::Value>, String> {
+    // Each platform opens the stream itself so there is something for the read timeouts to apply to.
+    // Handing the address straight to the websocket leaves the stream out of reach, and a server that
+    // stops answering then holds the session tab open with nothing left to time it out.
     #[cfg(unix)]
-    {
-        let path = endpoint
-            .strip_prefix("unix://")
-            .ok_or("Invalid Codex endpoint")?;
-        let stream =
-            std::os::unix::net::UnixStream::connect(path).map_err(|error| error.to_string())?;
-        stream
-            .set_read_timeout(Some(CODEX_CONNECT_TIMEOUT))
-            .map_err(|error| error.to_string())?;
-        let (socket, _) =
-            tungstenite::client("ws://localhost/", stream).map_err(|error| error.to_string())?;
-        codex_exchange(socket, requests, |stream| {
-            stream
-                .set_read_timeout(Some(CODEX_REQUEST_TIMEOUT))
-                .map_err(|error| error.to_string())
-        })
-    }
+    let (address, stream) = (
+        "ws://localhost/",
+        std::os::unix::net::UnixStream::connect(
+            endpoint
+                .strip_prefix("unix://")
+                .ok_or("Invalid Codex endpoint")?,
+        )
+        .map_err(|error| error.to_string())?,
+    );
     #[cfg(windows)]
-    {
-        let (socket, _) = tungstenite::connect(endpoint).map_err(|error| error.to_string())?;
-        codex_exchange(socket, requests, |_| Ok(()))
-    }
+    let (address, stream) = (
+        endpoint,
+        std::net::TcpStream::connect(
+            endpoint
+                .strip_prefix("ws://")
+                .ok_or("Invalid Codex endpoint")?,
+        )
+        .map_err(|error| error.to_string())?,
+    );
+    stream
+        .set_read_timeout(Some(CODEX_CONNECT_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    let (socket, _) = tungstenite::client(address, stream).map_err(|error| error.to_string())?;
+    codex_exchange(socket, requests, |stream| {
+        stream
+            .set_read_timeout(Some(CODEX_REQUEST_TIMEOUT))
+            .map_err(|error| error.to_string())
+    })
 }
 
 fn codex_executable() -> Result<PathBuf, String> {


### PR DESCRIPTION
A Codex app server that stops answering holds a session tab open forever on Windows. Unix sets a read timeout on the stream before the handshake and extends it for each request; Windows handed the address straight to the websocket, which keeps the stream to itself, so there was nothing to set a timeout on and the exchange passed a closure that did nothing:

```rust
codex_exchange(socket, requests, |_| Ok(()))
```

Windows now opens the stream itself, the way Unix already did, so `CODEX_CONNECT_TIMEOUT` and `CODEX_REQUEST_TIMEOUT` apply on both. The handshake is still given the same endpoint string as before, so nothing about the connection changes beyond who opens it.

That leaves the two platforms differing only in how the stream is opened, so the timeout, the handshake, and the exchange are shared rather than written twice — the duplicate closure and the second `codex_exchange` call are gone.

Verified `cargo check` and `cargo fmt --check` on macOS with no warnings. The Windows branch is the one that changed and this machine has no Windows target available, so CI is what verifies it; I have not merged on the assumption that it compiles.

- fixes #25

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improved Codex WebSocket connections in Ultralytics Lite by explicitly opening platform-specific streams so request timeouts are reliably enforced. ⏱️

### 📊 Key Changes
- Opens Unix socket connections directly from `unix://` endpoints.
- Opens TCP connections on Windows from `ws://` endpoints.
- Applies connection and request read timeouts to both platforms.
- Passes the already-open stream to Tungstenite instead of letting it create the connection internally.

### 🎯 Purpose & Impact
- Prevents session tabs from hanging indefinitely when the Codex server stops responding. 🛡️
- Provides more consistent timeout behavior across Unix and Windows.
- Improves application responsiveness and makes stalled Codex requests fail more reliably. 🚀