### PR TITLE
Reuse the top bar version badge in the update dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,6 +406,23 @@ function App() {
       .catch(() => setCommit(""));
   }, []);
 
+  // One owner for the release question, so the startup check and a manual one cannot contradict each
+  // other: the ask that started last is the only one still allowed to answer, and a slow startup reply
+  // can no longer land on top of a fresh manual result.
+  const releaseAsk = useRef(0);
+  const askRelease = useCallback(async () => {
+    const ask = ++releaseAsk.current;
+    setRelease("checking");
+    try {
+      const next = await invoke<string | null>("check_update");
+      if (ask === releaseAsk.current) setRelease(next ? "behind" : "current");
+      return next;
+    } catch (reason) {
+      if (ask === releaseAsk.current) setRelease("unknown");
+      throw reason;
+    }
+  }, []);
+
   // Only a release can be behind a release. Asking costs a network round trip that is never worth
   // delaying a paint or a restored session for, so it waits for the window to go idle and is dropped
   // if the window goes away first.
@@ -413,14 +430,7 @@ function App() {
     if (commit !== "") return;
     let cancelled = false;
     const check = () => {
-      if (cancelled) return;
-      void invoke<string | null>("check_update")
-        .then((next) => {
-          if (!cancelled) setRelease(next ? "behind" : "current");
-        })
-        .catch(() => {
-          if (!cancelled) setRelease("unknown");
-        });
+      if (!cancelled) void askRelease().catch(() => {});
     };
     const idle = typeof window.requestIdleCallback === "function";
     const handle = idle ? window.requestIdleCallback(check, { timeout: 10000 }) : window.setTimeout(check, 3000);
@@ -429,7 +439,7 @@ function App() {
       if (idle) window.cancelIdleCallback(handle);
       else window.clearTimeout(handle);
     };
-  }, [commit]);
+  }, [commit, askRelease]);
 
   useEffect(() => {
     let disposed = false;
@@ -585,21 +595,20 @@ function App() {
   }
 
   async function checkForUpdates() {
+    // The dialog owns an install once it has started one. Re-entering here would reset it out of
+    // sight and offer a second install while the first is still running.
+    if (updateOpen && (updateStatus === "checking" || updateStatus === "installing")) return;
     setUpdateOpen(true);
     setUpdateStatus("checking");
     setUpdateError("");
-    if (!commit) setRelease("checking");
     try {
       // A release would replace this build rather than update it, so a local build asks its own tree.
-      const next = await invoke<string | null>(commit ? "local_update" : "check_update");
+      const next = commit ? await invoke<string | null>("local_update") : await askRelease();
       setAvailableVersion(next ?? "");
       setUpdateStatus(next ? (commit ? "rebuild" : "available") : "current");
-      // The badge asked the same question on startup, so a manual check answers it again for both.
-      if (!commit) setRelease(next ? "behind" : "current");
     } catch (reason) {
       setUpdateError(String(reason));
       setUpdateStatus("error");
-      if (!commit) setRelease("unknown");
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,63 @@ const RELEASE_NOTE = {
 
 type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installing" | "error";
 
+// A local build names its commit and is red, so it is never mistaken for the installed copy.
+// A release names its version and says at a glance whether it is the current one. The top bar and the
+// update dialog render this one badge, so the version, the release date and the link to it are stated
+// in exactly one place and cannot drift apart.
+function VersionBadge({
+  version,
+  commit,
+  built,
+  release,
+  onCheck,
+}: {
+  version: string;
+  commit: string | undefined;
+  built: string;
+  release: keyof typeof BADGE_VARIANT;
+  onCheck: () => void;
+}) {
+  if (!commit && !version) return null;
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Badge
+            variant={commit ? "error" : BADGE_VARIANT[release]}
+            render={<button type="button" onClick={onCheck} />}
+          >
+            {commit || version}
+          </Badge>
+        }
+      />
+      <TooltipContent>
+        {commit ? (
+          `Local build${built ? ` from ${built}` : ""} · click to compare with your working tree`
+        ) : (
+          <span className="flex flex-col gap-0.5">
+            <span>
+              {`Lite ${version}${RELEASE_NOTE[release]}`}
+              {built ? ` · released ${built}` : ""}
+            </span>
+            <button
+              type="button"
+              className="underline underline-offset-2"
+              onClick={() =>
+                void invoke("open_url", {
+                  url: `https://github.com/ultralytics/lite/releases/tag/v${version}`,
+                })
+              }
+            >
+              View this release on GitHub
+            </button>
+          </span>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function loadSessions(): Session[] {
   try {
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]") as Session[];
@@ -531,14 +588,18 @@ function App() {
     setUpdateOpen(true);
     setUpdateStatus("checking");
     setUpdateError("");
+    if (!commit) setRelease("checking");
     try {
       // A release would replace this build rather than update it, so a local build asks its own tree.
       const next = await invoke<string | null>(commit ? "local_update" : "check_update");
       setAvailableVersion(next ?? "");
       setUpdateStatus(next ? (commit ? "rebuild" : "available") : "current");
+      // The badge asked the same question on startup, so a manual check answers it again for both.
+      if (!commit) setRelease(next ? "behind" : "current");
     } catch (reason) {
       setUpdateError(String(reason));
       setUpdateStatus("error");
+      if (!commit) setRelease("unknown");
     }
   }
 
@@ -566,46 +627,28 @@ function App() {
           data-tauri-drag-region
           className="flex h-9 shrink-0 items-center gap-2 border-b bg-sidebar px-3 text-sidebar-foreground in-data-[titlebar=overlay]:pl-[86px]"
         >
-          <LiteLogomark className="size-5" />
-          {/* A local build names its commit and is red, so it is never mistaken for the installed copy.
-              A release names its version and says at a glance whether it is the current one. */}
-          {commit || version ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Badge
-                    variant={commit ? "error" : BADGE_VARIANT[release]}
-                    render={<button type="button" onClick={() => void checkForUpdates()} />}
-                  >
-                    {commit || version}
-                  </Badge>
-                }
-              />
-              <TooltipContent>
-                {commit ? (
-                  `Local build${built ? ` from ${built}` : ""} · click to compare with your working tree`
-                ) : (
-                  <span className="flex flex-col gap-0.5">
-                    <span>
-                      {`Lite ${version}${RELEASE_NOTE[release]}`}
-                      {built ? ` · released ${built}` : ""}
-                    </span>
-                    <button
-                      type="button"
-                      className="underline underline-offset-2"
-                      onClick={() =>
-                        void invoke("open_url", {
-                          url: `https://github.com/ultralytics/lite/releases/tag/v${version}`,
-                        })
-                      }
-                    >
-                      View this release on GitHub
-                    </button>
-                  </span>
-                )}
-              </TooltipContent>
-            </Tooltip>
-          ) : null}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  className="shrink-0"
+                  aria-label="Lite on GitHub"
+                  onClick={() => void invoke("open_url", { url: "https://github.com/ultralytics/lite" })}
+                />
+              }
+            >
+              <LiteLogomark className="size-5" />
+            </TooltipTrigger>
+            <TooltipContent>View Lite on GitHub</TooltipContent>
+          </Tooltip>
+          <VersionBadge
+            version={version}
+            commit={commit}
+            built={built}
+            release={release}
+            onCheck={() => void checkForUpdates()}
+          />
           {selected ? (
             <>
               <Separator orientation="vertical" className="mx-1 h-4" />
@@ -787,7 +830,16 @@ function App() {
         <Dialog open={updateOpen} onOpenChange={changeUpdateOpen}>
           <DialogContent showCloseButton={updateStatus !== "checking" && updateStatus !== "installing"}>
             <DialogHeader>
-              <DialogTitle>Lite updates</DialogTitle>
+              <div className="flex items-center gap-2">
+                <DialogTitle>Lite updates</DialogTitle>
+                <VersionBadge
+                  version={version}
+                  commit={commit}
+                  built={built}
+                  release={release}
+                  onCheck={() => void checkForUpdates()}
+                />
+              </div>
               <DialogDescription aria-live="polite">
                 {updateStatus === "checking"
                   ? commit


### PR DESCRIPTION
## Why

The top bar badge tooltip already carried the whole story — `Lite 0.0.5 · up to date · released 2026-08-07` plus **View this release on GitHub**. The "Check for updates" dialog that the same badge opens repeated none of it, showing only *"You have the latest version of Lite."*

## What

- `VersionBadge` is extracted from the top bar and rendered in **both** the top bar and the update dialog header — the same component, not a copy, so the version, release date, and release link are stated in exactly one place.
- `checkForUpdates()` now writes its answer back to the badge state. Previously a check started from the ⋯ menu updated the dialog but left the badge showing whatever the startup check had found, so the two could disagree.
- Clicking the Ultralytics logomark opens `ultralytics/lite` on GitHub.

## Validation

`bun run check` (Biome + tsgo) and `bun run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

✨ Improves Lite’s version and update experience with a reusable version badge, safer update checks, and clearer GitHub access.

### 📊 Key Changes

- Extracted version and build information into a reusable `VersionBadge` component shown in both the top bar and update dialog.
- Added release details, release dates, and a direct link to the matching GitHub release.
- Made the Lite logo link directly to the project’s GitHub repository.
- Centralized release checks to prevent outdated asynchronous responses from overwriting newer results.
- Prevented users from starting a second update or rebuild while an existing check or installation is in progress.
- Preserved distinct handling for released versions and local development builds.

### 🎯 Purpose & Impact

- 🧭 Gives users a clearer, consistent view of the installed version, release status, and build source.
- 🔗 Makes it easier to inspect the current release or visit the Lite repository.
- 🛡️ Reduces confusing update states caused by overlapping or slow network requests.
- ⚙️ Prevents accidental duplicate installations and improves update-dialog reliability.
- 👩‍💻 Makes version and update UI behavior easier to maintain by sharing one component across the application.