### PR TITLE
Bring the window forward on launch and populate the standard app metadata

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,10 @@ version = "0.0.5"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"
+license = "AGPL-3.0"
+homepage = "https://www.ultralytics.com"
+repository = "https://github.com/ultralytics/lite"
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2160,6 +2160,50 @@ async fn install_update(app: AppHandle) -> Result<(), String> {
     app.restart()
 }
 
+// Tauri builds the About panel from the bundle config, which carries only the name, version,
+// copyright and publisher, so the panel read as bare. Everything else it can show has to be handed
+// over here. macOS only: it is the one platform with an application menu, and the installers carry
+// the same details from tauri.conf.json on Windows and Linux, where adding a menu would put a native
+// menu bar on a window that draws its own chrome.
+#[cfg(target_os = "macos")]
+fn describe_app(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    use tauri::menu::{AboutMetadata, Menu, MenuItemKind, PredefinedMenuItem};
+
+    // The macOS panel renders credits as plain text, so the links read rather than click.
+    const CREDITS: &str = concat!(
+        "Runs Claude Code, Codex on OpenAI or DeepSeek, Kimi Code, and your shell side by side ",
+        "with your files, Git status, and provider usage.\n\n",
+        "Everything stays on this machine. No repository indexing, no telemetry, no cloud service.\n\n",
+        "Source\tgithub.com/ultralytics/lite\n",
+        "Issues\tgithub.com/ultralytics/lite/issues\n",
+        "Discord\tdiscord.com/invite/ultralytics\n",
+        "Forums\tcommunity.ultralytics.com\n",
+        "Licensing\tultralytics.com/license",
+    );
+
+    let about = AboutMetadata {
+        name: Some("Lite".into()),
+        version: Some(app.package_info().version.to_string()),
+        authors: Some(vec!["Ultralytics".into()]),
+        comments: Some("A fast, local workspace for AI coding agents.".into()),
+        copyright: Some("© 2026 Ultralytics Inc.".into()),
+        license: Some("AGPL-3.0".into()),
+        website: Some("https://www.ultralytics.com".into()),
+        website_label: Some("ultralytics.com".into()),
+        credits: Some(CREDITS.into()),
+        ..Default::default()
+    };
+
+    let menu = Menu::default(app)?;
+    // About is the first item of the application submenu, which is the first submenu on macOS.
+    if let Some(MenuItemKind::Submenu(app_menu)) = menu.items()?.first() {
+        app_menu.remove_at(0)?;
+        app_menu.insert(&PredefinedMenuItem::about(app, None, Some(about))?, 0)?;
+    }
+    app.set_menu(menu)?;
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -2175,6 +2219,8 @@ pub fn run() {
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_focus();
             }
+            #[cfg(target_os = "macos")]
+            describe_app(app.handle())?;
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2170,6 +2170,11 @@ pub fn run() {
             app.manage(load_roots(app.handle()));
             app.manage(load_provider_sessions(app.handle()));
             app.manage(load_codex_server(app.handle())?);
+            // A relaunch inherits no activation from the process it replaces, so the build installed
+            // by an update came back behind every other window with nothing to show it had finished.
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_focus();
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2160,37 +2160,26 @@ async fn install_update(app: AppHandle) -> Result<(), String> {
     app.restart()
 }
 
-// Tauri builds the About panel from the bundle config, which carries only the name, version,
-// copyright and publisher, so the panel read as bare. Everything else it can show has to be handed
-// over here. macOS only: it is the one platform with an application menu, and the installers carry
-// the same details from tauri.conf.json on Windows and Linux, where adding a menu would put a native
-// menu bar on a window that draws its own chrome.
+// Tauri fills the About panel from the bundle config, which reaches it with only a name and version,
+// so the panel read as bare. macOS only: it is the one platform Tauri gives an application menu, and
+// setting one on Windows or Linux would put a native menu bar on a window that draws its own chrome.
+// Those platforms carry the same details in the installer metadata from tauri.conf.json instead.
+//
+// Only the fields NSAboutPanel actually renders are set. It ignores authors, comments, license and
+// website, so setting those here would look thorough and show nothing.
 #[cfg(target_os = "macos")]
 fn describe_app(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     use tauri::menu::{AboutMetadata, Menu, MenuItemKind, PredefinedMenuItem};
 
-    // The macOS panel renders credits as plain text, so the links read rather than click.
-    const CREDITS: &str = concat!(
-        "Runs Claude Code, Codex on OpenAI or DeepSeek, Kimi Code, and your shell side by side ",
-        "with your files, Git status, and provider usage.\n\n",
-        "Everything stays on this machine. No repository indexing, no telemetry, no cloud service.\n\n",
-        "Source\tgithub.com/ultralytics/lite\n",
-        "Issues\tgithub.com/ultralytics/lite/issues\n",
-        "Discord\tdiscord.com/invite/ultralytics\n",
-        "Forums\tcommunity.ultralytics.com\n",
-        "Licensing\tultralytics.com/license",
-    );
-
     let about = AboutMetadata {
         name: Some("Lite".into()),
         version: Some(app.package_info().version.to_string()),
-        authors: Some(vec!["Ultralytics".into()]),
-        comments: Some("A fast, local workspace for AI coding agents.".into()),
         copyright: Some("© 2026 Ultralytics Inc.".into()),
-        license: Some("AGPL-3.0".into()),
-        website: Some("https://www.ultralytics.com".into()),
-        website_label: Some("ultralytics.com".into()),
-        credits: Some(CREDITS.into()),
+        // Credits are a plain NSAttributedString in a short scroll view: no link attributes, so a URL
+        // is dead text, and more than a line or two becomes a wall behind a scrollbar. The panel
+        // already states the name, version and copyright, so this only says what Lite is. The
+        // clickable way to the repository is the logomark in the top bar.
+        credits: Some("A fast, local workspace for AI coding agents.".into()),
         ..Default::default()
     };
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,14 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "publisher": "Ultralytics",
+    "homepage": "https://www.ultralytics.com",
+    "copyright": "© 2026 Ultralytics Inc.",
+    "license": "AGPL-3.0",
+    "licenseFile": "../LICENSE",
+    "category": "DeveloperTool",
+    "shortDescription": "A fast, local workspace for AI coding agents.",
+    "longDescription": "Lite is a fast, local workspace for Claude Code, Codex on OpenAI or DeepSeek, Kimi Code, and your shell. Keep agent sessions, files, and Git context together without repository indexing, telemetry, or a cloud service.",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
     "macOS": {
       "signingIdentity": "-"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,12 +78,12 @@ type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installi
 const QUIET_MS = 1200;
 
 // Three states the sidebar dot tells apart: the terminal is gone, it is up and quiet, or it is up and
-// producing output. Working keeps the same color as idle and adds motion, so connectedness reads off
-// the color alone and is not lost on a display where the pulse is suppressed.
+// producing output. Each gets its own color, so the state survives a display where the pulse is
+// suppressed and the motion only reinforces what green already says.
 const SESSION_STATUS = {
   disconnected: { dot: "bg-muted-foreground/40", label: "Disconnected" },
-  idle: { dot: "bg-emerald-500/60", label: "Connected, idle" },
-  working: { dot: "bg-emerald-500 animate-pulse motion-reduce:animate-none", label: "Connected, working" },
+  idle: { dot: "bg-emerald-500", label: "Connected, idle" },
+  working: { dot: "bg-blue-500 animate-pulse motion-reduce:animate-none", label: "Connected, working" },
 } as const;
 
 function loadSessions(): Session[] {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,8 +78,8 @@ type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installi
 const QUIET_MS = 1200;
 
 // Three states the sidebar dot tells apart: the terminal is gone, it is up and quiet, or it is up and
-// producing output. Working keeps the same colour as idle and adds motion, so connectedness reads off
-// the colour alone and is not lost on a display where the pulse is suppressed.
+// producing output. Working keeps the same color as idle and adds motion, so connectedness reads off
+// the color alone and is not lost on a display where the pulse is suppressed.
 const SESSION_STATUS = {
   disconnected: { dot: "bg-muted-foreground/40", label: "Disconnected" },
   idle: { dot: "bg-emerald-500/60", label: "Connected, idle" },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,19 @@ const RELEASE_NOTE = {
 
 type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installing" | "error";
 
+// How long a session has to stay quiet before it counts as connected but idle rather than working.
+// Long enough that the gaps between an agent's own writes do not flicker the dot.
+const QUIET_MS = 1200;
+
+// Three states the sidebar dot tells apart: the terminal is gone, it is up and quiet, or it is up and
+// producing output. Working keeps the same colour as idle and adds motion, so connectedness reads off
+// the colour alone and is not lost on a display where the pulse is suppressed.
+const SESSION_STATUS = {
+  disconnected: { dot: "bg-muted-foreground/40", label: "Disconnected" },
+  idle: { dot: "bg-emerald-500/60", label: "Connected, idle" },
+  working: { dot: "bg-emerald-500 animate-pulse motion-reduce:animate-none", label: "Connected, working" },
+} as const;
+
 function loadSessions(): Session[] {
   try {
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]") as Session[];
@@ -105,6 +118,7 @@ function SessionRow({
   session,
   active,
   starting,
+  working,
   onSelect,
   onRename,
   onRestart,
@@ -113,11 +127,13 @@ function SessionRow({
   session: Session;
   active: boolean;
   starting: boolean;
+  working: boolean;
   onSelect: () => void;
   onRename: (name: string) => void;
   onRestart: () => void;
   onClose: () => void;
 }) {
+  const status = SESSION_STATUS[!session.running ? "disconnected" : working ? "working" : "idle"];
   const [renaming, setRenaming] = useState(false);
   const [name, setName] = useState(session.name);
 
@@ -142,8 +158,8 @@ function SessionRow({
           ) : (
             <span
               role="img"
-              className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${active ? "ring-sidebar-accent" : "ring-sidebar"} ${session.running ? "bg-emerald-500" : "bg-muted-foreground/40"}`}
-              aria-label={session.running ? "Running" : "Not running"}
+              className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${active ? "ring-sidebar-accent" : "ring-sidebar"} ${status.dot}`}
+              aria-label={status.label}
             />
           )}
         </span>
@@ -268,6 +284,9 @@ function App() {
   const [closing, setClosing] = useState<Session>();
   const [error, setError] = useState("");
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
+  // Sessions whose terminal has written something recently, which is what separates a connected
+  // session that is working from one that is merely connected.
+  const [working, setWorking] = useState<Set<string>>(new Set());
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
   // Undefined until asked: an empty string is a release, anything else is the commit it was built from.
@@ -279,6 +298,7 @@ function App() {
   const [availableVersion, setAvailableVersion] = useState("");
   const [updateError, setUpdateError] = useState("");
   const runs = useRef(new Map<string, string>());
+  const workTimers = useRef(new Map<string, number>());
   const resumed = useRef("");
   const themeRef = useRef<Theme>("dark");
   const sessionsRef = useRef<Session[]>([]);
@@ -374,13 +394,36 @@ function App() {
     };
   }, [commit]);
 
+  // Output arrives as a stream of chunks, so this touches React state only on the two edges of a
+  // burst: the first chunk marks the session working, and a quiet spell marks it idle again. Between
+  // those the timer is just reset, which keeps a busy session from re-rendering the sidebar per chunk.
+  const markWorking = useCallback((sessionId: string) => {
+    const timers = workTimers.current;
+    const pending = timers.get(sessionId);
+    if (pending) window.clearTimeout(pending);
+    else setWorking((current) => new Set(current).add(sessionId));
+    timers.set(
+      sessionId,
+      window.setTimeout(() => {
+        timers.delete(sessionId);
+        setWorking((current) => {
+          const next = new Set(current);
+          next.delete(sessionId);
+          return next;
+        });
+      }, QUIET_MS),
+    );
+  }, []);
+
   useEffect(() => {
     let disposed = false;
     let unlistenOutput: (() => void) | undefined;
     let unlistenExit: (() => void) | undefined;
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
-        if (runs.current.get(payload.sessionId) === payload.runId) appendOutput(payload.sessionId, payload.data);
+        if (runs.current.get(payload.sessionId) !== payload.runId) return;
+        appendOutput(payload.sessionId, payload.data);
+        markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
@@ -398,12 +441,15 @@ function App() {
       unlistenOutput = output;
       unlistenExit = exit;
     });
+    const timers = workTimers.current;
     return () => {
       disposed = true;
       unlistenOutput?.();
       unlistenExit?.();
+      for (const timer of timers.values()) window.clearTimeout(timer);
+      timers.clear();
     };
-  }, []);
+  }, [markWorking]);
 
   const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return;
@@ -688,6 +734,7 @@ function App() {
                       session={session}
                       active={session.id === selectedId}
                       starting={startingIds.has(session.id)}
+                      working={working.has(session.id)}
                       onSelect={() => openRef.current(session)}
                       onRename={(name) =>
                         setSessions((current) =>


### PR DESCRIPTION
## 1. The updated build came back hidden

Clicking **Install and restart** appeared to do nothing: the window vanished and the updated build reopened *behind* every other window.

`install_update` ends in `app.restart()`, which launches the replacement from a process that is already exiting, so macOS gives the new instance no activation.

Fixed by focusing the main window from `setup()` — the owner of every launch, so it covers the post-update relaunch and an ordinary launch alike rather than special-casing the updater. `set_focus()` stays platform-neutral: `activateIgnoringOtherApps:` on macOS, `SetForegroundWindow` on Windows, `gtk_window_present` on Linux.

## 2. "About Lite" was bare

It showed the name and version and nothing else, because Tauri builds the About item from bundle config that carried neither a publisher nor a copyright.

- **`tauri.conf.json`** gains `publisher`, `homepage`, `copyright`, `license`, `licenseFile`, `category`, `shortDescription`, `longDescription` — these reach the macOS `Info.plist`, the Windows installer's Manufacturer, and the deb/rpm control metadata.
- **`Cargo.toml`** gains `license`, `homepage`, `repository`, `readme`.
- **The macOS About panel** gains `authors`, `comments`, `license`, `website`, and a `credits` block naming the harnesses, the local-only promise, and where to find source, issues, Discord, forums, and licensing.

### Why the panel is macOS-only

macOS is the only one of the three with an application menu — Tauri applies its default menu under `#[cfg(target_os = "macos")]`. Calling `set_menu` on Windows or Linux would attach a native menu bar to a window that draws its own chrome. Those platforms carry the same details in their installer metadata instead, which is where that information is conventionally read.

The field split is forced by the platforms: macOS's `NSAboutPanel` renders `copyright`, `credits`, `name`, `version` and ignores `authors`/`comments`/`license`/`website`; muda's Windows/Linux dialog does the reverse and ignores `credits`. Both halves are filled so each platform has content.

## Validation

`cargo check` and `cargo fmt --check` pass; `tauri-build` re-validated `tauri.conf.json` against the v2 schema. Every bundle key was taken from `BundleConfig` in `tauri-utils 2.9.3` rather than guessed, and `DeveloperTool` is a documented `category` value.

I did not run the built app: the installed Lite was running a live session and a dev instance shares the same `com.ultralytics.lite` app data directory. The macOS focus behavior is read off tao 0.35.3 (`Window::set_focus` → `makeKeyAndOrderFront` + `activateIgnoringOtherApps: YES`). **Worth confirming the About panel and the foreground relaunch on the next real update.**

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ Improves Lite’s release metadata, macOS About panel, post-update focus behavior, and session activity indicators.

### 📊 Key Changes
- 📦 Added AGPL-3.0 licensing, repository, homepage, publisher, category, and installer descriptions to Cargo and Tauri configuration.
- 🍎 Added a macOS-specific About panel showing Lite’s name, version, copyright, and description.
- 🎯 Automatically focuses the main window when the application starts or relaunches after an update.
- 🔵 Enhanced session indicators with three states: disconnected, connected and idle, or connected and working.
- ⏱️ Detects recent terminal output and keeps the “working” state active until the session has been quiet for 1.2 seconds.
- 🧹 Improved event filtering and timer cleanup to avoid stale session updates and unnecessary sidebar re-renders.

### 🎯 Purpose & Impact
- ✅ Gives installers, package managers, and users clearer ownership, licensing, and application information.
- 🖥️ Provides a more complete native About experience on macOS without adding unwanted native menus on other platforms.
- 🚀 Makes completed updates more visible by bringing the relaunched Lite window into focus.
- 👀 Helps users quickly understand whether an agent session is offline, waiting, or actively producing output.
- ⚡ Reduces UI flicker and rendering overhead during high-volume terminal output.