### PR TITLE
Keep the terminal inside its own box

### DIFF
--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -183,5 +183,15 @@ export function TerminalView({
     if (terminalRef.current) terminalRef.current.options.theme = themes[theme];
   }, [theme]);
 
-  return <div ref={containerRef} className="h-full w-full bg-background p-3" />;
+  // The padding belongs on the wrapper, never on the element the terminal is opened in. The fit addon
+  // sizes the terminal from getComputedStyle(parent).height, which WebKit reports as the border box,
+  // and it only subtracts padding declared on the terminal's own element. Padding here would be
+  // counted as usable space, so the terminal laid out a row and three columns more than fit and hung
+  // them past the edge, which also left the last row below the viewport where the scrollbar could
+  // neither show nor reach it.
+  return (
+    <div className="h-full w-full bg-background p-3">
+      <div ref={containerRef} className="h-full w-full" />
+    </div>
+  );
 }


### PR DESCRIPTION
## The bugs

Two reports, one cause:

1. The Claude Code CLI's input box sat flush on the bottom edge of the window — and only that CLI.
2. The scrollbar disappeared or failed to reflect the real position.

## The cause

`@xterm/addon-fit` sizes the terminal like this:

```js
r = getComputedStyle(this._terminal.element.parentElement)
i = parseInt(r.getPropertyValue("height"))          // the parent — WebKit reports the BORDER box
s = getComputedStyle(this._terminal.element)        // the .xterm element
n = i - (paddingTop(s) + paddingBottom(s))          // only .xterm's own padding is subtracted
rows = Math.max(1, Math.floor(n / cell.height))
```

The terminal was opened directly into the element carrying `p-3`, so that padding was measured as usable space and never subtracted.

**Measured in the running app**, with a debug overlay reading the live DOM:

| | before | after |
|---|---|---|
| container height | 764 (740 content + 24 padding) | **740** |
| screen height | 756 | **735** |
| gap below screen | **−4.0px** — overflowing | **+5.0px** |
| rows × cols | 36 × 79 | **35 × 76** |

36 rows × 21px = 756px in a 740px viewport. The bottom row hung 16px past the viewport, which is exactly why a CLI that anchors its input box to the last row looked like it was touching the window edge, while CLIs that leave the last row blank did not.

That same overflow explains the scrollbar: the row below the viewport was not counted in `scrollHeight`, so the bar under-reported the buffer and could never scroll to the true end.

## The fix

Move the padding to a wrapper so the element the terminal is opened in has none of its own. The addon then measures the real 740px and lays out 35 rows and 76 columns, and the screen ends *inside* its box.

Padding on `.xterm` was tried first and rejected: `.xterm-viewport` is absolutely positioned with a `#000` background, so it fills the padding box and paints a black band.

## Validation

`bun run check` and `bun run build` pass. The before and after figures above were both read out of the running app.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Fixes terminal sizing by moving padding to a wrapper, preventing content from overflowing in WebKit browsers. 🖥️

### 📊 Key Changes

- Added a padded outer wrapper around the terminal container.
- Removed padding from the element used to initialize the terminal.
- Ensured the terminal fit addon calculates available height and width correctly.
- Prevented extra terminal rows and columns from extending beyond the viewport.

### 🎯 Purpose & Impact

- 🐛 Resolves terminal layout and scrolling issues in WebKit-based browsers.
- 📐 Keeps terminal content within its visible container.
- ✅ Ensures the final row remains accessible without being hidden below the viewport.
- 🌐 Improves cross-browser consistency without changing terminal functionality.