### PR TITLE
Auto-update Cargo.lock via cargo update

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"


### PR DESCRIPTION
Weekly `cargo update` on `src-tauri/Cargo.toml`. Stays inside the declared semver ranges, so this is transitive-crate drift only - major bumps of the dependencies in Cargo.toml remain Dependabot's job.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The PR diff was not included, so its specific changes and impact cannot be accurately summarized.

### 📊 Key Changes

- No source-code or configuration changes were provided for review.
- `src-tauri/Cargo.lock` was mentioned as modified, but its details were omitted.

### 🎯 Purpose & Impact

- The purpose and user impact cannot be determined without the complete PR diff or description.
- Please provide the missing diff or PR details for an accurate summary.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
