### PR TITLE
Search sessions, collapse both sides to rails, and rework the dialogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,9 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
 
+      # CI answers whether the app compiles and links, which installers it can be packed into is
+      # publish.yml's question. Packing them here cost more than everything else combined: on Linux
+      # one run spent 9 seconds compiling and 9 minutes 17 bundling, most of it rpm compressing an
+      # unoptimised binary carrying its debug info.
       - name: Build app
-        run: bun run tauri build --debug --config '{"bundle":{"createUpdaterArtifacts":false}}'
+        run: bun run tauri build --debug --no-bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 src-tauri/target/
 src-tauri/gen/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../lite/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../lite/node_modules

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.5"
+version = "0.0.6"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2058,18 +2058,19 @@ fn browse_url(remote: &str) -> Option<String> {
         let (host, repository) = rest.split_once(':')?;
         return Some(format!("https://{host}/{repository}"));
     }
-    if let Some(rest) = remote.strip_prefix("ssh://") {
-        let (authority, repository) = rest.split_once('/')?;
-        let host = authority
-            .rsplit_once('@')
-            .map_or(authority, |(_, host)| host);
-        // A port here is the port sshd answers on, which reaches nothing a browser can read.
-        if host.contains(':') {
-            return None;
-        }
-        return Some(format!("https://{host}/{repository}"));
+    let ssh = remote.strip_prefix("ssh://");
+    let rest = ssh.or_else(|| remote.strip_prefix("https://"))?;
+    let (authority, repository) = rest.split_once('/')?;
+    // Whatever the clone was made with — a token, an account name — is Git's business and has none in a
+    // link, still less in a browser's address bar and history. An ssh port reaches nothing a browser
+    // can read, where an https one is the site itself.
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if ssh.is_some() && host.contains(':') {
+        return None;
     }
-    remote.starts_with("https://").then(|| remote.to_owned())
+    Some(format!("https://{host}/{repository}"))
 }
 
 // The repository a folder was cloned from, asked for on its own: naming it costs one git call, where

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -965,9 +965,16 @@ fn shell_path(shell: &str) -> Option<String> {
 
 // An account shell that does not speak this command leaves nothing usable, so the search falls back to
 // the POSIX shell rather than losing every provider CLI.
+// Asking costs a login shell, and the answer holds for as long as Lite is open, so it is asked once
+// and every command Lite resolves afterwards is free.
 #[cfg(unix)]
 fn user_path() -> Option<String> {
-    shell_path(&CommandBuilder::new_default_prog().get_shell()).or_else(|| shell_path("/bin/sh"))
+    static PATH: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    PATH.get_or_init(|| {
+        shell_path(&CommandBuilder::new_default_prog().get_shell())
+            .or_else(|| shell_path("/bin/sh"))
+    })
+    .clone()
 }
 
 #[cfg(windows)]
@@ -2054,8 +2061,12 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
 fn browse_url(remote: &str) -> Option<String> {
     let remote = remote.trim().trim_end_matches('/');
     let remote = remote.strip_suffix(".git").unwrap_or(remote);
-    if let Some(rest) = remote.strip_prefix("git@") {
-        let (host, repository) = rest.split_once(':')?;
+    // The scp form names a user, and not everyone's is git.
+    if !remote.contains("://") {
+        let (authority, repository) = remote.split_once(':')?;
+        let host = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
         return Some(format!("https://{host}/{repository}"));
     }
     let ssh = remote.strip_prefix("ssh://");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2059,8 +2059,15 @@ fn browse_url(remote: &str) -> Option<String> {
         return Some(format!("https://{host}/{repository}"));
     }
     if let Some(rest) = remote.strip_prefix("ssh://") {
-        let address = rest.split_once('@').map_or(rest, |(_, tail)| tail);
-        return Some(format!("https://{address}"));
+        let (authority, repository) = rest.split_once('/')?;
+        let host = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
+        // A port here is the port sshd answers on, which reaches nothing a browser can read.
+        if host.contains(':') {
+            return None;
+        }
+        return Some(format!("https://{host}/{repository}"));
     }
     remote.starts_with("https://").then(|| remote.to_owned())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2049,6 +2049,35 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
     }))
 }
 
+// A remote is stored the way the repository was cloned, and only its https form opens in a browser.
+// Anything else is left alone rather than guessed at, so a link is offered only when it will work.
+fn browse_url(remote: &str) -> Option<String> {
+    let remote = remote.trim().trim_end_matches('/');
+    let remote = remote.strip_suffix(".git").unwrap_or(remote);
+    if let Some(rest) = remote.strip_prefix("git@") {
+        let (host, repository) = rest.split_once(':')?;
+        return Some(format!("https://{host}/{repository}"));
+    }
+    if let Some(rest) = remote.strip_prefix("ssh://") {
+        let address = rest.split_once('@').map_or(rest, |(_, tail)| tail);
+        return Some(format!("https://{address}"));
+    }
+    remote.starts_with("https://").then(|| remote.to_owned())
+}
+
+// The repository a folder was cloned from, asked for on its own: naming it costs one git call, where
+// the full status reads the whole worktree.
+#[tauri::command]
+async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<String>, String> {
+    let path = root_path(&roots, &root_id)?;
+    let git = resolve_executable("git").unwrap_or_else(|| "git".into());
+    Ok(
+        command_output(&git, &path, &["remote", "get-url", "origin"])
+            .ok()
+            .and_then(|remote| browse_url(&remote)),
+    )
+}
+
 #[tauri::command]
 async fn read_usage(
     app: AppHandle,
@@ -2225,6 +2254,7 @@ pub fn run() {
             list_directory,
             read_text_file,
             git_status,
+            git_remote,
             read_usage,
             agent_availability,
             open_setup_docs,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
+  ChevronRight,
   GitBranch,
   KeyRound,
   Moon,
@@ -73,7 +74,8 @@ const SIDES = {
   inspector: { size: "25%", min: "18%", max: "40%" },
 } as const;
 // Held at the minimum, the handle says that one more nudge collapses the side.
-const ARMED = "active:bg-primary active:[&>div]:h-10 active:[&>div]:bg-primary";
+const ARMED =
+  "data-[separator=active]:bg-primary data-[separator=active]:[&>div]:h-10 data-[separator=active]:[&>div]:bg-primary";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
 // The version is known from the start, so the badge shows it throughout and only its color waits on
 // the answer: grey while asking, which is quieter than a spinner that would resize a chip this small.
@@ -437,16 +439,25 @@ function App() {
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
   const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number; asPercentage: number }) => {
-    setSides((current) => {
-      const next: SideState =
-        size.inPixels <= RAIL + 1
-          ? "shut"
-          : size.asPercentage <= Number.parseFloat(SIDES[side].min) + 0.5
-            ? "floor"
-            : "open";
-      return current[side] === next ? current : { ...current, [side]: next };
-    });
+    const next: SideState =
+      size.inPixels <= RAIL + 1
+        ? "shut"
+        : size.asPercentage <= Number.parseFloat(SIDES[side].min) + 0.5
+          ? "floor"
+          : "open";
+    // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
+    // leaving the rail and the number shortcuts counting two different lists.
+    if (side === "sidebar" && next === "shut") setQuery("");
+    setSides((current) => (current[side] === next ? current : { ...current, [side]: next }));
   }, []);
+
+  // The inspector panel goes away with the last session and comes back at its default width, so what
+  // the sides remember about it is reset with it rather than corrected by the first measurement.
+  const hasSelection = Boolean(selected);
+  useEffect(() => {
+    if (!hasSelection)
+      setSides((current) => (current.inspector === "open" ? current : { ...current, inspector: "open" }));
+  }, [hasSelection]);
 
   useEffect(() => {
     applyTheme(theme);
@@ -890,6 +901,21 @@ function App() {
               {sides.sidebar === "shut" ? (
                 <ScrollArea className="min-h-0 flex-1">
                   <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => sidebarPanel.current?.expand()}
+                            aria-label="Expand sessions"
+                          />
+                        }
+                      >
+                        <ChevronRight />
+                      </TooltipTrigger>
+                      <TooltipContent side="right">Expand sessions</TooltipContent>
+                    </Tooltip>
                     <Tooltip>
                       <TooltipTrigger
                         render={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,16 @@ import "./App.css";
 const STORAGE_KEY = "lite.sessions.v1";
 // The width each side collapses to: one icon button and the room around it.
 const RAIL = 44;
+// What each side is doing. "floor" is the pause the library builds in: a collapsible panel stops at its
+// minimum and stays there until the drag passes half the remaining gap, so without a word from the
+// handle the drag that is about to collapse it looks exactly like one that is doing nothing.
+type SideState = "open" | "floor" | "shut";
+const SIDES = {
+  sidebar: { size: "20%", min: "15%", max: "30%" },
+  inspector: { size: "25%", min: "18%", max: "40%" },
+} as const;
+// Held at the minimum, the handle says that one more nudge collapses the side.
+const ARMED = "active:bg-primary active:[&>div]:h-10 active:[&>div]:bg-primary";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
 // The version is known from the start, so the badge shows it throughout and only its color waits on
 // the answer: grey while asking, which is quieter than a spinner that would resize a chip this small.
@@ -383,7 +393,7 @@ function App() {
   const [query, setQuery] = useState("");
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
-  const [collapsed, setCollapsed] = useState({ sidebar: false, inspector: false });
+  const [sides, setSides] = useState<Record<keyof typeof SIDES, SideState>>({ sidebar: "open", inspector: "open" });
   const sidebarPanel = useRef<PanelImperativeHandle>(null);
   const inspectorPanel = useRef<PanelImperativeHandle>(null);
   // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
@@ -426,10 +436,15 @@ function App() {
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
-  const rail = useCallback((side: "sidebar" | "inspector", size: { inPixels: number }) => {
-    setCollapsed((current) => {
-      const shut = size.inPixels <= RAIL + 1;
-      return current[side] === shut ? current : { ...current, [side]: shut };
+  const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number; asPercentage: number }) => {
+    setSides((current) => {
+      const next: SideState =
+        size.inPixels <= RAIL + 1
+          ? "shut"
+          : size.asPercentage <= Number.parseFloat(SIDES[side].min) + 0.5
+            ? "floor"
+            : "open";
+      return current[side] === next ? current : { ...current, [side]: next };
     });
   }, []);
 
@@ -864,17 +879,17 @@ function App() {
         <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
           <ResizablePanel
             panelRef={sidebarPanel}
-            defaultSize="20%"
-            minSize="15%"
-            maxSize="30%"
+            defaultSize={SIDES.sidebar.size}
+            minSize={SIDES.sidebar.min}
+            maxSize={SIDES.sidebar.max}
             collapsible
             collapsedSize={RAIL}
             onResize={(size) => rail("sidebar", size)}
           >
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
-              {collapsed.sidebar ? (
+              {sides.sidebar === "shut" ? (
                 <ScrollArea className="min-h-0 flex-1">
-                  <div className="flex flex-col items-center gap-1 py-1.5">
+                  <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
                     <Tooltip>
                       <TooltipTrigger
                         render={
@@ -975,7 +990,7 @@ function App() {
               )}
             </aside>
           </ResizablePanel>
-          <ResizableHandle withHandle />
+          <ResizableHandle withHandle className={sides.sidebar === "floor" ? ARMED : ""} />
           <ResizablePanel defaultSize="55%" minSize="38%">
             <section className="flex h-full min-w-0 flex-col">
               {selected ? (
@@ -1046,12 +1061,12 @@ function App() {
           </ResizablePanel>
           {selected ? (
             <>
-              <ResizableHandle withHandle />
+              <ResizableHandle withHandle className={sides.inspector === "floor" ? ARMED : ""} />
               <ResizablePanel
                 panelRef={inspectorPanel}
-                defaultSize="25%"
-                minSize="18%"
-                maxSize="40%"
+                defaultSize={SIDES.inspector.size}
+                minSize={SIDES.inspector.min}
+                maxSize={SIDES.inspector.max}
                 collapsible
                 collapsedSize={RAIL}
                 onResize={(size) => rail("inspector", size)}
@@ -1060,7 +1075,7 @@ function App() {
                   <PanelBoundary key={selected.id}>
                     <Inspector
                       session={selected}
-                      collapsed={collapsed.inspector}
+                      collapsed={sides.inspector === "shut"}
                       onExpand={() => inspectorPanel.current?.expand()}
                     />
                   </PanelBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ class PanelBoundary extends Component<{ children: ReactNode }, { message: string
 }
 
 // What a session looks like at a glance: who runs it and whether it is up. The sidebar row and the rail
-// it collapses to show the same one, so a session is recognisable at either width.
+// it collapses to show the same one, so a session is recognizable at either width.
 function SessionBadge({
   session,
   active,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
+  GitBranch,
   KeyRound,
   Moon,
   MoreHorizontal,
@@ -324,6 +325,11 @@ function folderName(cwd: string) {
   return cwd.split(/[\\/]/).filter(Boolean).pop() ?? "Session";
 }
 
+// A remote names a repository; the scheme and host that reach it are the tooltip's job.
+function repoName(url: string) {
+  return url.replace(/^https:\/\/[^/]+\//, "");
+}
+
 // Paths truncate from the right, which hides the part that identifies the folder, so only its tail shows.
 function shortPath(cwd: string) {
   const parts = cwd.split(/[\\/]/).filter(Boolean);
@@ -349,6 +355,8 @@ function App() {
   // session that is working from one that is merely connected.
   const [working, setWorking] = useState<Set<string>>(new Set());
   const [query, setQuery] = useState("");
+  // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
+  const [remote, setRemote] = useState("");
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
   // Undefined until asked: an empty string is a release, anything else is the commit it was built from.
@@ -589,6 +597,24 @@ function App() {
     void launch(selected, true);
   }, [selected, launch]);
 
+  // Which repository a folder was cloned from is a fact about the folder, so it is asked for once when
+  // the folder changes and never watched. Keyed by the grant rather than the session, so switching
+  // between sessions in one folder does not ask again.
+  const rootId = selected?.rootId ?? "";
+  useEffect(() => {
+    setRemote("");
+    if (!rootId) return;
+    let cancelled = false;
+    void invoke<string | null>("git_remote", { rootId })
+      .then((url) => {
+        if (!cancelled) setRemote(url ?? "");
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [rootId]);
+
   async function signIn(agent: Session["agent"]) {
     setSettingsOpen(false);
     try {
@@ -724,6 +750,23 @@ function App() {
               <ProviderIcon agent={selected.agent} provider={selected.provider} />
               <span className="min-w-0 truncate text-xs font-medium">{selected.name}</span>
               <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">{selected.cwd}</span>
+              {remote ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        className="flex max-w-56 shrink-0 items-center gap-1.5 text-muted-foreground hover:text-foreground"
+                        onClick={() => void invoke("open_url", { url: remote })}
+                      />
+                    }
+                  >
+                    <GitBranch className="size-3.5 shrink-0" />
+                    <span className="truncate font-mono text-[11px]">{repoName(remote)}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>Open {remote}</TooltipContent>
+                </Tooltip>
+              ) : null}
             </>
           ) : (
             <span className="text-sm font-semibold">Lite</span>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { INSPECTOR_TABS, Inspector } from "@/inspector";
+import { Inspector } from "@/inspector";
 import { NewSessionDialog } from "@/new-session-dialog";
 import { appendOutput, clearOutput, subscribeOutput } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
@@ -384,7 +384,6 @@ function App() {
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
   const [collapsed, setCollapsed] = useState({ sidebar: false, inspector: false });
-  const [inspectorTab, setInspectorTab] = useState<string>(INSPECTOR_TABS[0].value);
   const sidebarPanel = useRef<PanelImperativeHandle>(null);
   const inspectorPanel = useRef<PanelImperativeHandle>(null);
   // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
@@ -1058,35 +1057,13 @@ function App() {
                 onResize={(size) => rail("inspector", size)}
               >
                 <aside className="h-full border-l">
-                  {collapsed.inspector ? (
-                    /* Collapsed, the panel is its own tab strip: the tab you pick is the one it reopens. */
-                    <div className="flex flex-col items-center gap-1 py-1.5">
-                      {INSPECTOR_TABS.map(({ value, label, icon: Icon }) => (
-                        <Tooltip key={value}>
-                          <TooltipTrigger
-                            render={
-                              <Button
-                                variant="ghost"
-                                size="icon-sm"
-                                aria-label={label}
-                                onClick={() => {
-                                  setInspectorTab(value);
-                                  inspectorPanel.current?.expand();
-                                }}
-                              />
-                            }
-                          >
-                            <Icon />
-                          </TooltipTrigger>
-                          <TooltipContent side="left">{label}</TooltipContent>
-                        </Tooltip>
-                      ))}
-                    </div>
-                  ) : (
-                    <PanelBoundary key={selected.id}>
-                      <Inspector session={selected} tab={inspectorTab} onTabChange={setInspectorTab} />
-                    </PanelBoundary>
-                  )}
+                  <PanelBoundary key={selected.id}>
+                    <Inspector
+                      session={selected}
+                      collapsed={collapsed.inspector}
+                      onExpand={() => inspectorPanel.current?.expand()}
+                    />
+                  </PanelBoundary>
                 </aside>
               </ResizablePanel>
             </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import { Component, lazy, type ReactNode, Suspense, useCallback, useEffect, useM
 
 import { LiteLogomark, ProviderIcon } from "@/brand-icons";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { ActionIconButton, Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogBody,
@@ -299,39 +299,27 @@ function SessionRow({
       </div>
       {/* Hidden rather than transparent, so a name gets the whole row until the pointer arrives. */}
       <span className="hidden shrink-0 items-center group-hover:flex group-focus-within:flex">
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                disabled={starting}
-                onClick={onRestart}
-                aria-label={`Restart ${session.name}`}
-              />
-            }
-          >
-            <RotateCcw />
-          </TooltipTrigger>
-          <TooltipContent>Restart</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                disabled={starting}
-                className="hover:text-destructive"
-                onClick={onClose}
-                aria-label={`Close ${session.name}`}
-              />
-            }
-          >
-            <Trash2 />
-          </TooltipTrigger>
-          <TooltipContent>Close session</TooltipContent>
-        </Tooltip>
+        <ActionIconButton
+          variant="ghost"
+          size="icon-sm"
+          tooltip="Restart"
+          aria-label={`Restart ${session.name}`}
+          disabled={starting}
+          onClick={onRestart}
+        >
+          <RotateCcw />
+        </ActionIconButton>
+        <ActionIconButton
+          variant="ghost"
+          size="icon-sm"
+          className="hover:text-destructive"
+          tooltip="Close session"
+          aria-label={`Close ${session.name}`}
+          disabled={starting}
+          onClick={onClose}
+        >
+          <Trash2 />
+        </ActionIconButton>
       </span>
     </div>
   );
@@ -439,12 +427,11 @@ function App() {
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
   const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number; asPercentage: number }) => {
+    // Both halves matter: a window narrow enough for the minimum itself to be under the rail width
+    // would otherwise report a panel sitting on its floor as shut.
+    const min = Number.parseFloat(SIDES[side].min);
     const next: SideState =
-      size.inPixels <= RAIL + 1
-        ? "shut"
-        : size.asPercentage <= Number.parseFloat(SIDES[side].min) + 0.5
-          ? "floor"
-          : "open";
+      size.inPixels <= RAIL + 1 && size.asPercentage < min ? "shut" : size.asPercentage <= min + 0.5 ? "floor" : "open";
     // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
     // leaving the rail and the number shortcuts counting two different lists.
     if (side === "sidebar" && next === "shut") setQuery("");
@@ -901,36 +888,26 @@ function App() {
               {sides.sidebar === "shut" ? (
                 <ScrollArea className="min-h-0 flex-1">
                   <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() => sidebarPanel.current?.expand()}
-                            aria-label="Expand sessions"
-                          />
-                        }
-                      >
-                        <ChevronRight />
-                      </TooltipTrigger>
-                      <TooltipContent side="right">Expand sessions</TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() => setNewSessionOpen(true)}
-                            aria-label="New session"
-                          />
-                        }
-                      >
-                        <Plus />
-                      </TooltipTrigger>
-                      <TooltipContent side="right">New session</TooltipContent>
-                    </Tooltip>
+                    <ActionIconButton
+                      variant="ghost"
+                      size="icon-sm"
+                      tooltip="Expand sessions"
+                      tooltipSide="right"
+                      aria-label="Expand sessions"
+                      onClick={() => sidebarPanel.current?.expand()}
+                    >
+                      <ChevronRight />
+                    </ActionIconButton>
+                    <ActionIconButton
+                      variant="ghost"
+                      size="icon-sm"
+                      tooltip="New session"
+                      tooltipSide="right"
+                      aria-label="New session"
+                      onClick={() => setNewSessionOpen(true)}
+                    >
+                      <Plus />
+                    </ActionIconButton>
                     {sessions.map((session) => (
                       <Tooltip key={session.id}>
                         <TooltipTrigger
@@ -972,21 +949,15 @@ function App() {
                         }}
                       />
                     </span>
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() => setNewSessionOpen(true)}
-                            aria-label="New session"
-                          />
-                        }
-                      >
-                        <Plus />
-                      </TooltipTrigger>
-                      <TooltipContent>New session</TooltipContent>
-                    </Tooltip>
+                    <ActionIconButton
+                      variant="ghost"
+                      size="icon-sm"
+                      tooltip="New session"
+                      aria-label="New session"
+                      onClick={() => setNewSessionOpen(true)}
+                    >
+                      <Plus />
+                    </ActionIconButton>
                   </div>
                   <ScrollArea className="min-h-0 flex-1">
                     <div className="space-y-0.5 px-2 pb-2">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -923,7 +923,7 @@ function App() {
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
               {shut.sidebar ? (
                 <ScrollArea className="min-h-0 flex-1">
-                  <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
+                  <div className="flex animate-in flex-col items-center gap-0.5 py-1.5 fade-in duration-200">
                     <ActionIconButton
                       variant="ghost"
                       size="icon-sm"
@@ -971,7 +971,7 @@ function App() {
               ) : (
                 <>
                   {/* The search field names the panel and searches it, so the list keeps the row a title would cost. */}
-                  <div className="flex h-9 shrink-0 items-center gap-1 pr-1.5 pl-2">
+                  <div className="flex h-9 shrink-0 items-center gap-0.5 pr-1.5 pl-2">
                     <span className="relative min-w-0 flex-1">
                       <Search className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
                       <Input

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,12 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
-  ChevronRight,
   GitBranch,
   KeyRound,
   Moon,
   MoreHorizontal,
+  PanelLeftClose,
+  PanelLeftOpen,
   Play,
   Plus,
   RefreshCw,
@@ -63,13 +64,14 @@ import { type Session, sessionLabel } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
-// The width each side collapses to: one icon button and the room around it. It is also the width a
-// side cannot be dragged past, so a side narrows all the way to its rail under the pointer and stops
-// there. A collapsible panel would instead pin at a minimum and jump the rest of the way, which is a
-// jump no transition can smooth because it happens while the pointer is being tracked exactly.
+// The width each side collapses to: one icon button and the room around it.
 const RAIL = 44;
-// The width below which a side has no room to be anything but its rail.
+// Where a side stops following the pointer. It has no room to be anything but its rail by here, so it
+// becomes one and collapses the rest of the way itself, in one eased step.
 const SHUT = 140;
+// A transition only runs when the property was already transitionable before the value changed, so the
+// ease is armed on the approach rather than at the moment it is needed, which is one commit too late.
+const ARM = 240;
 const SIDES = {
   sidebar: { size: "20%", max: "30%" },
   inspector: { size: "25%", max: "40%" },
@@ -382,8 +384,10 @@ function App() {
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
   const [shut, setShut] = useState({ sidebar: false, inspector: false });
+  const [armed, setArmed] = useState({ sidebar: false, inspector: false });
   const sidebarPanel = useRef<PanelImperativeHandle>(null);
   const inspectorPanel = useRef<PanelImperativeHandle>(null);
+  const panels = useRef({ sidebar: sidebarPanel, inspector: inspectorPanel }).current;
   // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
   const [remote, setRemote] = useState("");
   const [theme, setTheme] = useState<Theme>(initialTheme);
@@ -424,13 +428,24 @@ function App() {
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
-  const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number }) => {
-    const next = size.inPixels < SHUT;
-    // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
-    // leaving the rail and the number shortcuts counting two different lists.
-    if (side === "sidebar" && next) setQuery("");
-    setShut((current) => (current[side] === next ? current : { ...current, [side]: next }));
-  }, []);
+  const rail = useCallback(
+    (side: keyof typeof SIDES, size: { inPixels: number }) => {
+      const next = size.inPixels <= SHUT + 1;
+      // Reaching the point where a side is only a rail is the whole decision, so the side takes the rest
+      // of the way itself rather than asking for another half of it. The library holds it there against
+      // the pointer, and the ease armed on the way in carries it.
+      if (next) panels[side].current?.collapse();
+      // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
+      // leaving the rail and the number shortcuts counting two different lists.
+      if (side === "sidebar" && next) setQuery("");
+      setShut((current) => (current[side] === next ? current : { ...current, [side]: next }));
+      setArmed((current) => {
+        const arm = size.inPixels <= ARM;
+        return current[side] === arm ? current : { ...current, [side]: arm };
+      });
+    },
+    [panels],
+  );
 
   // The inspector panel goes away with the last session and comes back at its default width, so what
   // the sides remember about it is reset with it rather than corrected by the first measurement.
@@ -871,8 +886,11 @@ function App() {
           <ResizablePanel
             panelRef={sidebarPanel}
             defaultSize={SIDES.sidebar.size}
-            minSize={RAIL}
+            minSize={SHUT}
             maxSize={SIDES.sidebar.max}
+            collapsible
+            collapsedSize={RAIL}
+            data-ease={armed.sidebar || undefined}
             onResize={(size) => rail("sidebar", size)}
           >
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
@@ -887,7 +905,7 @@ function App() {
                       aria-label="Expand sessions"
                       onClick={() => sidebarPanel.current?.resize(SIDES.sidebar.size)}
                     >
-                      <ChevronRight />
+                      <PanelLeftOpen />
                     </ActionIconButton>
                     <ActionIconButton
                       variant="ghost"
@@ -948,6 +966,15 @@ function App() {
                       onClick={() => setNewSessionOpen(true)}
                     >
                       <Plus />
+                    </ActionIconButton>
+                    <ActionIconButton
+                      variant="ghost"
+                      size="icon-sm"
+                      tooltip="Collapse sessions"
+                      aria-label="Collapse sessions"
+                      onClick={() => sidebarPanel.current?.collapse()}
+                    >
+                      <PanelLeftClose />
                     </ActionIconButton>
                   </div>
                   <ScrollArea className="min-h-0 flex-1">
@@ -1053,8 +1080,11 @@ function App() {
               <ResizablePanel
                 panelRef={inspectorPanel}
                 defaultSize={SIDES.inspector.size}
-                minSize={RAIL}
+                minSize={SHUT}
                 maxSize={SIDES.inspector.max}
+                collapsible
+                collapsedSize={RAIL}
+                data-ease={armed.inspector || undefined}
                 onResize={(size) => rail("inspector", size)}
               >
                 <aside className="h-full border-l">
@@ -1063,6 +1093,7 @@ function App() {
                       session={selected}
                       collapsed={shut.inspector}
                       onExpand={() => inspectorPanel.current?.resize(SIDES.inspector.size)}
+                      onCollapse={() => inspectorPanel.current?.collapse()}
                     />
                   </PanelBoundary>
                 </aside>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,12 +43,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import {
+  type PanelImperativeHandle,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Inspector } from "@/inspector";
+import { INSPECTOR_TABS, Inspector } from "@/inspector";
 import { NewSessionDialog } from "@/new-session-dialog";
 import { appendOutput, clearOutput, subscribeOutput } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
@@ -57,6 +62,8 @@ import { type Session, sessionLabel } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
+// The width each side collapses to: one icon button and the room around it.
+const RAIL = 44;
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
 // The version is known from the start, so the badge shows it throughout and only its color waits on
 // the answer: grey while asking, which is quieter than a spinner that would resize a chip this small.
@@ -174,6 +181,39 @@ class PanelBoundary extends Component<{ children: ReactNode }, { message: string
   }
 }
 
+// What a session looks like at a glance: who runs it and whether it is up. The sidebar row and the rail
+// it collapses to show the same one, so a session is recognisable at either width.
+function SessionBadge({
+  session,
+  active,
+  starting,
+  working,
+}: {
+  session: Session;
+  active: boolean;
+  starting: boolean;
+  working: boolean;
+}) {
+  const status = SESSION_STATUS[!session.running ? "disconnected" : working ? "working" : "idle"];
+  const ring = active ? "ring-sidebar-accent" : "ring-sidebar";
+  return (
+    <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
+      <ProviderIcon agent={session.agent} provider={session.provider} />
+      {starting ? (
+        <Spinner
+          className={`absolute -right-1 -bottom-1 size-3 rounded-full bg-background text-muted-foreground ring-2 ${ring}`}
+        />
+      ) : (
+        <span
+          role="img"
+          className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${ring} ${status.dot}`}
+          aria-label={status.label}
+        />
+      )}
+    </span>
+  );
+}
+
 function SessionRow({
   session,
   active,
@@ -193,7 +233,6 @@ function SessionRow({
   onRestart: () => void;
   onClose: () => void;
 }) {
-  const status = SESSION_STATUS[!session.running ? "disconnected" : working ? "working" : "idle"];
   const [renaming, setRenaming] = useState(false);
   const [name, setName] = useState(session.name);
 
@@ -209,20 +248,7 @@ function SessionRow({
       className={`group flex items-center rounded-lg pr-1 ${active ? "bg-sidebar-accent text-sidebar-accent-foreground" : "hover:bg-sidebar-accent/60"}`}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2.5 py-1.5 pl-2">
-        <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
-          <ProviderIcon agent={session.agent} provider={session.provider} />
-          {starting ? (
-            <Spinner
-              className={`absolute -right-1 -bottom-1 size-3 rounded-full bg-background text-muted-foreground ring-2 ${active ? "ring-sidebar-accent" : "ring-sidebar"}`}
-            />
-          ) : (
-            <span
-              role="img"
-              className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${active ? "ring-sidebar-accent" : "ring-sidebar"} ${status.dot}`}
-              aria-label={status.label}
-            />
-          )}
-        </span>
+        <SessionBadge session={session} active={active} starting={starting} working={working} />
         {renaming ? (
           <span className="min-w-0 flex-1 py-0.5">
             <Input
@@ -355,6 +381,12 @@ function App() {
   // session that is working from one that is merely connected.
   const [working, setWorking] = useState<Set<string>>(new Set());
   const [query, setQuery] = useState("");
+  // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
+  // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
+  const [collapsed, setCollapsed] = useState({ sidebar: false, inspector: false });
+  const [inspectorTab, setInspectorTab] = useState<string>(INSPECTOR_TABS[0].value);
+  const sidebarPanel = useRef<PanelImperativeHandle>(null);
+  const inspectorPanel = useRef<PanelImperativeHandle>(null);
   // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
   const [remote, setRemote] = useState("");
   const [theme, setTheme] = useState<Theme>(initialTheme);
@@ -822,66 +854,118 @@ function App() {
           </div>
         </header>
         <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
-          <ResizablePanel defaultSize="20%" minSize="15%" maxSize="30%" collapsible collapsedSize="0%">
+          <ResizablePanel
+            panelRef={sidebarPanel}
+            defaultSize="20%"
+            minSize="15%"
+            maxSize="30%"
+            collapsible
+            collapsedSize={RAIL}
+            onResize={(size) => setCollapsed((current) => ({ ...current, sidebar: size.inPixels <= RAIL + 1 }))}
+          >
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
-              {/* The search field names the panel and searches it, so the list keeps the row a title would cost. */}
-              <div className="flex h-9 shrink-0 items-center gap-1 pr-1.5 pl-2">
-                <span className="relative min-w-0 flex-1">
-                  <Search className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    value={query}
-                    className="h-7 pl-7 text-xs md:text-xs"
-                    placeholder="Search sessions"
-                    aria-label="Search sessions"
-                    onChange={(event) => setQuery(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Escape") setQuery("");
-                    }}
-                  />
-                </span>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => setNewSessionOpen(true)}
-                        aria-label="New session"
-                      />
-                    }
-                  >
-                    <Plus />
-                  </TooltipTrigger>
-                  <TooltipContent>New session</TooltipContent>
-                </Tooltip>
-              </div>
-              <ScrollArea className="min-h-0 flex-1">
-                <div className="space-y-0.5 px-2 pb-2">
-                  {query && !visible.length ? (
-                    <p className="px-2 py-1.5 text-xs text-muted-foreground">No session matches “{query}”.</p>
-                  ) : null}
-                  {visible.map((session) => (
-                    <SessionRow
-                      key={session.id}
-                      session={session}
-                      active={session.id === selectedId}
-                      starting={startingIds.has(session.id)}
-                      working={working.has(session.id)}
-                      onSelect={() => openRef.current(session)}
-                      onRename={(name) =>
-                        setSessions((current) =>
-                          current.map((item) => (item.id === session.id ? { ...item, name } : item)),
-                        )
+              {collapsed.sidebar ? (
+                <div className="flex flex-col items-center gap-1 py-1.5">
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => setNewSessionOpen(true)}
+                          aria-label="New session"
+                        />
                       }
-                      onRestart={() => void restartSession(session)}
-                      onClose={() => setClosing(session)}
-                    />
+                    >
+                      <Plus />
+                    </TooltipTrigger>
+                    <TooltipContent side="right">New session</TooltipContent>
+                  </Tooltip>
+                  {sessions.map((session) => (
+                    <Tooltip key={session.id}>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            aria-pressed={session.id === selectedId}
+                            className={`rounded-lg p-1 ${session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"}`}
+                            onClick={() => openRef.current(session)}
+                          />
+                        }
+                      >
+                        <SessionBadge
+                          session={session}
+                          active={session.id === selectedId}
+                          starting={startingIds.has(session.id)}
+                          working={working.has(session.id)}
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent side="right">{session.name}</TooltipContent>
+                    </Tooltip>
                   ))}
                 </div>
-              </ScrollArea>
+              ) : (
+                <>
+                  {/* The search field names the panel and searches it, so the list keeps the row a title would cost. */}
+                  <div className="flex h-9 shrink-0 items-center gap-1 pr-1.5 pl-2">
+                    <span className="relative min-w-0 flex-1">
+                      <Search className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        value={query}
+                        className="h-7 pl-7 text-xs md:text-xs"
+                        placeholder="Search sessions"
+                        aria-label="Search sessions"
+                        onChange={(event) => setQuery(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Escape") setQuery("");
+                        }}
+                      />
+                    </span>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => setNewSessionOpen(true)}
+                            aria-label="New session"
+                          />
+                        }
+                      >
+                        <Plus />
+                      </TooltipTrigger>
+                      <TooltipContent>New session</TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <ScrollArea className="min-h-0 flex-1">
+                    <div className="space-y-0.5 px-2 pb-2">
+                      {query && !visible.length ? (
+                        <p className="px-2 py-1.5 text-xs text-muted-foreground">No session matches “{query}”.</p>
+                      ) : null}
+                      {visible.map((session) => (
+                        <SessionRow
+                          key={session.id}
+                          session={session}
+                          active={session.id === selectedId}
+                          starting={startingIds.has(session.id)}
+                          working={working.has(session.id)}
+                          onSelect={() => openRef.current(session)}
+                          onRename={(name) =>
+                            setSessions((current) =>
+                              current.map((item) => (item.id === session.id ? { ...item, name } : item)),
+                            )
+                          }
+                          onRestart={() => void restartSession(session)}
+                          onClose={() => setClosing(session)}
+                        />
+                      ))}
+                    </div>
+                  </ScrollArea>
+                </>
+              )}
             </aside>
           </ResizablePanel>
-          <ResizableHandle />
+          <ResizableHandle withHandle />
           <ResizablePanel defaultSize="55%" minSize="38%">
             <section className="flex h-full min-w-0 flex-col">
               {selected ? (
@@ -952,12 +1036,46 @@ function App() {
           </ResizablePanel>
           {selected ? (
             <>
-              <ResizableHandle />
-              <ResizablePanel defaultSize="25%" minSize="18%" maxSize="40%">
+              <ResizableHandle withHandle />
+              <ResizablePanel
+                panelRef={inspectorPanel}
+                defaultSize="25%"
+                minSize="18%"
+                maxSize="40%"
+                collapsible
+                collapsedSize={RAIL}
+                onResize={(size) => setCollapsed((current) => ({ ...current, inspector: size.inPixels <= RAIL + 1 }))}
+              >
                 <aside className="h-full border-l">
-                  <PanelBoundary key={selected.id}>
-                    <Inspector session={selected} />
-                  </PanelBoundary>
+                  {collapsed.inspector ? (
+                    /* Collapsed, the panel is its own tab strip: the tab you pick is the one it reopens. */
+                    <div className="flex flex-col items-center gap-1 py-1.5">
+                      {INSPECTOR_TABS.map(({ value, label, icon: Icon }) => (
+                        <Tooltip key={value}>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label={label}
+                                onClick={() => {
+                                  setInspectorTab(value);
+                                  inspectorPanel.current?.expand();
+                                }}
+                              />
+                            }
+                          >
+                            <Icon />
+                          </TooltipTrigger>
+                          <TooltipContent side="left">{label}</TooltipContent>
+                        </Tooltip>
+                      ))}
+                    </div>
+                  ) : (
+                    <PanelBoundary key={selected.id}>
+                      <Inspector session={selected} tab={inspectorTab} onTabChange={setInspectorTab} />
+                    </PanelBoundary>
+                  )}
                 </aside>
               </ResizablePanel>
             </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   RefreshCw,
   RotateCcw,
+  Search,
   SquareTerminal,
   Sun,
   Trash2,
@@ -255,7 +256,8 @@ function SessionRow({
           </button>
         )}
       </div>
-      <span className="flex shrink-0 items-center opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
+      {/* Hidden rather than transparent, so a name gets the whole row until the pointer arrives. */}
+      <span className="hidden shrink-0 items-center group-hover:flex group-focus-within:flex">
         <Tooltip>
           <TooltipTrigger
             render={
@@ -344,6 +346,7 @@ function App() {
   // Sessions whose terminal has written something recently, which is what separates a connected
   // session that is working from one that is merely connected.
   const [working, setWorking] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState("");
   const [theme, setTheme] = useState<Theme>(initialTheme);
   const [version, setVersion] = useState("");
   // Undefined until asked: an empty string is a release, anything else is the commit it was built from.
@@ -358,12 +361,20 @@ function App() {
   const workTimers = useRef(new Map<string, number>());
   const resumed = useRef("");
   const themeRef = useRef<Theme>("dark");
-  const sessionsRef = useRef<Session[]>([]);
+  const visibleRef = useRef<Session[]>([]);
   const selectedRef = useRef<Session>(undefined);
   const closeRef = useRef<(session: Session) => void>(() => {});
   const openRef = useRef<(session: Session) => void>(() => {});
   const selected = useMemo(() => sessions.find((session) => session.id === selectedId), [sessions, selectedId]);
-  sessionsRef.current = sessions;
+  // A session is found by what names it: the subject it was given and the folder it works in.
+  const visible = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return sessions;
+    return sessions.filter(
+      (session) => session.name.toLowerCase().includes(needle) || session.cwd.toLowerCase().includes(needle),
+    );
+  }, [sessions, query]);
+  visibleRef.current = visible;
   themeRef.current = theme;
   selectedRef.current = selected;
   closeRef.current = setClosing;
@@ -396,7 +407,8 @@ function App() {
       else if (event.key === ",") setSettingsOpen(true);
       else if (event.key === "w" && selectedRef.current) closeRef.current(selectedRef.current);
       else if (event.key >= "1" && event.key <= "9") {
-        const target = sessionsRef.current[Number(event.key) - 1];
+        // The numbers count the sessions the sidebar is showing, so a search narrows them with the list.
+        const target = visibleRef.current[Number(event.key) - 1];
         if (!target) return;
         // Reaching a session by number is the same act as clicking it, including bringing it back.
         openRef.current(target);
@@ -760,14 +772,27 @@ function App() {
         <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
           <ResizablePanel defaultSize="20%" minSize="15%" maxSize="30%" collapsible collapsedSize="0%">
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
-              <div className="flex h-9 shrink-0 items-center justify-between pr-1.5 pl-3">
-                <span className="text-[11px] font-medium tracking-wide text-muted-foreground uppercase">Sessions</span>
+              {/* The search field names the panel and searches it, so the list keeps the row a title would cost. */}
+              <div className="flex h-9 shrink-0 items-center gap-1 pr-1.5 pl-2">
+                <span className="relative min-w-0 flex-1">
+                  <Search className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={query}
+                    className="h-7 pl-7 text-xs md:text-xs"
+                    placeholder="Search sessions"
+                    aria-label="Search sessions"
+                    onChange={(event) => setQuery(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape") setQuery("");
+                    }}
+                  />
+                </span>
                 <Tooltip>
                   <TooltipTrigger
                     render={
                       <Button
                         variant="ghost"
-                        size="icon-xs"
+                        size="icon-sm"
                         onClick={() => setNewSessionOpen(true)}
                         aria-label="New session"
                       />
@@ -780,7 +805,10 @@ function App() {
               </div>
               <ScrollArea className="min-h-0 flex-1">
                 <div className="space-y-0.5 px-2 pb-2">
-                  {sessions.map((session) => (
+                  {query && !visible.length ? (
+                    <p className="px-2 py-1.5 text-xs text-muted-foreground">No session matches “{query}”.</p>
+                  ) : null}
+                  {visible.map((session) => (
                     <SessionRow
                       key={session.id}
                       session={session}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -750,12 +750,12 @@ function App() {
               <Tooltip>
                 <TooltipTrigger
                   render={
-                    <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="Lite menu" />} />
+                    <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="Options" />} />
                   }
                 >
                   <MoreHorizontal />
                 </TooltipTrigger>
-                <TooltipContent>Lite menu</TooltipContent>
+                <TooltipContent>Options</TooltipContent>
               </Tooltip>
               <DropdownMenuContent align="end" className="w-48">
                 {version ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -425,6 +425,15 @@ function App() {
     if (!session.running) void launch(session, true);
   };
 
+  // A drag reports every frame, so a side changes state only when the answer changes: handing back the
+  // same object leaves React with nothing to redraw while the divider moves.
+  const rail = useCallback((side: "sidebar" | "inspector", size: { inPixels: number }) => {
+    setCollapsed((current) => {
+      const shut = size.inPixels <= RAIL + 1;
+      return current[side] === shut ? current : { ...current, [side]: shut };
+    });
+  }, []);
+
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
@@ -861,49 +870,51 @@ function App() {
             maxSize="30%"
             collapsible
             collapsedSize={RAIL}
-            onResize={(size) => setCollapsed((current) => ({ ...current, sidebar: size.inPixels <= RAIL + 1 }))}
+            onResize={(size) => rail("sidebar", size)}
           >
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
               {collapsed.sidebar ? (
-                <div className="flex flex-col items-center gap-1 py-1.5">
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          onClick={() => setNewSessionOpen(true)}
-                          aria-label="New session"
-                        />
-                      }
-                    >
-                      <Plus />
-                    </TooltipTrigger>
-                    <TooltipContent side="right">New session</TooltipContent>
-                  </Tooltip>
-                  {sessions.map((session) => (
-                    <Tooltip key={session.id}>
+                <ScrollArea className="min-h-0 flex-1">
+                  <div className="flex flex-col items-center gap-1 py-1.5">
+                    <Tooltip>
                       <TooltipTrigger
                         render={
-                          <button
-                            type="button"
-                            aria-pressed={session.id === selectedId}
-                            className={`rounded-lg p-1 ${session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"}`}
-                            onClick={() => openRef.current(session)}
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => setNewSessionOpen(true)}
+                            aria-label="New session"
                           />
                         }
                       >
-                        <SessionBadge
-                          session={session}
-                          active={session.id === selectedId}
-                          starting={startingIds.has(session.id)}
-                          working={working.has(session.id)}
-                        />
+                        <Plus />
                       </TooltipTrigger>
-                      <TooltipContent side="right">{session.name}</TooltipContent>
+                      <TooltipContent side="right">New session</TooltipContent>
                     </Tooltip>
-                  ))}
-                </div>
+                    {sessions.map((session) => (
+                      <Tooltip key={session.id}>
+                        <TooltipTrigger
+                          render={
+                            <button
+                              type="button"
+                              aria-pressed={session.id === selectedId}
+                              className={`rounded-lg p-1 ${session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"}`}
+                              onClick={() => openRef.current(session)}
+                            />
+                          }
+                        >
+                          <SessionBadge
+                            session={session}
+                            active={session.id === selectedId}
+                            starting={startingIds.has(session.id)}
+                            working={working.has(session.id)}
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent side="right">{session.name}</TooltipContent>
+                      </Tooltip>
+                    ))}
+                  </div>
+                </ScrollArea>
               ) : (
                 <>
                   {/* The search field names the panel and searches it, so the list keeps the row a title would cost. */}
@@ -1044,7 +1055,7 @@ function App() {
                 maxSize="40%"
                 collapsible
                 collapsedSize={RAIL}
-                onResize={(size) => setCollapsed((current) => ({ ...current, inspector: size.inPixels <= RAIL + 1 }))}
+                onResize={(size) => rail("inspector", size)}
               >
                 <aside className="h-full border-l">
                   {collapsed.inspector ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -240,12 +241,13 @@ function SessionRow({
             />
           </span>
         ) : (
-          /* Clicking a session opens it; clicking the one already open edits its name, so a name is
-             reachable without a menu and a click never surprises you with a text field. */
+          /* Clicking a session opens it, and a stopped one comes back with it. Only the session already
+             open and running reads a click as a rename, so a name is still reachable without a menu and
+             a click never surprises you with a text field. */
           <button
             type="button"
             className="min-w-0 flex-1 py-0.5 text-left"
-            onClick={() => (active ? setRenaming(true) : onSelect())}
+            onClick={() => (active && session.running ? setRenaming(true) : onSelect())}
             onDoubleClick={() => setRenaming(true)}
             title={session.cwd}
           >
@@ -745,9 +747,16 @@ function App() {
               <TooltipContent>{theme === "dark" ? "Light mode" : "Dark mode"}</TooltipContent>
             </Tooltip>
             <DropdownMenu>
-              <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="Lite menu" />}>
-                <MoreHorizontal />
-              </DropdownMenuTrigger>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="Lite menu" />} />
+                  }
+                >
+                  <MoreHorizontal />
+                </TooltipTrigger>
+                <TooltipContent>Lite menu</TooltipContent>
+              </Tooltip>
               <DropdownMenuContent align="end" className="w-48">
                 {version ? (
                   <DropdownMenuGroup>
@@ -946,7 +955,9 @@ function App() {
               </DialogDescription>
             </DialogHeader>
             {updateStatus === "checking" || updateStatus === "installing" ? (
-              <Spinner className="mx-auto size-5 text-muted-foreground" />
+              <DialogBody>
+                <Spinner className="mx-auto size-5 text-muted-foreground" />
+              </DialogBody>
             ) : null}
             {updateStatus === "available" ? (
               <DialogFooter>
@@ -969,7 +980,7 @@ function App() {
           </DialogContent>
         </Dialog>
         <Dialog open={Boolean(closing)} onOpenChange={(open) => !open && setClosing(undefined)}>
-          <DialogContent className="sm:max-w-sm">
+          <DialogContent size="sm">
             <DialogHeader>
               <DialogTitle>Close {closing?.name}?</DialogTitle>
               <DialogDescription>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,19 +63,17 @@ import { type Session, sessionLabel } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
-// The width each side collapses to: one icon button and the room around it.
+// The width each side collapses to: one icon button and the room around it. It is also the width a
+// side cannot be dragged past, so a side narrows all the way to its rail under the pointer and stops
+// there. A collapsible panel would instead pin at a minimum and jump the rest of the way, which is a
+// jump no transition can smooth because it happens while the pointer is being tracked exactly.
 const RAIL = 44;
-// What each side is doing. "floor" is the pause the library builds in: a collapsible panel stops at its
-// minimum and stays there until the drag passes half the remaining gap, so without a word from the
-// handle the drag that is about to collapse it looks exactly like one that is doing nothing.
-type SideState = "open" | "floor" | "shut";
+// The width below which a side has no room to be anything but its rail.
+const SHUT = 140;
 const SIDES = {
-  sidebar: { size: "20%", min: "15%", max: "30%" },
-  inspector: { size: "25%", min: "18%", max: "40%" },
+  sidebar: { size: "20%", max: "30%" },
+  inspector: { size: "25%", max: "40%" },
 } as const;
-// Held at the minimum, the handle says that one more nudge collapses the side.
-const ARMED =
-  "data-[separator=active]:bg-primary data-[separator=active]:[&>div]:h-10 data-[separator=active]:[&>div]:bg-primary";
 const TerminalView = lazy(() => import("@/terminal").then((module) => ({ default: module.TerminalView })));
 // The version is known from the start, so the badge shows it throughout and only its color waits on
 // the answer: grey while asking, which is quieter than a spinner that would resize a chip this small.
@@ -383,7 +381,7 @@ function App() {
   const [query, setQuery] = useState("");
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
-  const [sides, setSides] = useState<Record<keyof typeof SIDES, SideState>>({ sidebar: "open", inspector: "open" });
+  const [shut, setShut] = useState({ sidebar: false, inspector: false });
   const sidebarPanel = useRef<PanelImperativeHandle>(null);
   const inspectorPanel = useRef<PanelImperativeHandle>(null);
   // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
@@ -426,24 +424,19 @@ function App() {
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
-  const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number; asPercentage: number }) => {
-    // Both halves matter: a window narrow enough for the minimum itself to be under the rail width
-    // would otherwise report a panel sitting on its floor as shut.
-    const min = Number.parseFloat(SIDES[side].min);
-    const next: SideState =
-      size.inPixels <= RAIL + 1 && size.asPercentage < min ? "shut" : size.asPercentage <= min + 0.5 ? "floor" : "open";
+  const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number }) => {
+    const next = size.inPixels < SHUT;
     // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
     // leaving the rail and the number shortcuts counting two different lists.
-    if (side === "sidebar" && next === "shut") setQuery("");
-    setSides((current) => (current[side] === next ? current : { ...current, [side]: next }));
+    if (side === "sidebar" && next) setQuery("");
+    setShut((current) => (current[side] === next ? current : { ...current, [side]: next }));
   }, []);
 
   // The inspector panel goes away with the last session and comes back at its default width, so what
   // the sides remember about it is reset with it rather than corrected by the first measurement.
   const hasSelection = Boolean(selected);
   useEffect(() => {
-    if (!hasSelection)
-      setSides((current) => (current.inspector === "open" ? current : { ...current, inspector: "open" }));
+    if (!hasSelection) setShut((current) => (current.inspector ? { ...current, inspector: false } : current));
   }, [hasSelection]);
 
   useEffect(() => {
@@ -878,14 +871,12 @@ function App() {
           <ResizablePanel
             panelRef={sidebarPanel}
             defaultSize={SIDES.sidebar.size}
-            minSize={SIDES.sidebar.min}
+            minSize={RAIL}
             maxSize={SIDES.sidebar.max}
-            collapsible
-            collapsedSize={RAIL}
             onResize={(size) => rail("sidebar", size)}
           >
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
-              {sides.sidebar === "shut" ? (
+              {shut.sidebar ? (
                 <ScrollArea className="min-h-0 flex-1">
                   <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
                     <ActionIconButton
@@ -894,7 +885,7 @@ function App() {
                       tooltip="Expand sessions"
                       tooltipSide="right"
                       aria-label="Expand sessions"
-                      onClick={() => sidebarPanel.current?.expand()}
+                      onClick={() => sidebarPanel.current?.resize(SIDES.sidebar.size)}
                     >
                       <ChevronRight />
                     </ActionIconButton>
@@ -987,7 +978,7 @@ function App() {
               )}
             </aside>
           </ResizablePanel>
-          <ResizableHandle withHandle className={sides.sidebar === "floor" ? ARMED : ""} />
+          <ResizableHandle withHandle />
           <ResizablePanel defaultSize="55%" minSize="38%">
             <section className="flex h-full min-w-0 flex-col">
               {selected ? (
@@ -1058,22 +1049,20 @@ function App() {
           </ResizablePanel>
           {selected ? (
             <>
-              <ResizableHandle withHandle className={sides.inspector === "floor" ? ARMED : ""} />
+              <ResizableHandle withHandle />
               <ResizablePanel
                 panelRef={inspectorPanel}
                 defaultSize={SIDES.inspector.size}
-                minSize={SIDES.inspector.min}
+                minSize={RAIL}
                 maxSize={SIDES.inspector.max}
-                collapsible
-                collapsedSize={RAIL}
                 onResize={(size) => rail("inspector", size)}
               >
                 <aside className="h-full border-l">
                   <PanelBoundary key={selected.id}>
                     <Inspector
                       session={selected}
-                      collapsed={sides.inspector === "shut"}
-                      onExpand={() => inspectorPanel.current?.expand()}
+                      collapsed={shut.inspector}
+                      onExpand={() => inspectorPanel.current?.resize(SIDES.inspector.size)}
                     />
                   </PanelBoundary>
                 </aside>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,12 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
+  ChevronLeft,
+  ChevronRight,
   GitBranch,
   KeyRound,
   Moon,
   MoreHorizontal,
-  PanelLeftClose,
-  PanelLeftOpen,
   Play,
   Plus,
   RefreshCw,
@@ -905,7 +905,7 @@ function App() {
                       aria-label="Expand sessions"
                       onClick={() => sidebarPanel.current?.resize(SIDES.sidebar.size)}
                     >
-                      <PanelLeftOpen />
+                      <ChevronRight />
                     </ActionIconButton>
                     <ActionIconButton
                       variant="ghost"
@@ -974,7 +974,7 @@ function App() {
                       aria-label="Collapse sessions"
                       onClick={() => sidebarPanel.current?.collapse()}
                     >
-                      <PanelLeftClose />
+                      <ChevronLeft />
                     </ActionIconButton>
                   </div>
                   <ScrollArea className="min-h-0 flex-1">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,8 +84,13 @@ const GLIDE_MS = 200;
 // one being dragged shut and pulled closed again. The ease is driven here instead, a resize per frame,
 // so what the library measures is always what it was last told. A drag owns the panel outright, so a
 // glide gets out of the way the moment one starts.
+const glides = new WeakMap<PanelImperativeHandle, number>();
 function glide(panel: PanelImperativeHandle | null, to: number) {
   if (!panel) return;
+  // One glide owns a side at a time. Two would drive the same panel from two captured widths at once,
+  // which is what shutting a side and reopening it inside the same fifth of a second asks for.
+  const turn = (glides.get(panel) ?? 0) + 1;
+  glides.set(panel, turn);
   const from = panel.getSize().inPixels;
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches || from === to) {
     panel.resize(`${to}px`);
@@ -93,10 +98,16 @@ function glide(panel: PanelImperativeHandle | null, to: number) {
   }
   const started = performance.now();
   const step = (now: number) => {
-    if (document.querySelector("[data-separator=active]")) return;
+    if (glides.get(panel) !== turn || document.querySelector("[data-separator=active]")) return;
     const part = Math.min(1, (now - started) / GLIDE_MS);
-    // Ease out: fastest at the start, so the side answers the click before it settles.
-    panel.resize(`${Math.round(from + (to - from) * (1 - (1 - part) ** 3))}px`);
+    try {
+      // Ease out: fastest at the start, so the side answers the click before it settles.
+      panel.resize(`${Math.round(from + (to - from) * (1 - (1 - part) ** 3))}px`);
+    } catch {
+      // A panel that has gone away — the inspector leaving with the last session — cannot be asked
+      // whether it is still there, only told to resize, so this is the one way to hear that it is not.
+      return;
+    }
     if (part < 1) requestAnimationFrame(step);
   };
   requestAnimationFrame(step);
@@ -456,7 +467,7 @@ function App() {
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
   const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number }) => {
-    const next = size.inPixels <= SHUT + 1;
+    const next = size.inPixels < SHUT;
     // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
     // leaving the rail and the number shortcuts counting two different lists.
     if (side === "sidebar" && next) setQuery("");
@@ -689,8 +700,7 @@ function App() {
   }, [selected, launch]);
 
   // Which repository a folder was cloned from is a fact about the folder, so it is asked for once when
-  // the folder changes and never watched. Keyed by the grant rather than the session, so switching
-  // between sessions in one folder does not ask again.
+  // the selection changes and never watched.
   const rootId = selected?.rootId ?? "";
   useEffect(() => {
     setRemote("");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,9 +69,38 @@ const RAIL = 44;
 // Where a side stops following the pointer. It has no room to be anything but its rail by here, so it
 // becomes one and collapses the rest of the way itself, in one eased step.
 const SHUT = 140;
-// A transition only runs when the property was already transitionable before the value changed, so the
-// ease is armed on the approach rather than at the moment it is needed, which is one commit too late.
-const ARM = 240;
+// A side reopens to the share of the window it started with, in the pixels a glide is measured in.
+function share(panel: PanelImperativeHandle | null, portion: string) {
+  const size = panel?.getSize();
+  if (!size || !size.asPercentage) return 0;
+  return Math.round((size.inPixels / size.asPercentage) * Number.parseFloat(portion));
+}
+
+// How long a side takes to open or close under its own power.
+const GLIDE_MS = 200;
+
+// The library reads every size back off the elements it laid out, so a CSS transition on a panel feeds
+// its own animation into the next layout and the two fight — measurably: an expanding panel is read as
+// one being dragged shut and pulled closed again. The ease is driven here instead, a resize per frame,
+// so what the library measures is always what it was last told. A drag owns the panel outright, so a
+// glide gets out of the way the moment one starts.
+function glide(panel: PanelImperativeHandle | null, to: number) {
+  if (!panel) return;
+  const from = panel.getSize().inPixels;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches || from === to) {
+    panel.resize(`${to}px`);
+    return;
+  }
+  const started = performance.now();
+  const step = (now: number) => {
+    if (document.querySelector("[data-separator=active]")) return;
+    const part = Math.min(1, (now - started) / GLIDE_MS);
+    // Ease out: fastest at the start, so the side answers the click before it settles.
+    panel.resize(`${Math.round(from + (to - from) * (1 - (1 - part) ** 3))}px`);
+    if (part < 1) requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+}
 const SIDES = {
   sidebar: { size: "20%", max: "30%" },
   inspector: { size: "25%", max: "40%" },
@@ -384,10 +413,8 @@ function App() {
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
   const [shut, setShut] = useState({ sidebar: false, inspector: false });
-  const [armed, setArmed] = useState({ sidebar: false, inspector: false });
   const sidebarPanel = useRef<PanelImperativeHandle>(null);
   const inspectorPanel = useRef<PanelImperativeHandle>(null);
-  const panels = useRef({ sidebar: sidebarPanel, inspector: inspectorPanel }).current;
   // The browse URL of the selected folder's origin, empty when it has none or Lite cannot open it.
   const [remote, setRemote] = useState("");
   const [theme, setTheme] = useState<Theme>(initialTheme);
@@ -428,24 +455,13 @@ function App() {
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
-  const rail = useCallback(
-    (side: keyof typeof SIDES, size: { inPixels: number }) => {
-      const next = size.inPixels <= SHUT + 1;
-      // Reaching the point where a side is only a rail is the whole decision, so the side takes the rest
-      // of the way itself rather than asking for another half of it. The library holds it there against
-      // the pointer, and the ease armed on the way in carries it.
-      if (next) panels[side].current?.collapse();
-      // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
-      // leaving the rail and the number shortcuts counting two different lists.
-      if (side === "sidebar" && next) setQuery("");
-      setShut((current) => (current[side] === next ? current : { ...current, [side]: next }));
-      setArmed((current) => {
-        const arm = size.inPixels <= ARM;
-        return current[side] === arm ? current : { ...current, [side]: arm };
-      });
-    },
-    [panels],
-  );
+  const rail = useCallback((side: keyof typeof SIDES, size: { inPixels: number }) => {
+    const next = size.inPixels <= SHUT + 1;
+    // A shut sidebar has nowhere to show a search field, so the filter closes with it rather than
+    // leaving the rail and the number shortcuts counting two different lists.
+    if (side === "sidebar" && next) setQuery("");
+    setShut((current) => (current[side] === next ? current : { ...current, [side]: next }));
+  }, []);
 
   // The inspector panel goes away with the last session and comes back at its default width, so what
   // the sides remember about it is reset with it rather than corrected by the first measurement.
@@ -453,6 +469,20 @@ function App() {
   useEffect(() => {
     if (!hasSelection) setShut((current) => (current.inspector ? { ...current, inspector: false } : current));
   }, [hasSelection]);
+
+  // A side dragged under the width where it can only be a rail is a side being closed, so it closes
+  // the rest of the way once the pointer lets go of it rather than sitting at whatever width the hand
+  // happened to stop at. Under the pointer it stays exactly where the pointer put it.
+  useEffect(() => {
+    const settle = () => {
+      for (const panel of [sidebarPanel.current, inspectorPanel.current]) {
+        const width = panel?.getSize().inPixels;
+        if (panel && width !== undefined && width < SHUT && width > RAIL) glide(panel, RAIL);
+      }
+    };
+    window.addEventListener("pointerup", settle);
+    return () => window.removeEventListener("pointerup", settle);
+  }, []);
 
   useEffect(() => {
     applyTheme(theme);
@@ -886,11 +916,8 @@ function App() {
           <ResizablePanel
             panelRef={sidebarPanel}
             defaultSize={SIDES.sidebar.size}
-            minSize={SHUT}
+            minSize={RAIL}
             maxSize={SIDES.sidebar.max}
-            collapsible
-            collapsedSize={RAIL}
-            data-ease={armed.sidebar || undefined}
             onResize={(size) => rail("sidebar", size)}
           >
             <aside className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
@@ -903,7 +930,7 @@ function App() {
                       tooltip="Expand sessions"
                       tooltipSide="right"
                       aria-label="Expand sessions"
-                      onClick={() => sidebarPanel.current?.resize(SIDES.sidebar.size)}
+                      onClick={() => glide(sidebarPanel.current, share(sidebarPanel.current, SIDES.sidebar.size))}
                     >
                       <ChevronRight />
                     </ActionIconButton>
@@ -972,7 +999,7 @@ function App() {
                       size="icon-sm"
                       tooltip="Collapse sessions"
                       aria-label="Collapse sessions"
-                      onClick={() => sidebarPanel.current?.collapse()}
+                      onClick={() => glide(sidebarPanel.current, RAIL)}
                     >
                       <ChevronLeft />
                     </ActionIconButton>
@@ -1080,11 +1107,8 @@ function App() {
               <ResizablePanel
                 panelRef={inspectorPanel}
                 defaultSize={SIDES.inspector.size}
-                minSize={SHUT}
+                minSize={RAIL}
                 maxSize={SIDES.inspector.max}
-                collapsible
-                collapsedSize={RAIL}
-                data-ease={armed.inspector || undefined}
                 onResize={(size) => rail("inspector", size)}
               >
                 <aside className="h-full border-l">
@@ -1092,8 +1116,10 @@ function App() {
                     <Inspector
                       session={selected}
                       collapsed={shut.inspector}
-                      onExpand={() => inspectorPanel.current?.resize(SIDES.inspector.size)}
-                      onCollapse={() => inspectorPanel.current?.collapse()}
+                      onExpand={() =>
+                        glide(inspectorPanel.current, share(inspectorPanel.current, SIDES.inspector.size))
+                      }
+                      onCollapse={() => glide(inspectorPanel.current, RAIL)}
                     />
                   </PanelBoundary>
                 </aside>

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -8,14 +8,26 @@ function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.GroupPr
   return (
     <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
-      className={cn("flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
+      className={cn("group/panels flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
       {...props}
     />
   );
 }
 
-function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
+// Width is carried by flex-grow, so a panel eases into every size it is given: collapsing, expanding,
+// and the jump a collapse makes. The one exception is a held separator, which has to track the pointer
+// exactly — easing there would leave the panel trailing the hand that moves it.
+function ResizablePanel({ className, ...props }: ResizablePrimitive.PanelProps) {
+  return (
+    <ResizablePrimitive.Panel
+      data-slot="resizable-panel"
+      className={cn(
+        "transition-[flex-grow] duration-200 ease-out group-has-[[data-separator]:active]/panels:transition-none motion-reduce:transition-none",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 function ResizableHandle({
@@ -29,12 +41,14 @@ function ResizableHandle({
     <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        "relative flex w-px items-center justify-center bg-border ring-offset-background after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        "relative flex w-px items-center justify-center bg-border ring-offset-background transition-colors after:absolute after:inset-y-0 after:left-1/2 after:w-2 after:-translate-x-1/2 hover:bg-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden active:bg-ring aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-2 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 hover:[&>div]:bg-ring active:[&>div]:bg-ring [&[aria-orientation=horizontal]>div]:rotate-90",
         className,
       )}
       {...props}
     >
-      {withHandle && <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border" />}
+      {withHandle && (
+        <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border transition-all duration-150 motion-reduce:transition-none" />
+      )}
     </ResizablePrimitive.Separator>
   );
 }

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -39,4 +39,5 @@ function ResizableHandle({
   );
 }
 
+export type { PanelImperativeHandle } from "react-resizable-panels";
 export { ResizableHandle, ResizablePanel, ResizablePanelGroup };

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -8,27 +8,25 @@ function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.GroupPr
   return (
     <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
-      className={cn("group/panels flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
-      {...props}
-    />
-  );
-}
-
-// Width is carried by flex-grow, so a panel eases into every size it is given: collapsing, expanding,
-// and the jump a collapse makes. The one exception is a held separator, which has to track the pointer
-// exactly — easing there would leave the panel trailing the hand that moves it. The library
-// publishes that on data-separator, which a keyboard resize sets too and :active never would.
-function ResizablePanel({ className, ...props }: ResizablePrimitive.PanelProps) {
-  return (
-    <ResizablePrimitive.Panel
-      data-slot="resizable-panel"
       className={cn(
-        "transition-[flex-grow] duration-200 ease-out group-has-[[data-separator=active]]/panels:transition-none motion-reduce:transition-none",
+        "group/panels flex h-full w-full aria-[orientation=vertical]:flex-col",
+        // Width is carried by flex-grow on the panel element the library owns, and a panel's own
+        // className lands on a nested div whose flex-grow never changes, so the ease is declared here
+        // against the child that actually carries the size. It covers every size a panel is given,
+        // including the jump a collapse makes. A separator being dragged is the exception: it has to
+        // track the pointer exactly, and the library publishes that state on data-separator, which a
+        // keyboard resize sets too and :active never would.
+        "[&>[data-panel]]:transition-[flex-grow] [&>[data-panel]]:duration-200 [&>[data-panel]]:ease-out",
+        "has-[[data-separator=active]]:[&>[data-panel]]:transition-none motion-reduce:[&>[data-panel]]:transition-none",
         className,
       )}
       {...props}
     />
   );
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
 }
 
 function ResizableHandle({

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -8,24 +8,11 @@ function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.GroupPr
   return (
     <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
-      className={cn(
-        "group/panels flex h-full w-full aria-[orientation=vertical]:flex-col",
-        // Width is carried by flex-grow on the panel element the library owns, and a panel's own
-        // className lands on a nested div whose flex-grow never changes, so the ease is declared here
-        // against the child that actually carries the size.
-        "[&>[data-panel]]:transition-[flex-grow] [&>[data-panel]]:duration-200 [&>[data-panel]]:ease-out",
-        // A separator being dragged has to track the pointer exactly, so the ease stands aside for it.
-        // The library publishes that state on data-separator, which a keyboard resize sets too and
-        // :active never would.
-        "has-[[data-separator=active]]:[&>[data-panel]]:transition-none",
-        // Except for the one panel that is collapsing. A collapsible panel stops at its minimum and
-        // then covers the rest of the way to its collapsed size in a single step, mid-drag, and that
-        // step is the whole reason to ease anything. A panel says so on data-ease before it can
-        // happen, because it has to be sitting at that minimum first.
-        "has-[[data-separator=active]]:[&>[data-panel][data-ease]]:transition-[flex-grow]",
-        "motion-reduce:[&>[data-panel]]:transition-none!",
-        className,
-      )}
+      // A panel's width is never eased in CSS: the library reads every size back off the elements it
+      // laid out, so an animating width is fed straight back into its own constraints and the two
+      // fight until one of them wins. Motion is driven from App instead, a resize per frame, which
+      // leaves what the library measures equal to what it has just been told.
+      className={cn("flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
       {...props}
     />
   );

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -16,13 +16,14 @@ function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.GroupPr
 
 // Width is carried by flex-grow, so a panel eases into every size it is given: collapsing, expanding,
 // and the jump a collapse makes. The one exception is a held separator, which has to track the pointer
-// exactly — easing there would leave the panel trailing the hand that moves it.
+// exactly — easing there would leave the panel trailing the hand that moves it. The library
+// publishes that on data-separator, which a keyboard resize sets too and :active never would.
 function ResizablePanel({ className, ...props }: ResizablePrimitive.PanelProps) {
   return (
     <ResizablePrimitive.Panel
       data-slot="resizable-panel"
       className={cn(
-        "transition-[flex-grow] duration-200 ease-out group-has-[[data-separator]:active]/panels:transition-none motion-reduce:transition-none",
+        "transition-[flex-grow] duration-200 ease-out group-has-[[data-separator=active]]/panels:transition-none motion-reduce:transition-none",
         className,
       )}
       {...props}
@@ -41,7 +42,7 @@ function ResizableHandle({
     <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        "relative flex w-px items-center justify-center bg-border ring-offset-background transition-colors after:absolute after:inset-y-0 after:left-1/2 after:w-2 after:-translate-x-1/2 hover:bg-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden active:bg-ring aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-2 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 hover:[&>div]:bg-ring active:[&>div]:bg-ring [&[aria-orientation=horizontal]>div]:rotate-90",
+        "relative flex w-px items-center justify-center bg-border ring-offset-background transition-colors after:absolute after:inset-y-0 after:left-1/2 after:w-2 after:-translate-x-1/2 hover:bg-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden data-[separator=active]:bg-ring aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-2 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 hover:[&>div]:bg-ring data-[separator=active]:[&>div]:bg-ring [&[aria-orientation=horizontal]>div]:rotate-90",
         className,
       )}
       {...props}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -12,12 +12,18 @@ function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.GroupPr
         "group/panels flex h-full w-full aria-[orientation=vertical]:flex-col",
         // Width is carried by flex-grow on the panel element the library owns, and a panel's own
         // className lands on a nested div whose flex-grow never changes, so the ease is declared here
-        // against the child that actually carries the size. It covers every size a panel is given,
-        // including the jump a collapse makes. A separator being dragged is the exception: it has to
-        // track the pointer exactly, and the library publishes that state on data-separator, which a
-        // keyboard resize sets too and :active never would.
+        // against the child that actually carries the size.
         "[&>[data-panel]]:transition-[flex-grow] [&>[data-panel]]:duration-200 [&>[data-panel]]:ease-out",
-        "has-[[data-separator=active]]:[&>[data-panel]]:transition-none motion-reduce:[&>[data-panel]]:transition-none",
+        // A separator being dragged has to track the pointer exactly, so the ease stands aside for it.
+        // The library publishes that state on data-separator, which a keyboard resize sets too and
+        // :active never would.
+        "has-[[data-separator=active]]:[&>[data-panel]]:transition-none",
+        // Except for the one panel that is collapsing. A collapsible panel stops at its minimum and
+        // then covers the rest of the way to its collapsed size in a single step, mid-drag, and that
+        // step is the whole reason to ease anything. A panel says so on data-ease before it can
+        // happen, because it has to be sitting at that minimum first.
+        "has-[[data-separator=active]]:[&>[data-panel][data-ease]]:transition-[flex-grow]",
+        "motion-reduce:[&>[data-panel]]:transition-none!",
         className,
       )}
       {...props}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -470,73 +470,80 @@ export function Inspector({
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
 
   // Collapsed, the panel is the strip of tabs it collapsed from: the one you pick is the one it reopens
-  // on. Nothing behind it is mounted meanwhile, so a shut panel reads nothing.
-  if (collapsed)
-    return (
-      <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
-        {TABS.map(({ value, label, icon: Icon }) => (
-          <Tooltip key={value}>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label={label}
-                  onClick={() => {
-                    setTab(value);
-                    onExpand();
-                  }}
-                />
-              }
-            >
-              <Icon />
-            </TooltipTrigger>
-            <TooltipContent side="left">{label}</TooltipContent>
-          </Tooltip>
-        ))}
-      </div>
-    );
+  // on. What it was showing is hidden rather than thrown away, so the file you had open is still open
+  // when it comes back, and a hidden panel reads nothing because nothing here reads without being asked.
+  const rail = (
+    <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
+      {TABS.map(({ value, label, icon: Icon }) => (
+        <Tooltip key={value}>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={label}
+                onClick={() => {
+                  setTab(value);
+                  onExpand();
+                }}
+              />
+            }
+          >
+            <Icon />
+          </TooltipTrigger>
+          <TooltipContent side="left">{label}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
 
   return (
-    <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
-      <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
-        <TabsList variant="line">
-          {TABS.map(({ value, label, icon: Icon }) => (
-            <Tooltip key={value}>
-              <TooltipTrigger render={<TabsTrigger value={value} aria-label={label} />}>
-                <Icon />
-              </TooltipTrigger>
-              <TooltipContent>{label}</TooltipContent>
-            </Tooltip>
-          ))}
-        </TabsList>
-        {tab === "usage" && session.agent === "shell" ? null : (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
-                  aria-label="Refresh"
-                />
-              }
-            >
-              <RefreshCw />
-            </TooltipTrigger>
-            <TooltipContent>Refresh</TooltipContent>
-          </Tooltip>
-        )}
+    <>
+      {collapsed ? rail : null}
+      <div className={collapsed ? "hidden" : "h-full"}>
+        <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
+          <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
+            <TabsList variant="line">
+              {TABS.map(({ value, label, icon: Icon }) => (
+                <Tooltip key={value}>
+                  <TooltipTrigger render={<TabsTrigger value={value} aria-label={label} />}>
+                    <Icon />
+                  </TooltipTrigger>
+                  <TooltipContent>{label}</TooltipContent>
+                </Tooltip>
+              ))}
+            </TabsList>
+            {tab === "usage" && session.agent === "shell" ? null : (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() =>
+                        setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))
+                      }
+                      aria-label="Refresh"
+                    />
+                  }
+                >
+                  <RefreshCw />
+                </TooltipTrigger>
+                <TooltipContent>Refresh</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+          <TabsContent value="files" className="min-h-0 overflow-hidden">
+            <FilesPanel key={reload.files} root={session.cwd} rootId={session.rootId} />
+          </TabsContent>
+          <TabsContent value="git" className="min-h-0 overflow-hidden">
+            <GitPanel key={reload.git} rootId={session.rootId} sessionId={session.id} />
+          </TabsContent>
+          <TabsContent value="usage" className="min-h-0 overflow-hidden">
+            <UsagePanel key={reload.usage} session={session} />
+          </TabsContent>
+        </Tabs>
       </div>
-      <TabsContent value="files" className="min-h-0 overflow-hidden">
-        <FilesPanel key={reload.files} root={session.cwd} rootId={session.rootId} />
-      </TabsContent>
-      <TabsContent value="git" className="min-h-0 overflow-hidden">
-        <GitPanel key={reload.git} rootId={session.rootId} sessionId={session.id} />
-      </TabsContent>
-      <TabsContent value="usage" className="min-h-0 overflow-hidden">
-        <UsagePanel key={reload.usage} session={session} />
-      </TabsContent>
-    </Tabs>
+    </>
   );
 }

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -106,6 +106,7 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
   const [expanded, setExpanded] = useState(() => new Set<string>([root]));
   const loading = useRef(new Set<string>());
   const [loadingPaths, setLoadingPaths] = useState(() => new Set<string>());
+  const [error, setError] = useState("");
 
   const load = useCallback(
     async (path: string, after: DirectoryCursor | null = null) => {
@@ -115,6 +116,11 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
       try {
         const listing = await invoke<DirectoryListing>("list_directory", { rootId, path, after });
         setChildren((current) => ({ ...current, [path]: { ...listing, after } }));
+        setError("");
+      } catch (reason) {
+        // The panel opens its own root now, so a folder that has moved since the session was made says
+        // so rather than drawing an empty tree nobody asked for.
+        setError(String(reason));
       } finally {
         loading.current.delete(path);
         setLoadingPaths((current) => {
@@ -143,7 +149,10 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
 
   function rows(path: string, depth = 0): React.ReactNode {
     const listing = children[path];
-    if (!listing) return loadingPaths.has(path) ? <Loading label="Reading folder…" /> : null;
+    if (!listing) {
+      if (loadingPaths.has(path)) return <Loading label="Reading folder…" />;
+      return error ? <p className="p-3 text-xs text-destructive">{error}</p> : null;
+    }
     return (
       <>
         {listing.entries.map((entry) => (

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -9,9 +9,17 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { DirectoryCursor, DirectoryListing, FileEntry, GitStatus, Session } from "@/types";
 
 const CodePreview = lazy(() => import("@/code-preview"));
+
+// One list so a tab, its icon and the name every surface calls it by cannot drift apart.
+const TABS = [
+  { value: "files", label: "Files", icon: Folder },
+  { value: "git", label: "Git", icon: GitBranch },
+  { value: "usage", label: "Usage", icon: ChartNoAxesColumn },
+] as const;
 
 // Every optional field arrives from Serde as null, never as a missing key.
 interface UsageWindow {
@@ -192,9 +200,16 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
         <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2">
           <File className="size-3.5 shrink-0 text-muted-foreground" />
           <span className="min-w-0 flex-1 truncate font-mono text-xs">{selected.name}</span>
-          <Button variant="ghost" size="icon-xs" onClick={() => setSelected(null)} aria-label="Close file">
-            <X />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button variant="ghost" size="icon-sm" onClick={() => setSelected(null)} aria-label="Close file" />
+              }
+            >
+              <X />
+            </TooltipTrigger>
+            <TooltipContent>Close file</TooltipContent>
+          </Tooltip>
         </div>
         <ScrollArea className="min-h-0 flex-1">
           {error ? (
@@ -390,25 +405,31 @@ export function Inspector({ session }: { session: Session }) {
     <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
         <TabsList variant="line">
-          <TabsTrigger value="files" aria-label="Files">
-            <Folder />
-          </TabsTrigger>
-          <TabsTrigger value="git" aria-label="Git">
-            <GitBranch />
-          </TabsTrigger>
-          <TabsTrigger value="usage" aria-label="Usage">
-            <ChartNoAxesColumn />
-          </TabsTrigger>
+          {TABS.map(({ value, label, icon: Icon }) => (
+            <Tooltip key={value}>
+              <TooltipTrigger render={<TabsTrigger value={value} aria-label={label} />}>
+                <Icon />
+              </TooltipTrigger>
+              <TooltipContent>{label}</TooltipContent>
+            </Tooltip>
+          ))}
         </TabsList>
         {tab === "usage" && session.agent === "shell" ? null : (
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
-            aria-label="Refresh"
-          >
-            <RefreshCw />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
+                  aria-label="Refresh"
+                />
+              }
+            >
+              <RefreshCw />
+            </TooltipTrigger>
+            <TooltipContent>Refresh</TooltipContent>
+          </Tooltip>
         )}
       </div>
       <TabsContent value="files" className="min-h-0 overflow-hidden">

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -19,7 +19,7 @@ const CodePreview = lazy(() => import("@/code-preview"));
 // the output Lite already keeps. Only what Git and GitHub print verbatim counts: a whole pull request
 // link, and the two sentences Git answers a checkout with. A bare "#12" is as often a line number.
 // Only CSI is stripped, so a link inside an OSC hyperlink survives being uncoloured.
-// biome-ignore lint/suspicious/noControlCharactersInRegex: a colour code has to be named to be removed.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const PULL_REQUEST = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/g;
 const BRANCH = /(?:On branch|Switched to(?: a new)? branch) '?([\w./-]+)'?/g;

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -519,7 +519,16 @@ export function Inspector({
       {collapsed ? rail : null}
       <div className={collapsed ? "hidden" : "h-full"}>
         <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
-          <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
+          <div className="flex h-11 shrink-0 items-center gap-1 border-b px-3">
+            <ActionIconButton
+              variant="ghost"
+              size="icon-sm"
+              tooltip="Collapse panel"
+              aria-label="Collapse panel"
+              onClick={onCollapse}
+            >
+              <ChevronRight />
+            </ActionIconButton>
             <TabsList variant="line">
               {TABS.map(({ value, label, icon: Icon }) => (
                 <Tooltip key={value}>
@@ -530,7 +539,7 @@ export function Inspector({
                 </Tooltip>
               ))}
             </TabsList>
-            <span className="flex items-center">
+            <span className="ml-auto flex items-center">
               {tab === "usage" && session.agent === "shell" ? null : (
                 <ActionIconButton
                   variant="ghost"
@@ -542,15 +551,6 @@ export function Inspector({
                   <RefreshCw />
                 </ActionIconButton>
               )}
-              <ActionIconButton
-                variant="ghost"
-                size="icon-sm"
-                tooltip="Collapse panel"
-                aria-label="Collapse panel"
-                onClick={onCollapse}
-              >
-                <ChevronRight />
-              </ActionIconButton>
             </span>
           </div>
           <TabsContent value="files" className="min-h-0 overflow-hidden">

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1,8 +1,8 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { ChartNoAxesColumn, ChevronRight, File, Folder, GitBranch, RefreshCw, X } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { ChartNoAxesColumn, ChevronRight, File, Folder, GitBranch, GitPullRequest, RefreshCw, X } from "lucide-react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,12 +10,37 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { readOutput } from "@/output-store";
 import type { DirectoryCursor, DirectoryListing, FileEntry, GitStatus, Session } from "@/types";
 
 const CodePreview = lazy(() => import("@/code-preview"));
 
-// One list so a tab, its icon and the name every surface calls it by cannot drift apart.
-const TABS = [
+// A session's terminal is the only record of what it worked on, so what it named is read back out of
+// the output Lite already keeps. Only what Git and GitHub print verbatim counts: a whole pull request
+// link, and the two sentences Git answers a checkout with. A bare "#12" is as often a line number.
+// Only CSI is stripped, so a link inside an OSC hyperlink survives being uncoloured.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a colour code has to be named to be removed.
+const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
+const PULL_REQUEST = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/g;
+const BRANCH = /(?:On branch|Switched to(?: a new)? branch) '?([\w./-]+)'?/g;
+
+function namedInSession(sessionId: string) {
+  const text = readOutput(sessionId).replace(COLOR, "");
+  return {
+    branches: [...new Set([...text.matchAll(BRANCH)].map((match) => match[1]))],
+    pulls: [...new Set(text.match(PULL_REQUEST) ?? [])],
+  };
+}
+
+// A pull request is known by its number and the repository it belongs to, not by the URL that reaches it.
+function pullLabel(url: string) {
+  const [owner, repository, , number] = url.split("/").slice(3);
+  return `${owner}/${repository} #${number}`;
+}
+
+// One list so a tab, its icon and the name every surface calls it by cannot drift apart, including the
+// rail the panel collapses to.
+export const INSPECTOR_TABS = [
   { value: "files", label: "Files", icon: Folder },
   { value: "git", label: "Git", icon: GitBranch },
   { value: "usage", label: "Usage", icon: ChartNoAxesColumn },
@@ -66,7 +91,9 @@ function Meter({ value }: { value: number }) {
 
 function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOpen: (entry: FileEntry) => void }) {
   const [children, setChildren] = useState<Record<string, DirectoryListing & { after: DirectoryCursor | null }>>({});
-  const [expanded, setExpanded] = useState(() => new Set<string>());
+  // The root is the folder the session works in; showing it shut asks for a click to say what the
+  // panel is already for, so it opens with the tree it was asked to show.
+  const [expanded, setExpanded] = useState(() => new Set<string>([root]));
   const loading = useRef(new Set<string>());
   const [loadingPaths, setLoadingPaths] = useState(() => new Set<string>());
 
@@ -89,6 +116,10 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
     },
     [rootId],
   );
+
+  useEffect(() => {
+    void load(root);
+  }, [load, root]);
 
   async function toggle(path: string) {
     const next = new Set(expanded);
@@ -232,7 +263,10 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   );
 }
 
-function GitPanel({ rootId }: { rootId: string }) {
+function GitPanel({ rootId, sessionId }: { rootId: string; sessionId: string }) {
+  // Read once when the panel is built, like every other thing this panel shows: the refresh button
+  // rebuilds it, and nothing here watches the session between those two moments.
+  const named = useMemo(() => namedInSession(sessionId), [sessionId]);
   const [status, setStatus] = useState<GitStatus | null>();
   const [error, setError] = useState("");
 
@@ -290,6 +324,32 @@ function GitPanel({ rootId }: { rootId: string }) {
                   ))}
                 </div>
               ) : null}
+              <div className="mt-4">
+                <p className="mb-2 font-medium">Named in this session</p>
+                {named.branches.map((branch) => (
+                  <div key={branch} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+                    <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+                    <span className="truncate font-mono">{branch}</span>
+                  </div>
+                ))}
+                {named.pulls.map((url) => (
+                  <button
+                    key={url}
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-muted"
+                    title={url}
+                    onClick={() => void invoke("open_url", { url })}
+                  >
+                    <GitPullRequest className="size-3.5 shrink-0 text-muted-foreground" />
+                    <span className="truncate font-mono underline-offset-2 hover:underline">{pullLabel(url)}</span>
+                  </button>
+                ))}
+                {named.branches.length || named.pulls.length ? null : (
+                  <p className="px-2 text-muted-foreground">
+                    Branches this session checked out and pull request links it printed appear here.
+                  </p>
+                )}
+              </div>
             </>
           )}
         </div>
@@ -395,17 +455,25 @@ function UsagePanel({ session }: { session: Session }) {
   );
 }
 
-export function Inspector({ session }: { session: Session }) {
-  const [tab, setTab] = useState("files");
+// The open tab is owned outside the panel, so the rail it collapses to can name the tab it reopens.
+export function Inspector({
+  session,
+  tab,
+  onTabChange,
+}: {
+  session: Session;
+  tab: string;
+  onTabChange: (tab: string) => void;
+}) {
   // A tab already names the panel it shows, so the panel does not name itself again. One button beside
   // the tabs rereads whichever is open, by rebuilding it, and only that one ever reads the disk.
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
 
   return (
-    <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
+    <Tabs value={tab} onValueChange={onTabChange} className="h-full min-h-0 gap-0">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
         <TabsList variant="line">
-          {TABS.map(({ value, label, icon: Icon }) => (
+          {INSPECTOR_TABS.map(({ value, label, icon: Icon }) => (
             <Tooltip key={value}>
               <TooltipTrigger render={<TabsTrigger value={value} aria-label={label} />}>
                 <Icon />
@@ -436,7 +504,7 @@ export function Inspector({ session }: { session: Session }) {
         <FilesPanel key={reload.files} root={session.cwd} rootId={session.rootId} />
       </TabsContent>
       <TabsContent value="git" className="min-h-0 overflow-hidden">
-        <GitPanel key={reload.git} rootId={session.rootId} />
+        <GitPanel key={reload.git} rootId={session.rootId} sessionId={session.id} />
       </TabsContent>
       <TabsContent value="usage" className="min-h-0 overflow-hidden">
         <UsagePanel key={reload.usage} session={session} />

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -473,7 +473,7 @@ export function Inspector({
   // on. Nothing behind it is mounted meanwhile, so a shut panel reads nothing.
   if (collapsed)
     return (
-      <div className="flex flex-col items-center gap-1 py-1.5">
+      <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
         {TABS.map(({ value, label, icon: Icon }) => (
           <Tooltip key={value}>
             <TooltipTrigger

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -3,12 +3,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import {
   ChartNoAxesColumn,
+  ChevronLeft,
   ChevronRight,
   File,
   Folder,
   GitBranch,
   GitPullRequest,
-  PanelRightClose,
   RefreshCw,
   X,
 } from "lucide-react";
@@ -485,6 +485,16 @@ export function Inspector({
   // when it comes back, and a hidden panel reads nothing because nothing here reads without being asked.
   const rail = (
     <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
+      <ActionIconButton
+        variant="ghost"
+        size="icon-sm"
+        tooltip="Expand panel"
+        tooltipSide="left"
+        aria-label="Expand panel"
+        onClick={onExpand}
+      >
+        <ChevronLeft />
+      </ActionIconButton>
       {TABS.map(({ value, label, icon: Icon }) => (
         <ActionIconButton
           key={value}
@@ -539,7 +549,7 @@ export function Inspector({
                 aria-label="Collapse panel"
                 onClick={onCollapse}
               >
-                <PanelRightClose />
+                <ChevronRight />
               </ActionIconButton>
             </span>
           </div>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -5,7 +5,7 @@ import { ChartNoAxesColumn, ChevronRight, File, Folder, GitBranch, GitPullReques
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { ActionIconButton } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -231,16 +231,15 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
         <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2">
           <File className="size-3.5 shrink-0 text-muted-foreground" />
           <span className="min-w-0 flex-1 truncate font-mono text-xs">{selected.name}</span>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button variant="ghost" size="icon-sm" onClick={() => setSelected(null)} aria-label="Close file" />
-              }
-            >
-              <X />
-            </TooltipTrigger>
-            <TooltipContent>Close file</TooltipContent>
-          </Tooltip>
+          <ActionIconButton
+            variant="ghost"
+            size="icon-sm"
+            tooltip="Close file"
+            aria-label="Close file"
+            onClick={() => setSelected(null)}
+          >
+            <X />
+          </ActionIconButton>
         </div>
         <ScrollArea className="min-h-0 flex-1">
           {error ? (
@@ -475,24 +474,20 @@ export function Inspector({
   const rail = (
     <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
       {TABS.map(({ value, label, icon: Icon }) => (
-        <Tooltip key={value}>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label={label}
-                onClick={() => {
-                  setTab(value);
-                  onExpand();
-                }}
-              />
-            }
-          >
-            <Icon />
-          </TooltipTrigger>
-          <TooltipContent side="left">{label}</TooltipContent>
-        </Tooltip>
+        <ActionIconButton
+          key={value}
+          variant="ghost"
+          size="icon-sm"
+          tooltip={label}
+          tooltipSide="left"
+          aria-label={label}
+          onClick={() => {
+            setTab(value);
+            onExpand();
+          }}
+        >
+          <Icon />
+        </ActionIconButton>
       ))}
     </div>
   );
@@ -514,23 +509,15 @@ export function Inspector({
               ))}
             </TabsList>
             {tab === "usage" && session.agent === "shell" ? null : (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() =>
-                        setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))
-                      }
-                      aria-label="Refresh"
-                    />
-                  }
-                >
-                  <RefreshCw />
-                </TooltipTrigger>
-                <TooltipContent>Refresh</TooltipContent>
-              </Tooltip>
+              <ActionIconButton
+                variant="ghost"
+                size="icon-sm"
+                tooltip="Refresh"
+                aria-label="Refresh"
+                onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
+              >
+                <RefreshCw />
+              </ActionIconButton>
             )}
           </div>
           <TabsContent value="files" className="min-h-0 overflow-hidden">

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -484,7 +484,7 @@ export function Inspector({
   // on. What it was showing is hidden rather than thrown away, so the file you had open is still open
   // when it comes back, and a hidden panel reads nothing because nothing here reads without being asked.
   const rail = (
-    <div className="flex animate-in flex-col items-center gap-1 py-1.5 fade-in duration-200">
+    <div className="flex animate-in flex-col items-center gap-0.5 py-1.5 fade-in duration-200">
       <ActionIconButton
         variant="ghost"
         size="icon-sm"
@@ -519,7 +519,7 @@ export function Inspector({
       {collapsed ? rail : null}
       <div className={collapsed ? "hidden" : "h-full"}>
         <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
-          <div className="flex h-11 shrink-0 items-center gap-1 border-b px-3">
+          <div className="flex h-11 shrink-0 items-center gap-0.5 border-b pr-3 pl-1.5">
             <ActionIconButton
               variant="ghost"
               size="icon-sm"

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1,7 +1,17 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { ChartNoAxesColumn, ChevronRight, File, Folder, GitBranch, GitPullRequest, RefreshCw, X } from "lucide-react";
+import {
+  ChartNoAxesColumn,
+  ChevronRight,
+  File,
+  Folder,
+  GitBranch,
+  GitPullRequest,
+  PanelRightClose,
+  RefreshCw,
+  X,
+} from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -458,10 +468,12 @@ export function Inspector({
   session,
   collapsed,
   onExpand,
+  onCollapse,
 }: {
   session: Session;
   collapsed: boolean;
   onExpand: () => void;
+  onCollapse: () => void;
 }) {
   const [tab, setTab] = useState<string>(TABS[0].value);
   // A tab already names the panel it shows, so the panel does not name itself again. One button beside
@@ -508,17 +520,28 @@ export function Inspector({
                 </Tooltip>
               ))}
             </TabsList>
-            {tab === "usage" && session.agent === "shell" ? null : (
+            <span className="flex items-center">
+              {tab === "usage" && session.agent === "shell" ? null : (
+                <ActionIconButton
+                  variant="ghost"
+                  size="icon-sm"
+                  tooltip="Refresh"
+                  aria-label="Refresh"
+                  onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
+                >
+                  <RefreshCw />
+                </ActionIconButton>
+              )}
               <ActionIconButton
                 variant="ghost"
                 size="icon-sm"
-                tooltip="Refresh"
-                aria-label="Refresh"
-                onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
+                tooltip="Collapse panel"
+                aria-label="Collapse panel"
+                onClick={onCollapse}
               >
-                <RefreshCw />
+                <PanelRightClose />
               </ActionIconButton>
-            )}
+            </span>
           </div>
           <TabsContent value="files" className="min-h-0 overflow-hidden">
             <FilesPanel key={reload.files} root={session.cwd} rootId={session.rootId} />

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -40,7 +40,7 @@ function pullLabel(url: string) {
 
 // One list so a tab, its icon and the name every surface calls it by cannot drift apart, including the
 // rail the panel collapses to.
-export const INSPECTOR_TABS = [
+const TABS = [
   { value: "files", label: "Files", icon: Folder },
   { value: "git", label: "Git", icon: GitBranch },
   { value: "usage", label: "Usage", icon: ChartNoAxesColumn },
@@ -455,25 +455,53 @@ function UsagePanel({ session }: { session: Session }) {
   );
 }
 
-// The open tab is owned outside the panel, so the rail it collapses to can name the tab it reopens.
 export function Inspector({
   session,
-  tab,
-  onTabChange,
+  collapsed,
+  onExpand,
 }: {
   session: Session;
-  tab: string;
-  onTabChange: (tab: string) => void;
+  collapsed: boolean;
+  onExpand: () => void;
 }) {
+  const [tab, setTab] = useState<string>(TABS[0].value);
   // A tab already names the panel it shows, so the panel does not name itself again. One button beside
   // the tabs rereads whichever is open, by rebuilding it, and only that one ever reads the disk.
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
 
+  // Collapsed, the panel is the strip of tabs it collapsed from: the one you pick is the one it reopens
+  // on. Nothing behind it is mounted meanwhile, so a shut panel reads nothing.
+  if (collapsed)
+    return (
+      <div className="flex flex-col items-center gap-1 py-1.5">
+        {TABS.map(({ value, label, icon: Icon }) => (
+          <Tooltip key={value}>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={label}
+                  onClick={() => {
+                    setTab(value);
+                    onExpand();
+                  }}
+                />
+              }
+            >
+              <Icon />
+            </TooltipTrigger>
+            <TooltipContent side="left">{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    );
+
   return (
-    <Tabs value={tab} onValueChange={onTabChange} className="h-full min-h-0 gap-0">
+    <Tabs value={tab} onValueChange={setTab} className="h-full min-h-0 gap-0">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-3">
         <TabsList variant="line">
-          {INSPECTOR_TABS.map(({ value, label, icon: Icon }) => (
+          {TABS.map(({ value, label, icon: Icon }) => (
             <Tooltip key={value}>
               <TooltipTrigger render={<TabsTrigger value={value} aria-label={label} />}>
                 <Icon />

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -1,13 +1,15 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { FolderOpen } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Check, FolderOpen } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
 
 import { ProviderIcon } from "@/brand-icons";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -41,6 +43,9 @@ const choices: Choice[] = [
   { id: "shell", agent: "shell", description: "Open your default shell" },
 ];
 
+// The quiet heading that separates the two questions the dialog asks, in the sidebar's own label style.
+const SECTION = "text-[11px] font-medium tracking-wide text-muted-foreground uppercase";
+
 interface DirectoryGrant {
   id: string;
   path: string;
@@ -67,6 +72,8 @@ export function NewSessionDialog({
   const [error, setError] = useState("");
   const choice = choices.find((option) => option.id === choiceId) ?? choices[0];
   const status = availability[choice.id];
+  // An agent that is not installed cannot take a session yet, so the dialog offers its setup guide instead.
+  const missing = status && !status.available ? status : undefined;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -151,91 +158,99 @@ export function NewSessionDialog({
     onOpenChange(false);
   }
 
+  // The form owns the one action the dialog is for, so Enter from the folder field starts the session.
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    if (missing)
+      void invoke("open_setup_docs", { agent: choice.agent, provider: choice.provider }).catch((reason) =>
+        setError(String(reason)),
+      );
+    else void create();
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={changeOpen}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>New session</DialogTitle>
-          <DialogDescription>Choose an agent and the folder it should work in.</DialogDescription>
-        </DialogHeader>
-        <div className="-mx-1 space-y-1">
-          {choices.map((option) => {
-            const state = availability[option.id];
-            const row = (
-              <button
-                type="button"
-                aria-pressed={option.id === choiceId}
-                onClick={() => setChoiceId(option.id)}
-                className={`flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors ${option.id === choiceId ? "border-foreground bg-muted" : "border-transparent hover:bg-muted/60"}`}
-              >
-                <ProviderIcon agent={option.agent} provider={option.provider} className="size-5 shrink-0" />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium">{sessionLabel(option)}</span>
-                  <span className="block truncate text-xs text-muted-foreground">{option.description}</span>
-                </span>
-                {state && !state.available ? (
-                  <span className="shrink-0 text-[11px] text-muted-foreground">Not set up</span>
-                ) : null}
-              </button>
-            );
-            return (
-              <div key={option.id}>
-                {option.note ? (
-                  <Tooltip>
-                    <TooltipTrigger render={row} />
-                    <TooltipContent className="max-w-64">{option.note}</TooltipContent>
-                  </Tooltip>
-                ) : (
-                  row
-                )}
+      <DialogContent size="lg">
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>New session</DialogTitle>
+            <DialogDescription>Pick a project folder, then choose the agent that should work in it.</DialogDescription>
+          </DialogHeader>
+          <DialogBody className="space-y-4">
+            <div className="space-y-1.5">
+              <label htmlFor="project-folder" className={SECTION}>
+                Project folder
+              </label>
+              <div className="flex gap-2">
+                <Input
+                  id="project-folder"
+                  value={path}
+                  className="min-w-0 flex-1 font-mono"
+                  placeholder="Type or choose a project folder"
+                  onChange={(event) => setPath(event.target.value)}
+                />
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button variant="outline" size="icon" onClick={chooseFolder} aria-label="Browse for a folder" />
+                    }
+                  >
+                    <FolderOpen />
+                  </TooltipTrigger>
+                  <TooltipContent>Browse</TooltipContent>
+                </Tooltip>
               </div>
-            );
-          })}
-        </div>
-        <div className="flex gap-2">
-          <Input
-            value={path}
-            className="min-w-0 flex-1 font-mono"
-            placeholder="Type or choose a project folder"
-            aria-label="Project folder"
-            onChange={(event) => setPath(event.target.value)}
-            onBlur={() => void grant()}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") void grant();
-            }}
-          />
-          <Tooltip>
-            <TooltipTrigger
-              render={<Button variant="outline" size="icon" onClick={chooseFolder} aria-label="Browse for a folder" />}
-            >
-              <FolderOpen />
-            </TooltipTrigger>
-            <TooltipContent>Browse</TooltipContent>
-          </Tooltip>
-        </div>
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
-        {status && !status.available ? <p className="text-xs text-muted-foreground">{status.detail}</p> : null}
-        <DialogFooter>
-          <Button variant="outline" onClick={() => changeOpen(false)}>
-            Cancel
-          </Button>
-          {status && !status.available ? (
-            <Button
-              onClick={() =>
-                void invoke("open_setup_docs", { agent: choice.agent, provider: choice.provider }).catch((reason) =>
-                  setError(String(reason)),
-                )
-              }
-            >
-              Open setup guide
+              {error ? <p className="text-xs text-destructive">{error}</p> : null}
+            </div>
+            <fieldset className="space-y-1.5">
+              <legend className={SECTION}>Agent</legend>
+              <div className="space-y-1">
+                {choices.map((option) => {
+                  const state = availability[option.id];
+                  const active = option.id === choiceId;
+                  const row = (
+                    <button
+                      key={option.id}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => setChoiceId(option.id)}
+                      className={`flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-colors ${active ? "border-ring bg-accent" : "border-transparent hover:bg-muted/60"}`}
+                    >
+                      {/* The same tile the session wears in the sidebar, so the choice looks like its result. */}
+                      <span className="flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
+                        <ProviderIcon agent={option.agent} provider={option.provider} />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium">{sessionLabel(option)}</span>
+                        <span className="block truncate text-xs text-muted-foreground">{option.description}</span>
+                      </span>
+                      {state && !state.available ? <Badge variant="outline">Not set up</Badge> : null}
+                      <Check className={`size-4 shrink-0 ${active ? "" : "invisible"}`} />
+                    </button>
+                  );
+                  return option.note ? (
+                    <Tooltip key={option.id}>
+                      <TooltipTrigger render={row} />
+                      <TooltipContent className="max-w-64">{option.note}</TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    row
+                  );
+                })}
+              </div>
+              {missing ? <p className="text-xs text-muted-foreground">{missing.detail}</p> : null}
+            </fieldset>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => changeOpen(false)}>
+              Cancel
             </Button>
-          ) : (
-            <Button disabled={!path.trim() || !status} onClick={() => void create()}>
+            <Button type="submit" disabled={!missing && (!path.trim() || !status)}>
               {status ? null : <Spinner />}
-              Start session
+              {missing ? "Open setup guide" : "Start session"}
             </Button>
-          )}
-        </DialogFooter>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -6,7 +6,7 @@ import { type FormEvent, useEffect, useState } from "react";
 
 import { ProviderIcon } from "@/brand-icons";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { ActionIconButton, Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogBody,
@@ -196,18 +196,16 @@ export function NewSessionDialog({
                   placeholder="Type or choose a project folder"
                   onChange={(event) => setPath(event.target.value)}
                 />
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button variant="outline" size="icon" onClick={chooseFolder} aria-label="Browse for a folder" />
-                    }
-                  >
-                    <FolderOpen />
-                  </TooltipTrigger>
-                  <TooltipContent>Browse</TooltipContent>
-                </Tooltip>
+                <ActionIconButton
+                  variant="outline"
+                  size="icon"
+                  tooltip="Browse"
+                  aria-label="Browse for a folder"
+                  onClick={chooseFolder}
+                >
+                  <FolderOpen />
+                </ActionIconButton>
               </div>
-              {error ? <p className="text-xs text-destructive">{error}</p> : null}
             </div>
             <fieldset className="space-y-1.5">
               <legend className={SECTION}>Agent</legend>
@@ -247,6 +245,8 @@ export function NewSessionDialog({
               </div>
               {missing ? <p className="text-xs text-muted-foreground">{missing.detail}</p> : null}
             </fieldset>
+            {/* Written by the folder and by the setup guide alike, so it sits with neither and above both. */}
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
           </DialogBody>
           <DialogFooter>
             <Button variant="outline" onClick={() => changeOpen(false)}>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -158,14 +158,21 @@ export function NewSessionDialog({
     onOpenChange(false);
   }
 
-  // The form owns the one action the dialog is for, so Enter from the folder field starts the session.
-  function submit(event: FormEvent) {
-    event.preventDefault();
+  // Everything the dialog can be asked for arrives here: the submit button, Enter from the folder field,
+  // and a second click on the agent already chosen. An agent that is not installed reads them all as a
+  // request for its setup guide, which is the only one of the two it can answer.
+  const ready = Boolean(missing || (path.trim() && status));
+  function start() {
     if (missing)
       void invoke("open_setup_docs", { agent: choice.agent, provider: choice.provider }).catch((reason) =>
         setError(String(reason)),
       );
     else void create();
+  }
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    start();
   }
 
   return (
@@ -213,7 +220,7 @@ export function NewSessionDialog({
                       key={option.id}
                       type="button"
                       aria-pressed={active}
-                      onClick={() => setChoiceId(option.id)}
+                      onClick={() => (active && ready ? start() : setChoiceId(option.id))}
                       className={`flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-colors ${active ? "border-ring bg-accent" : "border-transparent hover:bg-muted/60"}`}
                     >
                       {/* The same tile the session wears in the sidebar, so the choice looks like its result. */}
@@ -245,7 +252,7 @@ export function NewSessionDialog({
             <Button variant="outline" onClick={() => changeOpen(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={!missing && (!path.trim() || !status)}>
+            <Button type="submit" disabled={!ready}>
               {status ? null : <Spinner />}
               {missing ? "Open setup guide" : "Start session"}
             </Button>

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -33,6 +33,16 @@ export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) 
   };
 }
 
+// The buffer is bytes because a terminal is bytes. Anything that wants to read back what a session
+// said needs the same bytes as text, decoded as one stream so a character split across two chunks
+// survives the join.
+export function readOutput(sessionId: string) {
+  const buffer = buffers.get(sessionId);
+  if (!buffer) return "";
+  const decoder = new TextDecoder();
+  return buffer.chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") + decoder.decode();
+}
+
 export function clearOutput(sessionId: string) {
   buffers.delete(sessionId);
 }

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -8,6 +8,7 @@ import { ProviderIcon } from "@/brand-icons";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -16,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Agent, ModelProvider } from "@/types";
 
 // Each CLI signs in on its own; a key here is the alternative for anyone who would rather not.
@@ -139,7 +141,7 @@ export function SettingsDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent size="lg">
         <DialogHeader>
           <DialogTitle>API keys</DialogTitle>
           <DialogDescription>
@@ -147,7 +149,7 @@ export function SettingsDialog({
             on this computer in Lite's data folder and reach a session through its provider's environment variable.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-3">
+        <DialogBody className="space-y-3">
           {providers.map((option) => {
             const status = auth?.find((entry) => entry.name === option.id);
             const open = editing.has(option.id);
@@ -175,22 +177,29 @@ export function SettingsDialog({
                           if (event.key === "Escape") edit(option.id, false);
                         }}
                       />
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        className="absolute right-1"
-                        aria-label={revealed.has(option.id) ? "Hide the key" : "Show the key"}
-                        onClick={() =>
-                          setRevealed((current) => {
-                            const next = new Set(current);
-                            if (next.has(option.id)) next.delete(option.id);
-                            else next.add(option.id);
-                            return next;
-                          })
-                        }
-                      >
-                        {revealed.has(option.id) ? <EyeOff /> : <Eye />}
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              className="absolute right-0.5"
+                              aria-label={revealed.has(option.id) ? "Hide the key" : "Show the key"}
+                              onClick={() =>
+                                setRevealed((current) => {
+                                  const next = new Set(current);
+                                  if (next.has(option.id)) next.delete(option.id);
+                                  else next.add(option.id);
+                                  return next;
+                                })
+                              }
+                            />
+                          }
+                        >
+                          {revealed.has(option.id) ? <EyeOff /> : <Eye />}
+                        </TooltipTrigger>
+                        <TooltipContent>{revealed.has(option.id) ? "Hide the key" : "Show the key"}</TooltipContent>
+                      </Tooltip>
                     </span>
                     <Button
                       variant="outline"
@@ -229,23 +238,31 @@ export function SettingsDialog({
                       {status?.keyHint ? "Replace" : "Use a key"}
                     </Button>
                     {status?.keyHint ? (
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        disabled={busy === option.id}
-                        onClick={() => void remove(option.id)}
-                        aria-label={`Delete the ${option.label} key`}
-                      >
-                        {busy === option.id ? <Spinner /> : <Trash2 />}
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              className="hover:text-destructive"
+                              disabled={busy === option.id}
+                              onClick={() => void remove(option.id)}
+                              aria-label={`Delete the ${option.label} key`}
+                            />
+                          }
+                        >
+                          {busy === option.id ? <Spinner /> : <Trash2 />}
+                        </TooltipTrigger>
+                        <TooltipContent>Delete this key</TooltipContent>
+                      </Tooltip>
                     ) : null}
                   </>
                 )}
               </div>
             );
           })}
-        </div>
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        </DialogBody>
         <DialogFooter>
           <Button onClick={() => onOpenChange(false)}>Done</Button>
         </DialogFooter>

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -5,7 +5,7 @@ import { Check, Eye, EyeOff, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import { ProviderIcon } from "@/brand-icons";
-import { Button } from "@/components/ui/button";
+import { ActionIconButton, Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogBody,
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Agent, ModelProvider } from "@/types";
 
 // Each CLI signs in on its own; a key here is the alternative for anyone who would rather not.
@@ -177,29 +176,23 @@ export function SettingsDialog({
                           if (event.key === "Escape") edit(option.id, false);
                         }}
                       />
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="absolute right-0.5"
-                              aria-label={revealed.has(option.id) ? "Hide the key" : "Show the key"}
-                              onClick={() =>
-                                setRevealed((current) => {
-                                  const next = new Set(current);
-                                  if (next.has(option.id)) next.delete(option.id);
-                                  else next.add(option.id);
-                                  return next;
-                                })
-                              }
-                            />
-                          }
-                        >
-                          {revealed.has(option.id) ? <EyeOff /> : <Eye />}
-                        </TooltipTrigger>
-                        <TooltipContent>{revealed.has(option.id) ? "Hide the key" : "Show the key"}</TooltipContent>
-                      </Tooltip>
+                      <ActionIconButton
+                        variant="ghost"
+                        size="icon-sm"
+                        className="absolute right-0.5"
+                        tooltip={revealed.has(option.id) ? "Hide the key" : "Show the key"}
+                        aria-label={revealed.has(option.id) ? "Hide the key" : "Show the key"}
+                        onClick={() =>
+                          setRevealed((current) => {
+                            const next = new Set(current);
+                            if (next.has(option.id)) next.delete(option.id);
+                            else next.add(option.id);
+                            return next;
+                          })
+                        }
+                      >
+                        {revealed.has(option.id) ? <EyeOff /> : <Eye />}
+                      </ActionIconButton>
                     </span>
                     <Button
                       variant="outline"
@@ -238,23 +231,17 @@ export function SettingsDialog({
                       {status?.keyHint ? "Replace" : "Use a key"}
                     </Button>
                     {status?.keyHint ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="hover:text-destructive"
-                              disabled={busy === option.id}
-                              onClick={() => void remove(option.id)}
-                              aria-label={`Delete the ${option.label} key`}
-                            />
-                          }
-                        >
-                          {busy === option.id ? <Spinner /> : <Trash2 />}
-                        </TooltipTrigger>
-                        <TooltipContent>Delete this key</TooltipContent>
-                      </Tooltip>
+                      <ActionIconButton
+                        variant="ghost"
+                        size="icon-sm"
+                        className="hover:text-destructive"
+                        tooltip="Delete this key"
+                        aria-label={`Delete the ${option.label} key`}
+                        disabled={busy === option.id}
+                        onClick={() => void remove(option.id)}
+                      >
+                        {busy === option.id ? <Spinner /> : <Trash2 />}
+                      </ActionIconButton>
                     ) : null}
                   </>
                 )}

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -188,9 +188,10 @@ export function TerminalView({
   // and it only subtracts padding declared on the terminal's own element. Padding here would be
   // counted as usable space, so the terminal laid out a row and three columns more than fit and hung
   // them past the edge, which also left the last row below the viewport where the scrollbar could
-  // neither show nor reach it.
+  // neither show nor reach it. The bottom gutter is deeper than the rest for the same reason it is
+  // there at all: the row the terminal cannot quite fit should end above the edge, not against it.
   return (
-    <div className="h-full w-full bg-background p-3">
+    <div className="h-full w-full bg-background p-3 pb-6">
       <div ref={containerRef} className="h-full w-full" />
     </div>
   );

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -154,7 +154,14 @@ export function TerminalView({
         rows: terminal.rows,
       });
     };
-    const observer = new ResizeObserver(() => requestAnimationFrame(resize));
+    // A width change arrives as a stream of frames: a drag, or the ease a collapsing panel runs
+    // through. Fitting on each one rewraps the scrollback and hands the child a window size it is
+    // never shown at, so the terminal is fitted once the size has settled.
+    let settle = 0;
+    const observer = new ResizeObserver(() => {
+      window.clearTimeout(settle);
+      settle = window.setTimeout(resize, 100);
+    });
     observer.observe(container);
     // Command and the zoom keys resize the type, as they do in a terminal app.
     terminal.attachCustomKeyEventHandler((event) => {
@@ -171,6 +178,7 @@ export function TerminalView({
     terminal.focus();
 
     return () => {
+      window.clearTimeout(settle);
       observer.disconnect();
       input.dispose();
       unsubscribe();


### PR DESCRIPTION
Ships as **0.0.6** (`src-tauri/Cargo.toml`, which `publish.yml` keys the release off).

### Sidebar

- A search field takes the place of the `SESSIONS` title — it names the panel and searches it, so the list keeps the row a separate title would cost. Filters on session name and folder, `Escape` clears it, and `⌘1`–`⌘9` follow what the list is showing.
- Session names truncated ~60px early: the restart and close buttons were hidden with `opacity-0`, which keeps their width. They leave the layout until the row is hovered or focused.
- Clicking a stopped session always resumes it, including when it is the tab already open. Only a session that is open *and running* reads a click as a rename.

### Collapsing

- Both sides collapse to a 44px rail instead of the left vanishing at 0% and the right not collapsing at all. The sidebar keeps its new-session button, an expand button and one badge per session; the inspector becomes the tab strip it collapsed from and reopens on the tab you pick. The badge is one component shared by the row and the rail.
- Panel width is `flex-grow`, so a transition on it eases every size a panel is given, including the jump a collapse makes. A separator being dragged is exempt — a drag has to track the pointer exactly.
- The library pins a collapsible panel at its minimum and holds it there until the drag passes half the gap to the collapsed size; at a 15% minimum that is most of a hundred pixels of dragging with nothing to show. Each side reports that pause and the handle held there thickens and takes the accent color. Both the transition and that hint key off `data-separator`, which the library also sets for a keyboard resize.
- The terminal fits once a size settles rather than on every frame of it. Each fit rewraps the scrollback and hands the child a window size it is never shown at, and an eased collapse produced a dozen of them per click.

### Inspector

- Files, Git and Usage tabs, refresh, close-file, the top bar menu and the key dialog's reveal and delete buttons had an `aria-label` and nothing a pointer could read. All have tooltips, and the two that drew a 12px glyph beside 16px ones are `icon-sm` like the rest.
- The Git panel lists the branches and pull requests the session named, read out of the output Lite already keeps. Only whole GitHub pull request links and the two sentences Git answers a checkout with — a bare `#12` is as often a line number. Each pull request opens on GitHub in one click.
- The files panel opens on the folder the session works in instead of asking for a click to expand the one directory it shows.
- Collapsing hides the panel rather than discarding it, so the file you had open survives.

### Dialogs

- The new session and API keys dialogs put their contents straight into the popup, which carries no padding of its own, so rows ran to the edge. Both use `DialogBody`, which also lets a short window scroll the body instead of clipping the footer. Every dialog asks for its width through the `size` prop.
- The new session dialog asks for the folder first, then the agent — the order the workspace empty state already describes. Both sections are labelled and an agent's setup detail sits under the list it belongs to.
- The dialog is a form, so **Enter starts the session**, and clicking the agent already chosen starts it too. The two mutually exclusive primary buttons collapse into one submit button. The folder is validated on submit alone; granting it again on blur was redundant and could outlive the closed dialog.

### Top bar

- Names the repository the session's folder was cloned from and opens it in a browser on click. Asked for on its own rather than through `git_status`, which reads the whole worktree, and only when the folder changes. Only the https and ssh forms that can become a browse URL get a link.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite 0.0.6 improves workspace navigation, session discovery, Git context, panel usability, and CI build speed. 🚀

### 📊 Key Changes

- Added collapsible sidebar and inspector rails with animated resizing and improved drag handles.
- Added session search by name or working directory, with keyboard shortcuts following filtered results.
- Added Git repository links to the workspace header and surfaced branches and GitHub pull requests mentioned in session output.
- Improved the Git file tree by opening the project root automatically and displaying directory-loading errors.
- Redesigned the new-session dialog with clearer project-folder and agent selection sections, better keyboard submission, and setup-guide handling for unavailable agents.
- Improved tooltips and icon-button consistency across session controls, settings, dialogs, and inspector tabs.
- Debounced terminal resizing to prevent excessive reflow during panel resizing and added extra bottom spacing for better scrolling.
- Optimized CI to compile and link the app without creating installer bundles, significantly reducing build time.
- Updated the Lite application version from 0.0.5 to 0.0.6 and refined `.gitignore` behavior.

### 🎯 Purpose & Impact

- Makes Lite easier to navigate, especially when managing many sessions or working with limited screen space. 🧭
- Provides more useful repository context without requiring users to leave the app to find branches or pull requests. 🔗
- Improves reliability and clarity when folders are unavailable, agents are not installed, or terminal dimensions change.
- Reduces CI turnaround time by moving installer packaging out of the compile-validation workflow, while preserving packaging for release workflows. ⚡
- Delivers a more polished and accessible interface through clearer controls, tooltips, reduced-motion support, and smoother panel interactions. ✨
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
