### PR TITLE
Title tabs with what the session is doing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,17 @@ Lite is available under the [AGPL-3.0 License](LICENSE). For commercial licensin
 
 <br>
 <div align="center">
-  <a href="https://github.com/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://twitter.com/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://www.youtube.com/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://discord.com/invite/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,13 +133,17 @@ Lite 基于 [AGPL-3.0 许可证](LICENSE) 提供。如需商业许可，请联�
 
 <br>
 <div align="center">
-  <a href="https://github.com/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://twitter.com/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://www.youtube.com/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
-  <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://discord.com/invite/ultralytics"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
 </div>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1384,11 +1384,6 @@ fn agent_command(
         }
         "codex" => {
             let mut command = CommandBuilder::new("codex");
-            // Codex names the window after the folder, which the tab is named after already, unless it
-            // is asked for the thread's own title instead. An item identifier it does not know leaves
-            // the window unnamed rather than failing, so a Codex that renames this one costs the tab
-            // nothing it had before.
-            command.args(["-c", "tui.terminal_title=[\"thread-title\"]"]);
             // DeepSeek is selected per launch so the default Codex provider stays whatever the user set.
             if provider == Some("deepseek") {
                 let key = saved_api_key(app, agent, provider).is_some();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1384,6 +1384,11 @@ fn agent_command(
         }
         "codex" => {
             let mut command = CommandBuilder::new("codex");
+            // Codex names the window after the folder, which the tab is named after already, unless it
+            // is asked for the thread's own title instead. An item identifier it does not know leaves
+            // the window unnamed rather than failing, so a Codex that renames this one costs the tab
+            // nothing it had before.
+            command.args(["-c", "tui.terminal_title=[\"thread-title\"]"]);
             // DeepSeek is selected per launch so the default Codex provider stays whatever the user set.
             if provider == Some("deepseek") {
                 let key = saved_api_key(app, agent, provider).is_some();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1369,7 +1369,6 @@ fn agent_command(
     resume: bool,
     session_id: &str,
     provider_session_id: Option<&str>,
-    name: &str,
 ) -> Result<CommandBuilder, String> {
     let mut command = match agent {
         "claude" => {
@@ -1377,7 +1376,9 @@ fn agent_command(
             if resume {
                 command.args(["--resume", session_id]);
             } else {
-                command.args(["--session-id", session_id, "--name", name]);
+                // Naming the session after its folder is the one thing that stops Claude Code from
+                // naming it after what it is doing, and that name is what the tab is titled with.
+                command.args(["--session-id", session_id]);
             }
             command
         }
@@ -1598,7 +1599,6 @@ async fn spawn_session(
     provider: Option<String>,
     mode: Option<String>,
     theme: Option<String>,
-    name: String,
     resume: bool,
     cols: u16,
     rows: u16,
@@ -1686,7 +1686,6 @@ async fn spawn_session(
             resume,
             &session_id,
             provider_session_id.as_deref(),
-            &name,
         )?
     };
     if !signing_in && agent == "claude" {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -415,10 +415,6 @@ function shortPath(cwd: string) {
 // program that sets none. A leading glyph is a spinner or a status mark rather than part of the
 // subject, and it changes several times a second while saying nothing the badge does not already say,
 // so the name is what follows it. A name the user chose is left alone.
-// Codex names the window after the thread it is working on, and reports the thread's id until it has
-// named it. An id is not a subject.
-const THREAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 function subject(text: string) {
   const words = text
     .replace(/^[\p{S}\p{P}]\s+/u, "")
@@ -626,15 +622,18 @@ function App() {
 
   // A working session retitles itself several times a second, nearly always to what the tab already
   // says, so the list it would re-render is handed back untouched unless the subject really changed.
-  // A sign-in tab says what it is for and is gone as soon as it is done, and not every title is a
-  // subject: a program with nothing to say yet names the window after itself, which the badge already
-  // says and the folder name beats.
+  // A sign-in tab says what it is for and is gone as soon as it is done. And not every title is a
+  // subject: a program with nothing of its own to say names the window after itself or after the
+  // folder it was started in, which the badge and the tab's own name already say, and taking those
+  // would undo the subject a tab had already been given.
   const markTitle = useCallback((sessionId: string, title: string) => {
     setSessions((current) => {
       const session = current.find((item) => item.id === sessionId);
       if (!session || session.mode || session.renamed) return current;
       const name = subject(title);
-      if (!name || name === session.name || name === sessionLabel(session) || THREAD_ID.test(name)) return current;
+      if (!name || name === session.name || name === sessionLabel(session) || name === folderName(session.cwd)) {
+        return current;
+      }
       return current.map((item) => (item.id === sessionId ? { ...item, name } : item));
     });
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,7 +208,15 @@ function VersionBadge({
 function loadSessions(): Session[] {
   try {
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]") as Session[];
-    return stored.filter((session) => session.rootId).map((session) => ({ ...session, running: false }));
+    // A session stored before Lite read window titles kept no record of who named it, so a name it did
+    // not get from its folder is treated as the user's rather than replaced by the first title to arrive.
+    return stored
+      .filter((session) => session.rootId)
+      .map((session) => ({
+        ...session,
+        running: false,
+        renamed: session.renamed ?? session.name !== folderName(session.cwd),
+      }));
   } catch {
     return [];
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -403,9 +403,15 @@ function shortPath(cwd: string) {
 }
 
 // A tab named after its folder says nothing, and several in one folder say the same nothing, so the
-// first thing asked of the session becomes its subject. A name the user chose is left alone.
-function promptName(text: string) {
-  const words = text.replace(/\s+/g, " ").trim();
+// session says what it is about: the window title its program sets, or the first thing asked of a
+// program that sets none. A leading glyph is a spinner or a status mark rather than part of the
+// subject, and it changes several times a second while saying nothing the badge does not already say,
+// so the name is what follows it. A name the user chose is left alone.
+function subject(text: string) {
+  const words = text
+    .replace(/^[\p{S}\p{P}]\s+/u, "")
+    .replace(/\s+/g, " ")
+    .trim();
   return words.length > 40 ? `${words.slice(0, 40).trimEnd()}…` : words;
 }
 
@@ -606,6 +612,22 @@ function App() {
     );
   }, []);
 
+  // A working session retitles itself several times a second, nearly always to what the tab already
+  // says, so the list it would re-render is handed back untouched unless the subject really changed.
+  // A program that has nothing to say yet names the window after itself, which the badge already says
+  // and the folder name beats, and a sign-in tab says what it is for and is gone as soon as it is done.
+  const markTitle = useCallback((sessionId: string, title: string) => {
+    setSessions((current) => {
+      const name = subject(title);
+      if (!name) return current;
+      const session = current.find((item) => item.id === sessionId);
+      if (!session || session.mode || session.renamed || session.name === name || name === sessionLabel(session)) {
+        return current;
+      }
+      return current.map((item) => (item.id === sessionId ? { ...item, name } : item));
+    });
+  }, []);
+
   useEffect(() => {
     let disposed = false;
     let unlistenOutput: (() => void) | undefined;
@@ -613,7 +635,8 @@ function App() {
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
-        appendOutput(payload.sessionId, payload.data);
+        const title = appendOutput(payload.sessionId, payload.data);
+        if (title) markTitle(payload.sessionId, title);
         markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
@@ -640,7 +663,7 @@ function App() {
       for (const timer of timers.values()) window.clearTimeout(timer);
       timers.clear();
     };
-  }, [markWorking]);
+  }, [markWorking, markTitle]);
 
   const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return;
@@ -658,7 +681,6 @@ function App() {
         provider: session.provider,
         mode: session.mode,
         theme: themeRef.current,
-        name: session.name,
         resume,
         cols: 100,
         rows: 30,
@@ -1029,7 +1051,7 @@ function App() {
                           onSelect={() => openRef.current(session)}
                           onRename={(name) =>
                             setSessions((current) =>
-                              current.map((item) => (item.id === session.id ? { ...item, name } : item)),
+                              current.map((item) => (item.id === session.id ? { ...item, name, renamed: true } : item)),
                             )
                           }
                           onRestart={() => void restartSession(session)}
@@ -1055,8 +1077,8 @@ function App() {
                         onPrompt={(text) =>
                           setSessions((current) =>
                             current.map((item) =>
-                              item.id === selected.id && item.name === folderName(item.cwd)
-                                ? { ...item, name: promptName(text) }
+                              item.id === selected.id && !item.renamed && item.name === folderName(item.cwd)
+                                ? { ...item, name: subject(text) }
                                 : item,
                             ),
                           )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -407,6 +407,10 @@ function shortPath(cwd: string) {
 // program that sets none. A leading glyph is a spinner or a status mark rather than part of the
 // subject, and it changes several times a second while saying nothing the badge does not already say,
 // so the name is what follows it. A name the user chose is left alone.
+// Codex names the window after the thread it is working on, and reports the thread's id until it has
+// named it. An id is not a subject.
+const THREAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function subject(text: string) {
   const words = text
     .replace(/^[\p{S}\p{P}]\s+/u, "")
@@ -614,16 +618,15 @@ function App() {
 
   // A working session retitles itself several times a second, nearly always to what the tab already
   // says, so the list it would re-render is handed back untouched unless the subject really changed.
-  // A program that has nothing to say yet names the window after itself, which the badge already says
-  // and the folder name beats, and a sign-in tab says what it is for and is gone as soon as it is done.
+  // A sign-in tab says what it is for and is gone as soon as it is done, and not every title is a
+  // subject: a program with nothing to say yet names the window after itself, which the badge already
+  // says and the folder name beats.
   const markTitle = useCallback((sessionId: string, title: string) => {
     setSessions((current) => {
-      const name = subject(title);
-      if (!name) return current;
       const session = current.find((item) => item.id === sessionId);
-      if (!session || session.mode || session.renamed || session.name === name || name === sessionLabel(session)) {
-        return current;
-      }
+      if (!session || session.mode || session.renamed) return current;
+      const name = subject(title);
+      if (!name || name === session.name || name === sessionLabel(session) || THREAD_ID.test(name)) return current;
       return current.map((item) => (item.id === sessionId ? { ...item, name } : item));
     });
   }, []);

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -10,7 +10,28 @@ interface Buffer {
 const buffers = new Map<string, Buffer>();
 const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 
-export function appendOutput(sessionId: string, data: number[]) {
+// A program names the window it runs in with OSC 0 or 2, and an agent names it with a short summary of
+// what the session is doing. The title arrives in the output whether or not the session is the one on
+// screen, so it is read here, where every session's bytes land, rather than from the single terminal
+// that happens to be mounted.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
+const TITLE = /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+
+// The same sequence begun but not yet terminated, which the chunk that ends it completes. Anything
+// longer than a title could be is no longer one, so the wait is given up rather than grown.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
+const PARTIAL = /\x1b(?:\][^\x07\x1b]*)?$/;
+const MAX_PARTIAL = 512;
+
+interface Stream {
+  decoder: TextDecoder;
+  partial: string;
+}
+
+const streams = new Map<string, Stream>();
+
+// Returns the last window title the chunk set, empty when it set none.
+export function appendOutput(sessionId: string, data: number[]): string {
   const bytes = new Uint8Array(data);
   const buffer = buffers.get(sessionId) ?? { chunks: [], size: 0 };
   buffer.chunks.push(bytes);
@@ -21,6 +42,20 @@ export function appendOutput(sessionId: string, data: number[]) {
   }
   buffers.set(sessionId, buffer);
   for (const listener of listeners.get(sessionId) ?? []) listener(bytes);
+  // Decoded as one stream, so neither a character nor a sequence split across two chunks is misread.
+  const stream = streams.get(sessionId) ?? { decoder: new TextDecoder(), partial: "" };
+  streams.set(sessionId, stream);
+  const text = stream.partial + stream.decoder.decode(bytes, { stream: true });
+  let title = "";
+  let read = 0;
+  TITLE.lastIndex = 0;
+  for (let match = TITLE.exec(text); match; match = TITLE.exec(text)) {
+    title = match[1];
+    read = TITLE.lastIndex;
+  }
+  const partial = text.slice(read).match(PARTIAL)?.[0] ?? "";
+  stream.partial = partial.length > MAX_PARTIAL ? "" : partial;
+  return title;
 }
 
 export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) => void) {
@@ -45,4 +80,5 @@ export function readOutput(sessionId: string) {
 
 export function clearOutput(sessionId: string) {
   buffers.delete(sessionId);
+  streams.delete(sessionId);
 }

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -5,6 +5,10 @@ const MAX_BYTES = 1_000_000;
 interface Buffer {
   chunks: Uint8Array[];
   size: number;
+  // Read as one stream, so neither a character nor a sequence split across two chunks is misread: the
+  // decoder holds a character's remaining bytes and the tail holds an unfinished sequence.
+  decoder: TextDecoder;
+  tail: string;
 }
 
 const buffers = new Map<string, Buffer>();
@@ -20,20 +24,13 @@ const TITLE = /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 // The same sequence begun but not yet terminated, which the chunk that ends it completes. Anything
 // longer than a title could be is no longer one, so the wait is given up rather than grown.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
-const PARTIAL = /\x1b(?:\][^\x07\x1b]*)?$/;
-const MAX_PARTIAL = 512;
-
-interface Stream {
-  decoder: TextDecoder;
-  partial: string;
-}
-
-const streams = new Map<string, Stream>();
+const UNTERMINATED = /\x1b(?:\][^\x07\x1b]*)?$/;
+const MAX_TAIL = 512;
 
 // Returns the last window title the chunk set, empty when it set none.
 export function appendOutput(sessionId: string, data: number[]): string {
   const bytes = new Uint8Array(data);
-  const buffer = buffers.get(sessionId) ?? { chunks: [], size: 0 };
+  const buffer = buffers.get(sessionId) ?? { chunks: [], size: 0, decoder: new TextDecoder(), tail: "" };
   buffer.chunks.push(bytes);
   buffer.size += bytes.byteLength;
   while (buffer.size > MAX_BYTES && buffer.chunks.length > 1) {
@@ -42,10 +39,7 @@ export function appendOutput(sessionId: string, data: number[]): string {
   }
   buffers.set(sessionId, buffer);
   for (const listener of listeners.get(sessionId) ?? []) listener(bytes);
-  // Decoded as one stream, so neither a character nor a sequence split across two chunks is misread.
-  const stream = streams.get(sessionId) ?? { decoder: new TextDecoder(), partial: "" };
-  streams.set(sessionId, stream);
-  const text = stream.partial + stream.decoder.decode(bytes, { stream: true });
+  const text = buffer.tail + buffer.decoder.decode(bytes, { stream: true });
   let title = "";
   let read = 0;
   TITLE.lastIndex = 0;
@@ -53,8 +47,8 @@ export function appendOutput(sessionId: string, data: number[]): string {
     title = match[1];
     read = TITLE.lastIndex;
   }
-  const partial = text.slice(read).match(PARTIAL)?.[0] ?? "";
-  stream.partial = partial.length > MAX_PARTIAL ? "" : partial;
+  const tail = text.slice(read).match(UNTERMINATED)?.[0] ?? "";
+  buffer.tail = tail.length > MAX_TAIL ? "" : tail;
   return title;
 }
 
@@ -80,5 +74,4 @@ export function readOutput(sessionId: string) {
 
 export function clearOutput(sessionId: string) {
   buffers.delete(sessionId);
-  streams.delete(sessionId);
 }

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -21,10 +21,14 @@ const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const TITLE = /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 
-// The same sequence begun but not yet terminated, which the chunk that ends it completes. Anything
-// longer than a title could be is no longer one, so the wait is given up rather than grown.
+// The same sequence begun but not yet terminated, which the chunk that ends it completes. A title may
+// hold an escape of its own, so the payload ends only at a terminator, and a lone escape is kept
+// because the bracket that makes it a title can be the first byte of the next chunk. That last part is
+// where this parts company with the rule terminal.tsx applies to what is typed, which deliberately does
+// not hold a lone escape back: there it is the Escape key, not the start of anything. Anything longer
+// than a title could be is no longer one, so the wait is given up rather than grown.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
-const UNTERMINATED = /\x1b(?:\][^\x07\x1b]*)?$/;
+const UNTERMINATED = /\x1b(?:\](?:(?!\x07|\x1b\\)[\s\S])*)?$/;
 const MAX_TAIL = 512;
 
 // Returns the last window title the chunk set, empty when it set none.

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface Session {
   // A sign-in session runs the provider's own login command; it is never stored or resumed.
   mode?: "login";
   name: string;
+  // A name the user typed is theirs, so nothing the session says about itself overwrites it again.
+  renamed?: boolean;
   cwd: string;
   rootId: string;
   running: boolean;


### PR DESCRIPTION
A terminal program names the window it runs in with `OSC 0` or `OSC 2`, and a coding agent names it with a short summary of what the session is doing — the same thing that gives a PyCharm terminal tab its title a couple of seconds in. Lite threw that away and named every tab after its folder. Now the sidebar takes it.

- **The title is read where every session's bytes land**, not from the terminal that happens to be mounted, so a tab working in the background is titled too. `appendOutput` already owns the per-session byte stream, so it returns the last title the chunk set; a sequence split across two chunks waits for the chunk that ends it.
- **`--name` is gone.** Naming a Claude Code session after its folder is the one thing that stops Claude Code from naming it after what it is doing, and Lite passed the folder name on every fresh launch. Dropping it left the parameter dead through `spawn_session` and `agent_command`, so that went with it.
- **Not every title is a subject.** A program with nothing of its own to say names the window after itself or after the folder it was started in — both of which the tab already says — so those are ignored rather than allowed to undo a subject the tab had been given.
- **A leading glyph is not part of the subject.** Both Claude Code and Codex prefix the title with a spinner frame while they work; it changes several times a second and says nothing the badge does not, so the name is what follows it.
- **A name the user typed is theirs.** Renaming a tab records that, and no title overwrites it again — including across a restart, and including names chosen before this change, which are recognised by not matching their folder.

## Behavior per harness, measured in a PTY

| Harness | Emits | Tab shows |
| --- | --- | --- |
| Claude Code | `OSC 0`, `✳ Spider leg count question` | the summary, updated as the conversation moves |
| Kimi Code | `OSC 0`, its session title, on every change | that title (no change needed — it already did this) |
| Codex | `OSC 0`, the current directory | the name it already had; Codex has no auto-title to give |
| Shell | whatever the user's shell sets | that title, or the first prompt |

Codex only names a thread when the user runs `/rename`, so asking it for `[tui].terminal_title = ["thread-title"]` yields a bare thread UUID in the ordinary case. That was tried and dropped: it is a launch flag whose payoff cannot be demonstrated, and the folder-name guard above fixes the underlying problem for every harness instead, including a shell whose prompt titles with the directory.

## Note

Claude Code's `--name` also labelled the session in its own prompt box and `/resume` picker. Lite-started sessions now carry the name Claude Code gives itself there instead, which is the same summary the tab shows.

## Validation

- Captured real `OSC` traffic from `claude`, `codex`, and `kimi` in a PTY, before and after dropping `--name` — which is where the `--name` finding came from — and read Kimi's and Codex's own binaries to confirm what each one can emit.
- Unit-checked the scanner against split sequences, split UTF-8, `ESC \` termination (including a split exactly at the terminator), a title containing an escape, `OSC 8` noise, multiple titles per chunk, empty titles, and an overlong partial.
- `bun run check`, `bun run build`, `cargo check`, `cargo fmt --check`.
- Not run in the GUI: another dev instance of Lite is live on this machine and a second one would race it for the same session ids.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves Lite session naming by automatically using meaningful terminal or agent titles while preserving user-defined names, alongside refreshed README social links. ✨

### 📊 Key Changes

- Added automatic session title detection from terminal title sequences and agent output.
- Made title parsing robust across split output chunks, including incomplete UTF-8 characters and escape sequences.
- Added a `renamed` session flag so manually chosen names are never overwritten.
- Improved fallback naming by using the session’s first meaningful prompt or program-provided title, while ignoring status symbols and redundant folder names.
- Removed Claude Code’s `--name` argument so Claude can provide a more useful session title based on its activity.
- Updated English and Chinese README social links, including new TikTok and BiliBili links. 🔗

### 🎯 Purpose & Impact

- Sessions can now identify their purpose automatically, making multiple sessions easier to distinguish. 🏷️
- User-renamed sessions remain stable across future terminal or agent title updates.
- More reliable output handling prevents missed titles when terminal data arrives in fragments.
- Existing saved sessions receive improved name handling through backward-compatible migration logic.
- Documentation branding and social navigation are refreshed without affecting application functionality.