### PR TITLE
Let a Kimi session that has already said hello be answered

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -399,19 +399,27 @@ function startKimiConversation(sessionId: string) {
   const decoder = new TextDecoder();
   let seen = "";
   let sent = false;
+  // Subscribing replays everything the session has already said, so the greeting can arrive inside the
+  // subscribe call itself — before it has returned the way to undo it, and before there is a wait to
+  // call off. Both are named here so that asking early is a thing this can do rather than a crash.
+  let unsubscribe: (() => void) | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const send = () => {
     if (sent) return;
     sent = true;
-    unsubscribe();
+    unsubscribe?.();
     clearTimeout(timer);
     writeSession(sessionId, "/new\r");
   };
-  const unsubscribe = subscribeOutput(sessionId, (data) => {
+  unsubscribe = subscribeOutput(sessionId, (data) => {
     seen += decoder.decode(data, { stream: true });
     if (seen.includes("Welcome to Kimi")) send();
   });
+  // Already greeted: the listener is undone now, since there was nothing to undo when it ran, and no
+  // wait is started for a greeting that has been and gone.
+  if (sent) unsubscribe();
   // Its greeting may change; waiting forever for the words would be worse than asking a little late.
-  const timer = setTimeout(send, 15_000);
+  else timer = setTimeout(send, 15_000);
 }
 
 // A session opened to run one command is sent it once the program in it has finished arriving. A shell
@@ -433,6 +441,9 @@ function runOnStart(sessionId: string, command: string) {
     unsubscribe();
     writeSession(sessionId, `${command}\r`);
   };
+  // This waits rather than sends, which is also what keeps it safe: subscribing replays what the
+  // session has already said, so a listener that sent from here would be sending before the two lines
+  // below had run and before either of the things send() reaches for existed.
   const unsubscribe = subscribeOutput(sessionId, () => {
     window.clearTimeout(settle);
     settle = window.setTimeout(send, SETTLE_MS);


### PR DESCRIPTION
## The bug

`startKimiConversation` subscribes to a session's output and sends `/new` as soon as it sees the Kimi greeting. `subscribeOutput` replays whatever the session has already said, synchronously, inside the subscribe call:

```ts
buffers.get(sessionId)?.chunks.forEach(listener);
```

So the greeting can arrive **before `subscribeOutput` has returned**. `send()` then runs while `unsubscribe` and `timer` are still in their temporal dead zone:

```ts
const send = () => {
  unsubscribe();        // ReferenceError — declared below
  clearTimeout(timer);  // ReferenceError — declared below
  writeSession(sessionId, "/new\r");
};
const unsubscribe = subscribeOutput(sessionId, (data) => {
  if (seen.includes("Welcome to Kimi")) send();   // can run synchronously
});
const timer = setTimeout(send, 15_000);
```

The throw happens inside the replay loop, so it takes the greeting with it and `/new` is never sent — the session silently continues the old conversation instead of starting a fresh one.

## Reachability

**Not reachable today.** The only caller passes a freshly minted UUID after `clearOutput`, so there is never a buffer to replay. This is a latent trap, not a live fault — it was found while reviewing #40 and is fixed here on its own rather than folded into unrelated work.

## The fix

Name both bindings before the listener can reach them, so arriving early is something the function does rather than something it dies of:

- `unsubscribe?.()` — a greeting seen during the replay has nothing to undo yet, so the listener is undone after `subscribeOutput` returns instead.
- No timeout is started for a greeting that has already been and gone.

## Also

`runOnStart` next door does the same job and is safe **only** because its listener schedules a timer rather than calling `send` directly — the exact distinction that makes this bug possible. That constraint was implicit; it is now stated in a comment there, so the safe shape does not get edited into the unsafe one.

## Checks

`bun run check` and `bun run build` pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Fixes a race condition when session output is replayed immediately during subscription.

### 📊 Key Changes

- Declares `unsubscribe` and `timer` before registering the output listener.
- Safely handles greetings that arrive synchronously inside `subscribeOutput()`.
- Uses optional cleanup to prevent calling an unavailable unsubscribe function.
- Avoids starting a timeout when the greeting has already been received.
- Documents why `runOnStart()` waits before sending commands.

### 🎯 Purpose & Impact

- ✅ Prevents crashes caused by attempting to unsubscribe before the subscription is fully initialized.
- ⚡ Improves reliability when starting Kimi conversations with existing session output.
- 🧹 Prevents unnecessary timers and duplicate cleanup work.
- 📖 Makes the subscription timing behavior clearer for future maintainers.