### PR TITLE
Show update download progress

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,13 +81,6 @@ struct PtyExit {
     run_id: String,
 }
 
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct UpdateProgress {
-    downloaded: u64,
-    total: Option<u64>,
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DirectoryGrant {
@@ -2370,13 +2363,26 @@ async fn install_update(app: AppHandle) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "No update is available.".to_string())?;
+    // The download reports every chunk it receives, which is thousands of messages for a bar with a
+    // hundred steps it can show, so only a percent the dialog has not already been given is worth
+    // sending. A server that never said how large the update is says nothing, and the bar stays
+    // indeterminate for the whole download rather than filling against a size nobody knows.
     let progress_app = app.clone();
-    let mut downloaded = 0;
+    let mut downloaded = 0u64;
+    let mut sent = 0;
     update
         .download_and_install(
             move |chunk_length, total| {
                 downloaded += chunk_length as u64;
-                let _ = progress_app.emit("update-progress", UpdateProgress { downloaded, total });
+                let Some(total) = total.filter(|total| *total > 0) else {
+                    return;
+                };
+                let percent = (downloaded * 100 / total).min(100);
+                if percent == sent {
+                    return;
+                }
+                sent = percent;
+                let _ = progress_app.emit("update-progress", percent);
             },
             || {},
         )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2365,8 +2365,8 @@ async fn install_update(app: AppHandle) -> Result<(), String> {
         .ok_or_else(|| "No update is available.".to_string())?;
     // The download reports every chunk it receives, which is thousands of messages for a bar with a
     // hundred steps it can show, so only a percent the dialog has not already been given is worth
-    // sending. A server that never said how large the update is says nothing, and the bar stays
-    // indeterminate for the whole download rather than filling against a size nobody knows.
+    // sending. A server that never said how large the update is says nothing rather than filling a
+    // bar against a size nobody knows, and the dialog keeps its spinner for that download.
     let progress_app = app.clone();
     let mut downloaded = 0u64;
     let mut sent = 0;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,13 @@ struct PtyExit {
     run_id: String,
 }
 
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateProgress {
+    downloaded: u64,
+    total: Option<u64>,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DirectoryGrant {
@@ -2363,8 +2370,16 @@ async fn install_update(app: AppHandle) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "No update is available.".to_string())?;
+    let progress_app = app.clone();
+    let mut downloaded = 0;
     update
-        .download_and_install(|_, _| {}, || {})
+        .download_and_install(
+            move |chunk_length, total| {
+                downloaded += chunk_length as u64;
+                let _ = progress_app.emit("update-progress", UpdateProgress { downloaded, total });
+            },
+            || {},
+        )
         .await
         .map_err(|error| error.to_string())?;
     app.restart()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTi
 import { Input } from "@/components/ui/input";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { Item, ItemActions, ItemMedia } from "@/components/ui/item";
+import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
 import {
   type PanelImperativeHandle,
   ResizableHandle,
@@ -512,6 +513,10 @@ function App() {
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
+  const [updateProgress, setUpdateProgress] = useState<{ downloaded: number; total: number | null }>({
+    downloaded: 0,
+    total: null,
+  });
   const [updateError, setUpdateError] = useState("");
   const runs = useRef(new Map<string, string>());
   const workTimers = useRef(new Map<string, number>());
@@ -626,6 +631,21 @@ function App() {
     void invoke<string | null>("local_repo")
       .then((value) => setRepo(value ?? ""))
       .catch(() => setRepo(""));
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void listen<{ downloaded: number; total: number | null }>("update-progress", ({ payload }) => {
+      setUpdateProgress(payload);
+    }).then((stop) => {
+      if (disposed) stop();
+      else unlisten = stop;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
 
   // One owner for the release question, so the startup check and a manual one cannot contradict each
@@ -883,6 +903,7 @@ function App() {
     if (updateOpen && (updateStatus === "checking" || updateStatus === "installing")) return;
     setUpdateOpen(true);
     setUpdateStatus("checking");
+    setUpdateProgress({ downloaded: 0, total: null });
     setUpdateError("");
     try {
       // A release would replace this build rather than update it, so a local build asks its own tree.
@@ -925,6 +946,7 @@ function App() {
   }
 
   async function installUpdate() {
+    setUpdateProgress({ downloaded: 0, total: null });
     setUpdateStatus("installing");
     try {
       await invoke("install_update");
@@ -1309,8 +1331,19 @@ function App() {
               </DialogDescription>
             </DialogHeader>
             <DialogBody>
-              {updateStatus === "checking" || updateStatus === "installing" ? (
+              {updateStatus === "checking" ? (
                 <Spinner className="mx-auto size-5 text-muted-foreground" />
+              ) : updateStatus === "installing" ? (
+                <Progress
+                  value={
+                    updateProgress.total
+                      ? Math.min(100, (updateProgress.downloaded / updateProgress.total) * 100)
+                      : null
+                  }
+                >
+                  <ProgressLabel>Downloading update</ProgressLabel>
+                  <ProgressValue />
+                </Progress>
               ) : (
                 // What this copy of Lite actually is, which is the first thing worth knowing when it and
                 // the tree disagree. A release has no tree to name and leaves those rows out.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1318,13 +1318,16 @@ function App() {
               </DialogDescription>
             </DialogHeader>
             <DialogBody>
-              {updateStatus === "checking" ? (
-                <Spinner className="mx-auto size-5 text-muted-foreground" />
-              ) : updateStatus === "installing" ? (
+              {/* A bar only once the download has a percent to put in it: an update whose size the
+                  server never gave has none to give, and an empty bar would say less than the spinner
+                  it replaced. */}
+              {updateStatus === "installing" && updateProgress !== null ? (
                 <Progress value={updateProgress}>
                   <ProgressLabel>Downloading update</ProgressLabel>
                   <ProgressValue />
                 </Progress>
+              ) : updateStatus === "checking" || updateStatus === "installing" ? (
+                <Spinner className="mx-auto size-5 text-muted-foreground" />
               ) : (
                 // What this copy of Lite actually is, which is the first thing worth knowing when it and
                 // the tree disagree. A release has no tree to name and leaves those rows out.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -513,10 +513,7 @@ function App() {
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("checking");
   const [availableVersion, setAvailableVersion] = useState("");
-  const [updateProgress, setUpdateProgress] = useState<{ downloaded: number; total: number | null }>({
-    downloaded: 0,
-    total: null,
-  });
+  const [updateProgress, setUpdateProgress] = useState<number | null>(null);
   const [updateError, setUpdateError] = useState("");
   const runs = useRef(new Map<string, string>());
   const workTimers = useRef(new Map<string, number>());
@@ -631,21 +628,6 @@ function App() {
     void invoke<string | null>("local_repo")
       .then((value) => setRepo(value ?? ""))
       .catch(() => setRepo(""));
-  }, []);
-
-  useEffect(() => {
-    let disposed = false;
-    let unlisten: (() => void) | undefined;
-    void listen<{ downloaded: number; total: number | null }>("update-progress", ({ payload }) => {
-      setUpdateProgress(payload);
-    }).then((stop) => {
-      if (disposed) stop();
-      else unlisten = stop;
-    });
-    return () => {
-      disposed = true;
-      unlisten?.();
-    };
   }, []);
 
   // One owner for the release question, so the startup check and a manual one cannot contradict each
@@ -903,7 +885,6 @@ function App() {
     if (updateOpen && (updateStatus === "checking" || updateStatus === "installing")) return;
     setUpdateOpen(true);
     setUpdateStatus("checking");
-    setUpdateProgress({ downloaded: 0, total: null });
     setUpdateError("");
     try {
       // A release would replace this build rather than update it, so a local build asks its own tree.
@@ -946,13 +927,19 @@ function App() {
   }
 
   async function installUpdate() {
-    setUpdateProgress({ downloaded: 0, total: null });
+    setUpdateProgress(null);
     setUpdateStatus("installing");
+    // A download only reports itself while it is running, so it is heard for exactly that long. A
+    // successful install restarts Lite from underneath this, and the failures it can return come
+    // back here to be shown.
+    const stop = await listen<number>("update-progress", ({ payload }) => setUpdateProgress(payload));
     try {
       await invoke("install_update");
     } catch (reason) {
       setUpdateError(String(reason));
       setUpdateStatus("error");
+    } finally {
+      stop();
     }
   }
 
@@ -1334,13 +1321,7 @@ function App() {
               {updateStatus === "checking" ? (
                 <Spinner className="mx-auto size-5 text-muted-foreground" />
               ) : updateStatus === "installing" ? (
-                <Progress
-                  value={
-                    updateProgress.total
-                      ? Math.min(100, (updateProgress.downloaded / updateProgress.total) * 100)
-                      : null
-                  }
-                >
+                <Progress value={updateProgress}>
                   <ProgressLabel>Downloading update</ProgressLabel>
                   <ProgressValue />
                 </Progress>


### PR DESCRIPTION
## Summary\n- emit cumulative updater download progress from Rust\n- render the download progress in the update dialog\n\n## Validation\n- bun run check\n- bun run build\n- cargo check --manifest-path src-tauri/Cargo.toml\n- cargo fmt --check --manifest-path src-tauri/Cargo.toml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

✨ Added accurate, bandwidth-friendly download progress reporting for Lite application updates.

### 📊 Key Changes

- 📥 The Rust update installer now calculates download percentages and emits progress events only when the percentage changes.
- 🛡️ Handles updates without a known total size by keeping the existing spinner instead of showing an unreliable progress bar.
- 🖥️ Added a progress bar to the update dialog with “Downloading update” text and a percentage display.
- 🔄 The frontend listens for progress events only during installation and cleans up the listener afterward.
- ⚠️ Existing error handling remains in place for failed update installations.

### 🎯 Purpose & Impact

- 🚀 Gives users clearer visibility into update download progress.
- ⚡ Reduces unnecessary frontend event traffic by avoiding per-chunk progress messages.
- ✅ Prevents misleading progress indicators when the update size is unavailable.
- 🔧 Preserves the spinner experience for indeterminate downloads and maintains automatic restart behavior after successful installation.