### PR TITLE
Restore saved sessions and Claude usage

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.9"
+version = "0.0.10"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2344,7 +2344,11 @@ async fn read_usage(
             usage
                 .windows
                 .retain(|window| window.resets_at.is_none_or(|reset| reset > now));
-            Ok((usage.context_tokens.is_some() || !usage.windows.is_empty()).then_some(usage))
+            Ok((usage.context_used_percent.is_some()
+                || usage.context_tokens.is_some_and(|tokens| tokens > 0)
+                || usage.cost_usd.is_some_and(|cost| cost > 0.0)
+                || !usage.windows.is_empty())
+            .then_some(usage))
         }
         "codex" => codex_usage(&codex_server).map(Some),
         "kimi" | "shell" => Ok(None),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2295,10 +2295,11 @@ async fn read_usage(
                 Err(error) => return Err(error.to_string()),
             };
             // Claude's limits are account-wide, while its context and cost belong to this session.
-            // Use the newest limits Claude reported from any Lite session rather than hiding them
-            // when the selected session has not sent a message yet.
+            // Use Claude's newest report for each account-wide limit rather than hiding one when the
+            // selected session has not sent a message yet or another report omitted that window.
             if let Ok(entries) = fs::read_dir(directory) {
-                if let Some(windows) = entries
+                let mut latest = [None, None];
+                for (modified, window) in entries
                     .flatten()
                     .filter(|entry| {
                         entry.file_name().to_str().is_some_and(|name| {
@@ -2309,11 +2310,30 @@ async fn read_usage(
                         let modified = entry.metadata().ok()?.modified().ok()?;
                         let snapshot: UsageSnapshot =
                             serde_json::from_slice(&fs::read(entry.path()).ok()?).ok()?;
-                        (!snapshot.windows.is_empty()).then_some((modified, snapshot.windows))
+                        Some((modified, snapshot.windows))
                     })
-                    .max_by_key(|(modified, _)| *modified)
-                    .map(|(_, windows)| windows)
+                    .flat_map(|(modified, windows)| {
+                        windows.into_iter().map(move |window| (modified, window))
+                    })
                 {
+                    let index = match window.label.as_str() {
+                        "Current session" | "5 hour" => 0,
+                        "Current week" | "7 day" => 1,
+                        _ => continue,
+                    };
+                    if latest[index]
+                        .as_ref()
+                        .is_none_or(|(current, _)| modified > *current)
+                    {
+                        latest[index] = Some((modified, window));
+                    }
+                }
+                let windows: Vec<_> = latest
+                    .into_iter()
+                    .flatten()
+                    .map(|(_, window)| window)
+                    .collect();
+                if !windows.is_empty() {
                     usage.windows = windows;
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -447,17 +447,25 @@ fn shell_quote(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\\\""))
 }
 
-// Claude files a session under a key derived from its working directory. Searching for the transcript
-// by name avoids depending on how that key is spelled, and a session it never wrote cannot be resumed.
-fn claude_session_exists(app: &AppHandle, session_id: &str) -> bool {
-    let Ok(home) = std::env::var_os("CLAUDE_CONFIG_DIR")
+fn provider_home(app: &AppHandle, variable: &str, fallback: &str) -> Result<PathBuf, String> {
+    std::env::var_os(variable)
         .filter(|home| !home.is_empty())
         .map(PathBuf::from)
         .map_or_else(
-            || app.path().home_dir().map(|home| home.join(".claude")),
+            || {
+                app.path()
+                    .home_dir()
+                    .map(|home| home.join(fallback))
+                    .map_err(|error| error.to_string())
+            },
             Ok,
         )
-    else {
+}
+
+// Claude files a session under a key derived from its working directory. Searching for the transcript
+// by name avoids depending on how that key is spelled, and a session it never wrote cannot be resumed.
+fn claude_session_exists(app: &AppHandle, session_id: &str) -> bool {
+    let Ok(home) = provider_home(app, "CLAUDE_CONFIG_DIR", ".claude") else {
         return false;
     };
     let transcript = format!("{session_id}.jsonl");
@@ -1404,18 +1412,7 @@ fn executable_exists(name: &str) -> bool {
 }
 
 fn codex_home(app: &AppHandle) -> Result<PathBuf, String> {
-    std::env::var_os("CODEX_HOME")
-        .filter(|home| !home.is_empty())
-        .map(PathBuf::from)
-        .map_or_else(
-            || {
-                app.path()
-                    .home_dir()
-                    .map(|home| home.join(".codex"))
-                    .map_err(|error| error.to_string())
-            },
-            Ok,
-        )
+    provider_home(app, "CODEX_HOME", ".codex")
 }
 
 // Looks only for the section header. The DeepSeek credential lives in that file and is never read.
@@ -1454,18 +1451,7 @@ fn deepseek_profile_exists(app: &AppHandle) -> bool {
 }
 
 fn kimi_home(app: &AppHandle) -> Result<PathBuf, String> {
-    std::env::var_os("KIMI_CODE_HOME")
-        .filter(|home| !home.is_empty())
-        .map(PathBuf::from)
-        .map_or_else(
-            || {
-                app.path()
-                    .home_dir()
-                    .map(|home| home.join(".kimi-code"))
-                    .map_err(|error| error.to_string())
-            },
-            Ok,
-        )
+    provider_home(app, "KIMI_CODE_HOME", ".kimi-code")
 }
 
 // Kimi groups sessions under an opaque per-directory key that its workspace index maps back to a path.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     process::{Command, Stdio},
     sync::Mutex,
     thread,
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_dialog::DialogExt;
@@ -505,7 +505,10 @@ pub fn capture_claude_status(path: &str) -> Result<(), String> {
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
     let mut windows = Vec::new();
-    for (key, label) in [("five_hour", "5 hour"), ("seven_day", "7 day")] {
+    for (key, label) in [
+        ("five_hour", "Current session"),
+        ("seven_day", "Current week"),
+    ] {
         if let Some(window) = input.get("rate_limits").and_then(|limits| limits.get(key)) {
             if let Some(used_percent) = window
                 .get("used_percentage")
@@ -1761,6 +1764,7 @@ async fn spawn_session(
     session_id: String,
     run_id: String,
     root_id: String,
+    cwd: String,
     mut provider_session_id: Option<String>,
     agent: String,
     provider: Option<String>,
@@ -1770,6 +1774,21 @@ async fn spawn_session(
     cols: u16,
     rows: u16,
 ) -> Result<Option<String>, String> {
+    if !roots
+        .0
+        .lock()
+        .map_err(|error| error.to_string())?
+        .contains_key(&root_id)
+    {
+        uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
+        let path = fs::canonicalize(cwd).map_err(|_| "The selected folder no longer exists")?;
+        if is_sensitive_root(&path) {
+            return Err("Credential and configuration folders cannot be opened".into());
+        }
+        update_roots(&app, &roots, |roots| {
+            roots.entry(root_id.clone()).or_insert(path);
+        })?;
+    }
     let cwd = root_path(&roots, &root_id)?;
     // A sign-in runs the provider's own login command and owns no session of its own.
     let signing_in = mode.as_deref() == Some("login");
@@ -2277,18 +2296,55 @@ async fn read_usage(
     }
     match agent.as_str() {
         "claude" => {
-            let path = app
+            let directory = app
                 .path()
                 .app_data_dir()
-                .map_err(|error| error.to_string())?
-                .join(format!("usage-{session_id}.json"));
-            match fs::read(path) {
-                Ok(bytes) => serde_json::from_slice(&bytes)
-                    .map(Some)
-                    .map_err(|error| error.to_string()),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-                Err(error) => Err(error.to_string()),
+                .map_err(|error| error.to_string())?;
+            let path = directory.join(format!("usage-{session_id}.json"));
+            let mut usage = match fs::read(path) {
+                Ok(bytes) => serde_json::from_slice(&bytes).map_err(|error| error.to_string())?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    UsageSnapshot::default()
+                }
+                Err(error) => return Err(error.to_string()),
+            };
+            // Claude's limits are account-wide, while its context and cost belong to this session.
+            // Use the newest limits Claude reported from any Lite session rather than hiding them
+            // when the selected session has not sent a message yet.
+            if let Ok(entries) = fs::read_dir(directory) {
+                if let Some(windows) = entries
+                    .flatten()
+                    .filter(|entry| {
+                        entry.file_name().to_str().is_some_and(|name| {
+                            name.starts_with("usage-") && name.ends_with(".json")
+                        })
+                    })
+                    .filter_map(|entry| {
+                        let modified = entry.metadata().ok()?.modified().ok()?;
+                        let snapshot: UsageSnapshot =
+                            serde_json::from_slice(&fs::read(entry.path()).ok()?).ok()?;
+                        (!snapshot.windows.is_empty()).then_some((modified, snapshot.windows))
+                    })
+                    .max_by_key(|(modified, _)| *modified)
+                    .map(|(_, windows)| windows)
+                {
+                    usage.windows = windows;
+                }
             }
+            for window in &mut usage.windows {
+                window.label = match window.label.as_str() {
+                    "5 hour" => "Current session".into(),
+                    "7 day" => "Current week".into(),
+                    _ => continue,
+                };
+            }
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_secs());
+            usage
+                .windows
+                .retain(|window| window.resets_at.is_none_or(|reset| reset > now));
+            Ok((usage.context_tokens.is_some() || !usage.windows.is_empty()).then_some(usage))
         }
         "codex" => codex_usage(&codex_server).map(Some),
         "kimi" | "shell" => Ok(None),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1109,6 +1109,7 @@ function App() {
         sessionId: session.id,
         runId,
         rootId: session.rootId,
+        cwd: session.cwd,
         providerSessionId: session.providerSessionId,
         agent: session.agent,
         provider: session.provider,
@@ -1288,7 +1289,7 @@ function App() {
       type: "success",
       timeout: 8000,
       onClose: async () => {
-        if (!undone && (await stopped)) await cleanupSession(session);
+        if ((await stopped) && !undone) await cleanupSession(session);
       },
       actionProps: {
         children: "Undo",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1119,11 +1119,6 @@ function App() {
         cols: 100,
         rows: 30,
       });
-      setStartingIds((current) => {
-        const next = new Set(current);
-        next.delete(session.id);
-        return next;
-      });
       if (runs.current.get(session.id) !== runId) return;
       setSessions((current) =>
         current.map((item) =>
@@ -1138,13 +1133,14 @@ function App() {
       );
     } catch (reason) {
       if (runs.current.get(session.id) === runId) runs.current.delete(session.id);
+      setSessions((current) => current.map((item) => (item.id === session.id ? { ...item, running: false } : item)));
+      setError(String(reason));
+    } finally {
       setStartingIds((current) => {
         const next = new Set(current);
         next.delete(session.id);
         return next;
       });
-      setSessions((current) => current.map((item) => (item.id === session.id ? { ...item, running: false } : item)));
-      setError(String(reason));
     }
   }, []);
 
@@ -1239,7 +1235,7 @@ function App() {
     if (cleanupError) setError(`Session closed, but local cleanup failed: ${cleanupError}`);
   }
 
-  // Closing from a session row is reversible: the row leaves immediately and its PTY stops, while the
+  // Closing a session is reversible: the row leaves immediately and its PTY stops, while the
   // provider session metadata and directory grant remain until the toast closes without being undone.
   function closeSession(session: Session) {
     const index = sessions.findIndex((item) => item.id === session.id);
@@ -1397,9 +1393,9 @@ function App() {
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <button
-                    type="button"
-                    className="shrink-0"
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
                     aria-label="Lite on GitHub"
                     data-context-url="https://github.com/ultralytics/lite"
                     onClick={() => void invoke("open_url", { url: "https://github.com/ultralytics/lite" })}
@@ -1427,9 +1423,10 @@ function App() {
                   <Tooltip>
                     <TooltipTrigger
                       render={
-                        <button
-                          type="button"
-                          className="flex max-w-56 shrink-0 items-center gap-1.5 text-muted-foreground hover:text-foreground"
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="max-w-56 gap-1.5 text-muted-foreground"
                           data-context-url={remote}
                           onClick={() => void invoke("open_url", { url: remote })}
                         />
@@ -1531,11 +1528,15 @@ function App() {
                         <Tooltip key={session.id}>
                           <TooltipTrigger
                             render={
-                              <button
-                                type="button"
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
                                 aria-pressed={session.id === selectedId}
+                                aria-label={session.name}
                                 data-context-session={session.id}
-                                className={`rounded-lg p-1 ${session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"}`}
+                                className={
+                                  session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"
+                                }
                                 onClick={() => openRef.current(session)}
                               />
                             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1625,7 +1625,20 @@ function App() {
             <ResizablePanel defaultSize="55%" minSize="38%">
               <section className="flex h-full min-w-0 flex-col">
                 {selected ? (
-                  <div className="min-h-0 flex-1">
+                  <div className="relative min-h-0 flex-1">
+                    {selected.running ? (
+                      <ActionIconButton
+                        variant="outline"
+                        size="icon-sm"
+                        className="absolute top-2 right-2 z-10 bg-background/90 hover:text-destructive"
+                        tooltip="Close session"
+                        tooltipSide="left"
+                        aria-label={`Close ${selected.name}`}
+                        onClick={() => closeSession(selected)}
+                      >
+                        <Trash2 />
+                      </ActionIconButton>
+                    ) : null}
                     {selected.running ? (
                       <Suspense fallback={<div className="h-full bg-background" />}>
                         <TerminalView

--- a/src/brand-icons.tsx
+++ b/src/brand-icons.tsx
@@ -63,7 +63,7 @@ export const GitHubLogomark = ({ className = "size-4" }: { className?: string })
   </svg>
 );
 
-export const OpenAILogomark = ({ className = "size-4" }: { className?: string }) => (
+const OpenAILogomark = ({ className = "size-4" }: { className?: string }) => (
   <svg className={className} viewBox="0 0 24 24" role="img" aria-label="OpenAI">
     <title>OpenAI</title>
     <path
@@ -73,14 +73,14 @@ export const OpenAILogomark = ({ className = "size-4" }: { className?: string })
   </svg>
 );
 
-export const ClaudeLogomark = ({ className = "size-4" }: { className?: string }) => (
+const ClaudeLogomark = ({ className = "size-4" }: { className?: string }) => (
   <svg className={className} viewBox="0 0 100 100" fill="hsl(14.8, 63.1%, 59.6%)" role="img" aria-label="Claude">
     <title>Claude</title>
     <path d="m19.6 66.5 19.7-11 .3-1-.3-.5h-1l-3.3-.2-11.2-.3L14 53l-9.5-.5-2.4-.5L0 49l.2-1.5 2-1.3 2.9.2 6.3.5 9.5.6 6.9.4L38 49.1h1.6l.2-.7-.5-.4-.4-.4L29 41l-10.6-7-5.6-4.1-3-2-1.5-2-.6-4.2 2.7-3 3.7.3.9.2 3.7 2.9 8 6.1L37 36l1.5 1.2.6-.4.1-.3-.7-1.1L33 25l-6-10.4-2.7-4.3-.7-2.6c-.3-1-.4-2-.4-3l3-4.2L28 0l4.2.6L33.8 2l2.6 6 4.1 9.3L47 29.9l2 3.8 1 3.4.3 1h.7v-.5l.5-7.2 1-8.7 1-11.2.3-3.2 1.6-3.8 3-2L61 2.6l2 2.9-.3 1.8-1.1 7.7L59 27.1l-1.5 8.2h.9l1-1.1 4.1-5.4 6.9-8.6 3-3.5L77 13l2.3-1.8h4.3l3.1 4.7-1.4 4.9-4.4 5.6-3.7 4.7-5.3 7.1-3.2 5.7.3.4h.7l12-2.6 6.4-1.1 7.6-1.3 3.5 1.6.4 1.6-1.4 3.4-8.2 2-9.6 2-14.3 3.3-.2.1.2.3 6.4.6 2.8.2h6.8l12.6 1 3.3 2 1.9 2.7-.3 2-5.1 2.6-6.8-1.6-16-3.8-5.4-1.3h-.8v.4l4.6 4.5 8.3 7.5L89 80.1l.5 2.4-1.3 2-1.4-.2-9.2-7-3.6-3-8-6.8h-.5v.7l1.8 2.7 9.8 14.7.5 4.5-.7 1.4-2.6 1-2.7-.6-5.8-8-6-9-4.7-8.2-.5.4-2.9 30.2-1.3 1.5-3 1.2-2.5-2-1.4-3 1.4-6.2 1.6-8 1.3-6.4 1.2-7.9.7-2.6v-.2H49L43 72l-9 12.3-7.2 7.6-1.7.7-3-1.5.3-2.8L24 86l10-12.8 6-7.9 4-4.6-.1-.5h-.3L17.2 77.4l-4.7.6-2-2 .2-3 1-1 8-5.5Z" />
   </svg>
 );
 
-export const DeepSeekLogomark = ({ className = "size-4" }: { className?: string }) => (
+const DeepSeekLogomark = ({ className = "size-4" }: { className?: string }) => (
   <svg className={className} viewBox="0 0 24 24" role="img" aria-label="DeepSeek">
     <title>DeepSeek</title>
     <path
@@ -90,7 +90,7 @@ export const DeepSeekLogomark = ({ className = "size-4" }: { className?: string 
   </svg>
 );
 
-export const KimiLogomark = ({ className = "size-4" }: { className?: string }) => (
+const KimiLogomark = ({ className = "size-4" }: { className?: string }) => (
   <svg className={className} viewBox="0 0 24 24" role="img" aria-label="Kimi">
     <title>Kimi</title>
     <path

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -107,10 +107,7 @@ export default function CodePreview({ path, source }: { path: string; source: st
   const extension = path.split(".").pop()?.toLowerCase() ?? "";
   if (extension === "md" || extension === "mdx") {
     return (
-      <article
-        className="markdown-viewer max-w-none px-6 py-5 text-sm leading-7"
-        onContextMenu={(event) => event.stopPropagation()}
-      >
+      <article className="markdown-viewer max-w-none px-6 py-5 text-sm leading-7">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{
@@ -137,10 +134,7 @@ export default function CodePreview({ path, source }: { path: string; source: st
     );
   }
   return (
-    <pre
-      className="flex min-h-full overflow-auto font-mono text-[12.5px] leading-5"
-      onContextMenu={(event) => event.stopPropagation()}
-    >
+    <pre className="flex min-h-full overflow-auto font-mono text-[12.5px] leading-5">
       <LineNumbers count={source.split("\n").length} />
       <HighlightedCode source={source} language={extensionLanguages[extension]} className="py-4 pr-4 pl-3" />
     </pre>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -716,7 +716,7 @@ function missingUsage(session: Session): string {
   if (session.agent === "kimi") return "Kimi Code keeps session usage inside its own terminal view.";
   if (session.agent === "codex" && session.provider === "deepseek")
     return "DeepSeek publishes no account limits locally. Codex reports this session's usage in the terminal.";
-  if (session.agent === "claude") return "Usage appears after Claude reports its first update.";
+  if (session.agent === "claude") return "Account limits appear after any Lite Claude session receives a response.";
   return "This provider reports no usage locally.";
 }
 

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -40,7 +40,7 @@ import {
 } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { GitHubLogomark } from "@/brand-icons";
+import { GitHubLogomark, ProviderIcon } from "@/brand-icons";
 import { Badge } from "@/components/ui/badge";
 import { ActionIconButton } from "@/components/ui/button";
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
@@ -51,7 +51,14 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { readOutput } from "@/output-store";
-import type { DirectoryCursor, DirectoryListing, FileEntry, GitStatus, Session } from "@/types";
+import {
+  type DirectoryCursor,
+  type DirectoryListing,
+  type FileEntry,
+  type GitStatus,
+  type Session,
+  sessionLabel,
+} from "@/types";
 
 const CodePreview = lazy(() => import("@/code-preview"));
 
@@ -747,6 +754,14 @@ function UsagePanel({ session }: { session: Session }) {
     <div className="flex h-full min-h-0 flex-col">
       <ScrollArea className="min-h-0 flex-1">
         <div className="p-3">
+          <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+            <ProviderIcon agent={session.agent} provider={session.provider} className="size-5" />
+            {session.agent === "codex"
+              ? session.provider === "deepseek"
+                ? "DeepSeek"
+                : "OpenAI"
+              : sessionLabel(session)}
+          </div>
           {error ? (
             <p className="text-sm text-destructive">{error}</p>
           ) : usage === undefined ? (

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -215,24 +216,32 @@ export function NewSessionDialog({
                   const state = availability[option.id];
                   const active = option.id === choiceId;
                   const row = (
-                    <button
+                    <Item
                       key={option.id}
-                      type="button"
-                      aria-pressed={active}
-                      onClick={() => (active && ready ? start() : setChoiceId(option.id))}
-                      className={`flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-colors ${active ? "border-ring bg-accent" : "border-transparent hover:bg-muted/60"}`}
+                      size="xs"
+                      variant={active ? "outline" : "default"}
+                      className={active ? "border-ring bg-accent" : "hover:bg-muted/60"}
+                      render={
+                        <button
+                          type="button"
+                          aria-pressed={active}
+                          onClick={() => (active && ready ? start() : setChoiceId(option.id))}
+                        />
+                      }
                     >
                       {/* The same tile the session wears in the sidebar, so the choice looks like its result. */}
-                      <span className="flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
+                      <ItemMedia variant="icon" className="size-7 rounded-md border bg-background">
                         <ProviderIcon agent={option.agent} provider={option.provider} />
-                      </span>
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium">{sessionLabel(option)}</span>
-                        <span className="block truncate text-xs text-muted-foreground">{option.description}</span>
-                      </span>
-                      {state && !state.available ? <Badge variant="outline">Not set up</Badge> : null}
-                      <Check className={`size-4 shrink-0 ${active ? "" : "invisible"}`} />
-                    </button>
+                      </ItemMedia>
+                      <ItemContent>
+                        <ItemTitle>{sessionLabel(option)}</ItemTitle>
+                        <ItemDescription className="truncate">{option.description}</ItemDescription>
+                      </ItemContent>
+                      <ItemActions>
+                        {state && !state.available ? <Badge variant="outline">Not set up</Badge> : null}
+                        <Check className={`size-4 shrink-0 ${active ? "" : "invisible"}`} />
+                      </ItemActions>
+                    </Item>
                   );
                   return option.note ? (
                     <Tooltip key={option.id}>

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -101,8 +101,6 @@ export function TerminalView({
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-    const keepNativeMenu = (event: MouseEvent) => event.stopPropagation();
-    container.addEventListener("contextmenu", keepNativeMenu);
 
     const terminal = new Terminal({
       cursorBlink: true,
@@ -178,7 +176,6 @@ export function TerminalView({
 
     return () => {
       window.clearTimeout(settle);
-      container.removeEventListener("contextmenu", keepNativeMenu);
       observer.disconnect();
       input.dispose();
       unsubscribe();
@@ -198,7 +195,7 @@ export function TerminalView({
   // them past the edge, which also left the last row below the viewport where the scrollbar could
   // neither show nor reach it.
   return (
-    <div className="h-full w-full bg-background p-3">
+    <div data-context-session={sessionId} className="h-full w-full bg-background p-3">
       <div ref={containerRef} className="h-full w-full" />
     </div>
   );


### PR DESCRIPTION
## Summary
- restore each saved session’s validated folder grant so Claude Code and Codex can resume in their original folder
- finish stopping a trashed session before deciding whether Undo still permits cleanup, preventing future grant loss
- clear the folder-permission error row and restore the terminal’s full usable height
- show Claude’s newest account-wide session and weekly limits independently across Claude tabs while keeping context and cost session-specific
- keep expired limit windows out of Usage, use Claude’s labels, and show the selected provider’s existing logo
- close a running terminal through the same trash action, instant toast, and Undo owner as the sidebar
- replace native file and terminal menus with the app-wide generated Base UI context menu
- consolidate repeated provider-home resolution and replace matching local UI lookalikes with generated Nova components
- bump Lite to 0.0.10

## Validation
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `bun run local`
- red-icon `Lite Dev.app` validated against saved 0.0.9 application data
- Claude and OpenAI terminal colors validated with an uncontaminated preview environment
- full Core Principles and design/code duplication audit

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Lite 0.0.10 improves Claude usage reporting, session security, session controls, and the overall interface.

### 📊 Key Changes

- 📈 Updated Claude usage labels to **“Current session”** and **“Current week”**, while aggregating the latest account-wide limits across all Lite sessions.
- 🧹 Automatically hides expired Claude usage windows and preserves session-specific context and cost information.
- 🔐 Added shared provider-home path handling for Claude, Codex, and Kimi configuration directories.
- 🛡️ Validates session folders before starting agents, blocks sensitive credential/configuration directories, and restores valid folder permissions when needed.
- 🖥️ Improved session startup and cleanup state handling so sessions reliably stop loading and display errors.
- 🗑️ Added a close-session button directly to the active terminal view, with safer reversible session cleanup behavior.
- 🎨 Refined buttons, provider/session icons, usage panel headings, and the new-session dialog using shared UI components.
- 🖱️ Removed custom context-menu suppression so native context menus work correctly in code previews and terminals.
- 📦 Bumped the desktop application version from **0.0.9** to **0.0.10**.

### 🎯 Purpose & Impact

- ✅ Users can see Claude account limits even when the selected session has not yet produced a response.
- 📊 Usage information is more consistent across sessions and avoids displaying limits that have already expired.
- 🔒 Folder validation reduces the risk of accidentally opening credential or configuration directories through an agent session.
- ⚡ Session controls are easier to discover, and startup failures leave the interface in a more reliable state.
- ♿ Shared UI components and improved labels provide clearer interaction feedback and better accessibility.
- 🧩 Provider configuration handling is less repetitive and easier to maintain across supported agents.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
