### PR TITLE
Fix 0.0.11 workspace regressions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -385,9 +385,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -1689,7 +1689,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -1969,7 +1969,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -2289,7 +2289,7 @@ dependencies = [
  "objc2-osa-kit",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3538,7 +3538,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tray-icon",
  "url",
@@ -3589,7 +3589,7 @@ dependencies = [
  "sha2",
  "syn 2.0.119",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "url",
  "uuid",
@@ -3640,7 +3640,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -3663,7 +3663,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "url",
 ]
@@ -3693,7 +3693,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "url",
@@ -3719,7 +3719,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -3782,7 +3782,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
@@ -3834,11 +3834,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3854,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4158,7 +4158,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -4181,7 +4181,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4538,7 +4538,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows",
  "windows-core 0.61.2",
 ]
@@ -5065,7 +5065,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -426,15 +426,11 @@ fn grant_directory(
 }
 
 fn default_directory_path(app: &AppHandle) -> Option<PathBuf> {
-    if let Ok(path) = last_directory_path(app)
+    let path = last_directory_path(app)
         .and_then(|path| fs::read_to_string(path).map_err(|error| error.to_string()))
-    {
-        let path = PathBuf::from(path);
-        if path.is_dir() {
-            return Some(path);
-        }
-    }
-    None
+        .ok()
+        .map(PathBuf::from)?;
+    path.is_dir().then_some(path)
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -410,12 +410,13 @@ fn grant_directory(
     app: &AppHandle,
     roots: &Roots,
     path: PathBuf,
+    root_id: Option<String>,
 ) -> Result<DirectoryGrant, String> {
     let path = fs::canonicalize(path).map_err(|error| error.to_string())?;
     if is_sensitive_root(&path) {
         return Err("Credential and configuration folders cannot be opened".into());
     }
-    let id = uuid::Uuid::new_v4().to_string();
+    let id = root_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     update_roots(app, roots, |roots| {
         roots.insert(id.clone(), path.clone());
     })?;
@@ -559,7 +560,7 @@ fn default_directory(
     roots: State<Roots>,
 ) -> Result<Option<DirectoryGrant>, String> {
     default_directory_path(&app)
-        .map(|path| grant_directory(&app, &roots, path))
+        .map(|path| grant_directory(&app, &roots, path, None))
         .transpose()
 }
 
@@ -578,7 +579,7 @@ async fn choose_directory(
     let path = fs::canonicalize(path.into_path().map_err(|error| error.to_string())?)
         .map_err(|error| error.to_string())?;
     write_atomic(&last_directory_path(&app)?, path_text(&path).as_bytes())?;
-    grant_directory(&app, &roots, path).map(Some)
+    grant_directory(&app, &roots, path, None).map(Some)
 }
 
 // A typed path is a folder like any other: it has to exist and it goes through the same grant.
@@ -602,7 +603,18 @@ async fn use_directory(
     }
     let path = fs::canonicalize(path).map_err(|error| error.to_string())?;
     write_atomic(&last_directory_path(&app)?, path_text(&path).as_bytes())?;
-    grant_directory(&app, &roots, path)
+    grant_directory(&app, &roots, path, None)
+}
+
+#[tauri::command]
+async fn follow_directory(
+    app: AppHandle,
+    roots: State<'_, Roots>,
+    root_id: String,
+    path: String,
+) -> Result<DirectoryGrant, String> {
+    root_path(&roots, &root_id)?;
+    grant_directory(&app, &roots, PathBuf::from(path), Some(root_id))
 }
 
 #[derive(Serialize)]
@@ -1712,7 +1724,12 @@ fn agent_command(
             }
             command
         }
-        "shell" => CommandBuilder::new_default_prog(),
+        "shell" => {
+            let mut command = CommandBuilder::new_default_prog();
+            #[cfg(target_os = "macos")]
+            command.env("TERM_PROGRAM", "Apple_Terminal");
+            command
+        }
         _ => return Err("Unknown session type".into()),
     };
     if let Some(path) = user_path() {
@@ -2543,7 +2560,7 @@ fn local_repo() -> Option<&'static str> {
 #[tauri::command]
 async fn grant_repo(app: AppHandle, roots: State<'_, Roots>) -> Result<DirectoryGrant, String> {
     let repo = option_env!("LITE_REPO").ok_or("This build did not record where it came from")?;
-    grant_directory(&app, &roots, PathBuf::from(repo))
+    grant_directory(&app, &roots, PathBuf::from(repo), None)
 }
 
 #[tauri::command]
@@ -2655,6 +2672,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             choose_directory,
+            follow_directory,
             github_items,
             use_directory,
             default_directory,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -425,16 +425,16 @@ fn grant_directory(
     })
 }
 
-fn default_directory_path(app: &AppHandle) -> Result<PathBuf, String> {
+fn default_directory_path(app: &AppHandle) -> Option<PathBuf> {
     if let Ok(path) = last_directory_path(app)
         .and_then(|path| fs::read_to_string(path).map_err(|error| error.to_string()))
     {
         let path = PathBuf::from(path);
         if path.is_dir() {
-            return Ok(path);
+            return Some(path);
         }
     }
-    app.path().home_dir().map_err(|error| error.to_string())
+    None
 }
 
 #[cfg(unix)]
@@ -558,8 +558,13 @@ pub fn capture_claude_status(path: &str) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn default_directory(app: AppHandle, roots: State<Roots>) -> Result<DirectoryGrant, String> {
-    grant_directory(&app, &roots, default_directory_path(&app)?)
+fn default_directory(
+    app: AppHandle,
+    roots: State<Roots>,
+) -> Result<Option<DirectoryGrant>, String> {
+    default_directory_path(&app)
+        .map(|path| grant_directory(&app, &roots, path))
+        .transpose()
 }
 
 #[tauri::command]
@@ -568,7 +573,7 @@ async fn choose_directory(
     roots: State<'_, Roots>,
 ) -> Result<Option<DirectoryGrant>, String> {
     let mut dialog = app.dialog().file().set_title("Choose a project");
-    if let Ok(path) = default_directory_path(&app) {
+    if let Some(path) = default_directory_path(&app) {
         dialog = dialog.set_directory(path);
     }
     let Some(path) = dialog.blocking_pick_folder() else {

--- a/src/App.css
+++ b/src/App.css
@@ -18,7 +18,7 @@
   display: none;
 }
 
-.xterm .xterm-viewport {
+[data-context-session] .xterm .xterm-viewport {
   background-color: var(--background);
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklch, var(--muted-foreground) 40%, transparent) transparent;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { clearInspectorCache, Inspector } from "@/inspector";
+import { clearUsageCache, Inspector } from "@/inspector";
 import { NewSessionDialog } from "@/new-session-dialog";
 import { appendOutput, clearOutput, subscribeOutput, syncTerminalTheme, writeSession } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
@@ -1172,7 +1172,10 @@ function App() {
   async function signIn(agent: Session["agent"]) {
     setSettingsOpen(false);
     try {
-      const grant = await invoke<{ id: string; path: string }>("default_directory");
+      const grant =
+        (await invoke<{ id: string; path: string } | null>("default_directory")) ??
+        (await invoke<{ id: string; path: string } | null>("choose_directory"));
+      if (!grant) return;
       createSession({
         id: crypto.randomUUID(),
         agent,
@@ -1206,7 +1209,7 @@ function App() {
       setError(String(reason));
     }
     clearOutput(session.id);
-    clearInspectorCache(session.id, session.rootId);
+    clearUsageCache(session.id);
     const fresh: Session = { ...session, id: crypto.randomUUID(), providerSessionId: undefined, running: false };
     setSessions((current) => current.map((item) => (item.id === session.id ? fresh : item)));
     if (select) {
@@ -1234,7 +1237,7 @@ function App() {
       cleanupError ||= String(reason);
     }
     clearOutput(session.id);
-    clearInspectorCache(session.id, session.rootId);
+    clearUsageCache(session.id);
     if (cleanupError) setError(`Session closed, but local cleanup failed: ${cleanupError}`);
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1633,6 +1633,32 @@ function App() {
               <section className="flex h-full min-w-0 flex-col">
                 {selected ? (
                   <div className="relative min-h-0 flex-1">
+                    <Suspense fallback={<div className="absolute inset-0 bg-background" />}>
+                      {sessions.map((session) =>
+                        session.running ? (
+                          <div
+                            key={session.id}
+                            aria-hidden={!selected.running || session.id !== selectedId}
+                            className={`absolute inset-0 ${selected.running && session.id === selectedId ? "visible" : "invisible"}`}
+                          >
+                            <TerminalView
+                              sessionId={session.id}
+                              theme={theme}
+                              active={selected.running && session.id === selectedId}
+                              onPrompt={(text) =>
+                                setSessions((current) =>
+                                  current.map((item) =>
+                                    item.id === session.id && !item.renamed && item.name === folderName(item.cwd)
+                                      ? { ...item, name: subject(text) }
+                                      : item,
+                                  ),
+                                )
+                              }
+                            />
+                          </div>
+                        ) : null,
+                      )}
+                    </Suspense>
                     {selected.running ? (
                       <ActionIconButton
                         variant="outline"
@@ -1646,23 +1672,7 @@ function App() {
                         <Trash2 />
                       </ActionIconButton>
                     ) : null}
-                    {selected.running ? (
-                      <Suspense fallback={<div className="h-full bg-background" />}>
-                        <TerminalView
-                          sessionId={selected.id}
-                          theme={theme}
-                          onPrompt={(text) =>
-                            setSessions((current) =>
-                              current.map((item) =>
-                                item.id === selected.id && !item.renamed && item.name === folderName(item.cwd)
-                                  ? { ...item, name: subject(text) }
-                                  : item,
-                              ),
-                            )
-                          }
-                        />
-                      </Suspense>
-                    ) : startingIds.has(selected.id) ? (
+                    {selected.running ? null : startingIds.has(selected.id) ? (
                       <Empty className="h-full">
                         <EmptyHeader>
                           <SessionMark session={selected} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -866,6 +866,7 @@ function App() {
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
   const [updateError, setUpdateError] = useState("");
   const runs = useRef(new Map<string, string>());
+  const sessionsRef = useRef(sessions);
   const workTimers = useRef(new Map<string, number>());
   const resumed = useRef("");
   const themeRef = useRef<Theme>("dark");
@@ -883,6 +884,7 @@ function App() {
     );
   }, [sessions, query]);
   visibleRef.current = visible;
+  sessionsRef.current = sessions;
   themeRef.current = theme;
   selectedRef.current = selected;
   closeRef.current = closeSession;
@@ -1062,6 +1064,18 @@ function App() {
     });
   }, []);
 
+  const markDirectory = useCallback((sessionId: string, path: string) => {
+    const session = sessionsRef.current.find((item) => item.id === sessionId);
+    if (session?.agent !== "shell" || session.cwd === path) return;
+    void invoke<{ id: string; path: string }>("follow_directory", { rootId: session.rootId, path })
+      .then((grant) => {
+        setSessions((current) =>
+          current.map((item) => (item.id === sessionId ? { ...item, cwd: grant.path, rootId: grant.id } : item)),
+        );
+      })
+      .catch((reason) => setError(String(reason)));
+  }, []);
+
   useEffect(() => {
     let disposed = false;
     let unlistenOutput: (() => void) | undefined;
@@ -1069,8 +1083,9 @@ function App() {
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
-        const title = appendOutput(payload.sessionId, payload.data);
+        const { title, path } = appendOutput(payload.sessionId, payload.data);
         if (title) markTitle(payload.sessionId, title);
+        if (path) markDirectory(payload.sessionId, path);
         markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
@@ -1097,7 +1112,7 @@ function App() {
       for (const timer of timers.values()) window.clearTimeout(timer);
       timers.clear();
     };
-  }, [markWorking, markTitle]);
+  }, [markDirectory, markWorking, markTitle]);
 
   const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return;

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -286,24 +286,20 @@ const FILE_FAMILIES: (FileKind & { extensions: string[] })[] = [
   { icon: FileCode, color: "text-orange-500", extensions: ["html", "htm", "xml", "vue", "svelte"] },
   { icon: FileCode, color: "text-fuchsia-500", extensions: ["css", "scss", "sass", "less"] },
   { icon: FileJson, color: "text-amber-500", extensions: ["json", "jsonc", "json5"] },
-  {
-    icon: FileCog,
-    color: "text-violet-500",
-    extensions: ["yaml", "yml", "toml", "ini", "cfg", "conf", "editorconfig"],
-  },
-  { icon: FileCog, color: "text-orange-500", extensions: ["gitignore", "gitattributes", "dockerignore"] },
+  { icon: FileCog, color: "text-stone-500", extensions: ["yaml", "yml", "toml", "ini", "cfg", "conf", "editorconfig"] },
+  { icon: FileCog, color: "text-stone-500", extensions: ["gitignore", "gitattributes", "dockerignore"] },
   { icon: FileKey, color: "text-amber-600", extensions: ["env", "pem", "key", "crt", "cert"] },
-  { icon: FileLock, color: "text-amber-500", extensions: ["lock", "lockb"] },
+  { icon: FileLock, color: "text-stone-500", extensions: ["lock", "lockb"] },
   { icon: FileTerminal, color: "text-emerald-500", extensions: ["sh", "bash", "zsh", "fish", "ps1", "bat", "cmd"] },
   { icon: FileImage, color: "text-pink-500", extensions: ["png", "jpg", "jpeg", "gif", "webp", "svg", "ico", "avif"] },
   { icon: FileAudio, color: "text-purple-500", extensions: ["mp3", "wav", "flac", "ogg", "m4a"] },
   { icon: FileVideo, color: "text-purple-500", extensions: ["mp4", "mov", "mkv", "webm", "avi"] },
   { icon: FileSpreadsheet, color: "text-green-600", extensions: ["csv", "tsv", "xls", "xlsx", "parquet"] },
-  { icon: FileArchive, color: "text-amber-600", extensions: ["zip", "tar", "gz", "tgz", "bz2", "xz", "7z", "rar"] },
+  { icon: FileArchive, color: "text-stone-500", extensions: ["zip", "tar", "gz", "tgz", "bz2", "xz", "7z", "rar"] },
   { icon: Database, color: "text-indigo-500", extensions: ["sql", "db", "sqlite", "sqlite3"] },
-  { icon: FileType, color: "text-cyan-500", extensions: ["woff", "woff2", "ttf", "otf"] },
-  { icon: FileDiff, color: "text-orange-500", extensions: ["diff", "patch"] },
-  { icon: FileText, color: "text-blue-500", extensions: ["md", "mdx", "rst", "txt", "adoc"] },
+  { icon: FileType, color: "text-muted-foreground", extensions: ["woff", "woff2", "ttf", "otf"] },
+  { icon: FileDiff, color: "text-muted-foreground", extensions: ["diff", "patch"] },
+  { icon: FileText, color: "text-muted-foreground", extensions: ["md", "mdx", "rst", "txt", "adoc"] },
 ];
 
 const FILE_TYPES = new Map<string, FileKind>(
@@ -313,9 +309,9 @@ const FILE_TYPES = new Map<string, FileKind>(
 // The few files a project names rather than extends, which say more than the extension they lack.
 const FILE_NAMES = new Map<string, FileKind>([
   ["dockerfile", { icon: Container, color: "text-blue-500" }],
-  ["makefile", { icon: Hammer, color: "text-amber-500" }],
-  ["cmakelists.txt", { icon: Hammer, color: "text-amber-500" }],
-  ["license", { icon: Scale, color: "text-blue-500" }],
+  ["makefile", { icon: Hammer, color: "text-stone-500" }],
+  ["cmakelists.txt", { icon: Hammer, color: "text-stone-500" }],
+  ["license", { icon: Scale, color: "text-muted-foreground" }],
 ]);
 
 function FileIcon({ name, directory }: { name: string; directory?: boolean }) {
@@ -324,7 +320,7 @@ function FileIcon({ name, directory }: { name: string; directory?: boolean }) {
   const Icon = directory ? Folder : (kind?.icon ?? File);
   return (
     <Icon
-      className={`size-3.5 shrink-0 ${directory ? "fill-current text-sky-500" : (kind?.color ?? "text-blue-500")}`}
+      className={`size-3.5 shrink-0 ${directory ? "fill-current text-muted-foreground" : (kind?.color ?? "text-muted-foreground")}`}
     />
   );
 }

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -651,70 +651,50 @@ function RepositoryCard({ repository }: { repository: RepositoryGroup }) {
   );
 }
 
-// Revisiting a session paints its last small metadata snapshot immediately, then the mounted panel
-// rereads the owner in the background. File contents stay out of these caches.
-const gitStatusCache = new Map<string, GitStatus | null>();
-const githubItemsCache = new Map<string, GitHubItem[]>();
 const usageCache = new Map<string, UsageSnapshot | null>();
 
-export function clearInspectorCache(sessionId: string, rootId: string) {
-  gitStatusCache.delete(rootId);
-  githubItemsCache.delete(sessionId);
+export function clearUsageCache(sessionId: string) {
   usageCache.delete(sessionId);
 }
 
 function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: string; remote: string }) {
-  // A mount revalidates the cached snapshot, and the refresh button mounts the panel again. Nothing
-  // watches Git or GitHub between those explicit reads.
+  // Read once when the panel is built, like every other thing this panel shows: the refresh button
+  // rebuilds it, and nothing here watches the session between those two moments.
   const named = useMemo(() => namedInSession(sessionId), [sessionId]);
-  const [status, setStatus] = useState<GitStatus | null | undefined>(() => gitStatusCache.get(rootId));
-  const [items, setItems] = useState<GitHubItem[] | undefined>(() => githubItemsCache.get(sessionId));
+  const [status, setStatus] = useState<GitStatus | null>();
+  const [items, setItems] = useState<GitHubItem[]>();
   const [error, setError] = useState("");
 
-  // Asking GitHub on mount updates the stale snapshot already painted above.
+  // The panel is only built when the tab is opened and again whenever it is refreshed, so asking
+  // GitHub here asks it exactly on those two occasions and never between them.
   useEffect(() => {
-    if (!named.length) {
-      githubItemsCache.set(sessionId, []);
-      return setItems([]);
-    }
+    if (!named.length) return setItems([]);
     let disposed = false;
     void invoke<GitHubItem[]>("github_items", { urls: named })
       .then((checked) => {
-        if (!disposed) {
-          githubItemsCache.set(sessionId, checked);
-          setItems(checked);
-        }
+        if (!disposed) setItems(checked);
       })
       // A link that could not be checked is still a link, so it is shown the way it was printed.
       .catch(() => {
-        if (!disposed) {
-          const unchecked = named.map((url) => ({ url, title: null, state: null, occurredAt: null }));
-          githubItemsCache.set(sessionId, unchecked);
-          setItems(unchecked);
-        }
+        if (!disposed) setItems(named.map((url) => ({ url, title: null, state: null, occurredAt: null })));
       });
     return () => {
       disposed = true;
     };
-  }, [named, sessionId]);
+  }, [named]);
+
+  const refresh = useCallback(async () => {
+    setError("");
+    try {
+      setStatus(await invoke<GitStatus | null>("git_status", { rootId }));
+    } catch (reason) {
+      setError(String(reason));
+    }
+  }, [rootId]);
 
   useEffect(() => {
-    let disposed = false;
-    setError("");
-    void invoke<GitStatus | null>("git_status", { rootId })
-      .then((next) => {
-        if (!disposed) {
-          gitStatusCache.set(rootId, next);
-          setStatus(next);
-        }
-      })
-      .catch((reason) => {
-        if (!disposed) setError(String(reason));
-      });
-    return () => {
-      disposed = true;
-    };
-  }, [rootId]);
+    void refresh();
+  }, [refresh]);
 
   const repositories = repositoryGroups(remote, status ?? null, items ?? []);
 

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -286,10 +286,14 @@ const FILE_FAMILIES: (FileKind & { extensions: string[] })[] = [
   { icon: FileCode, color: "text-orange-500", extensions: ["html", "htm", "xml", "vue", "svelte"] },
   { icon: FileCode, color: "text-fuchsia-500", extensions: ["css", "scss", "sass", "less"] },
   { icon: FileJson, color: "text-amber-500", extensions: ["json", "jsonc", "json5"] },
-  { icon: FileCog, color: "text-stone-500", extensions: ["yaml", "yml", "toml", "ini", "cfg", "conf", "editorconfig"] },
-  { icon: FileCog, color: "text-stone-500", extensions: ["gitignore", "gitattributes", "dockerignore"] },
+  {
+    icon: FileCog,
+    color: "text-violet-500",
+    extensions: ["yaml", "yml", "toml", "ini", "cfg", "conf", "editorconfig"],
+  },
+  { icon: FileCog, color: "text-orange-500", extensions: ["gitignore", "gitattributes", "dockerignore"] },
   { icon: FileKey, color: "text-amber-600", extensions: ["env", "pem", "key", "crt", "cert"] },
-  { icon: FileLock, color: "text-stone-500", extensions: ["lock", "lockb"] },
+  { icon: FileLock, color: "text-amber-500", extensions: ["lock", "lockb"] },
   { icon: FileTerminal, color: "text-emerald-500", extensions: ["sh", "bash", "zsh", "fish", "ps1", "bat", "cmd"] },
   { icon: FileImage, color: "text-pink-500", extensions: ["png", "jpg", "jpeg", "gif", "webp", "svg", "ico", "avif"] },
   { icon: FileAudio, color: "text-purple-500", extensions: ["mp3", "wav", "flac", "ogg", "m4a"] },
@@ -297,9 +301,9 @@ const FILE_FAMILIES: (FileKind & { extensions: string[] })[] = [
   { icon: FileSpreadsheet, color: "text-green-600", extensions: ["csv", "tsv", "xls", "xlsx", "parquet"] },
   { icon: FileArchive, color: "text-stone-500", extensions: ["zip", "tar", "gz", "tgz", "bz2", "xz", "7z", "rar"] },
   { icon: Database, color: "text-indigo-500", extensions: ["sql", "db", "sqlite", "sqlite3"] },
-  { icon: FileType, color: "text-muted-foreground", extensions: ["woff", "woff2", "ttf", "otf"] },
-  { icon: FileDiff, color: "text-muted-foreground", extensions: ["diff", "patch"] },
-  { icon: FileText, color: "text-muted-foreground", extensions: ["md", "mdx", "rst", "txt", "adoc"] },
+  { icon: FileType, color: "text-cyan-500", extensions: ["woff", "woff2", "ttf", "otf"] },
+  { icon: FileDiff, color: "text-orange-500", extensions: ["diff", "patch"] },
+  { icon: FileText, color: "text-blue-500", extensions: ["md", "mdx", "rst", "txt", "adoc"] },
 ];
 
 const FILE_TYPES = new Map<string, FileKind>(
@@ -309,16 +313,20 @@ const FILE_TYPES = new Map<string, FileKind>(
 // The few files a project names rather than extends, which say more than the extension they lack.
 const FILE_NAMES = new Map<string, FileKind>([
   ["dockerfile", { icon: Container, color: "text-blue-500" }],
-  ["makefile", { icon: Hammer, color: "text-stone-500" }],
-  ["cmakelists.txt", { icon: Hammer, color: "text-stone-500" }],
-  ["license", { icon: Scale, color: "text-muted-foreground" }],
+  ["makefile", { icon: Hammer, color: "text-amber-500" }],
+  ["cmakelists.txt", { icon: Hammer, color: "text-amber-500" }],
+  ["license", { icon: Scale, color: "text-blue-500" }],
 ]);
 
-function FileIcon({ name }: { name: string }) {
+function FileIcon({ name, directory }: { name: string; directory?: boolean }) {
   const lower = name.toLowerCase();
   const kind = FILE_NAMES.get(lower) ?? FILE_TYPES.get(lower.split(".").pop() ?? "");
-  const Icon = kind?.icon ?? File;
-  return <Icon className={`size-3.5 shrink-0 ${kind?.color ?? "text-muted-foreground"}`} />;
+  const Icon = directory ? Folder : (kind?.icon ?? File);
+  return (
+    <Icon
+      className={`size-3.5 shrink-0 ${directory ? "fill-current text-sky-500" : (kind?.color ?? "text-blue-500")}`}
+    />
+  );
 }
 
 function Loading({ label }: { label: string }) {
@@ -448,7 +456,7 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
                   <ChevronRight
                     className={`size-3.5 text-muted-foreground transition-transform ${expanded.has(entry.path) ? "rotate-90" : ""}`}
                   />
-                  <Folder className="size-3.5 fill-current text-muted-foreground" />
+                  <FileIcon name={entry.name} directory />
                 </>
               ) : (
                 <>
@@ -505,7 +513,7 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
           <ChevronRight
             className={`size-3.5 text-muted-foreground transition-transform ${expanded.has(root) ? "rotate-90" : ""}`}
           />
-          <Folder className="size-3.5 fill-current text-muted-foreground" />
+          <FileIcon name={name} directory />
           <span className="truncate">{name}</span>
         </button>
         <ActionIconButton

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -299,7 +299,7 @@ const FILE_FAMILIES: (FileKind & { extensions: string[] })[] = [
   { icon: FileAudio, color: "text-purple-500", extensions: ["mp3", "wav", "flac", "ogg", "m4a"] },
   { icon: FileVideo, color: "text-purple-500", extensions: ["mp4", "mov", "mkv", "webm", "avi"] },
   { icon: FileSpreadsheet, color: "text-green-600", extensions: ["csv", "tsv", "xls", "xlsx", "parquet"] },
-  { icon: FileArchive, color: "text-stone-500", extensions: ["zip", "tar", "gz", "tgz", "bz2", "xz", "7z", "rar"] },
+  { icon: FileArchive, color: "text-amber-600", extensions: ["zip", "tar", "gz", "tgz", "bz2", "xz", "7z", "rar"] },
   { icon: Database, color: "text-indigo-500", extensions: ["sql", "db", "sqlite", "sqlite3"] },
   { icon: FileType, color: "text-cyan-500", extensions: ["woff", "woff2", "ttf", "otf"] },
   { icon: FileDiff, color: "text-orange-500", extensions: ["diff", "patch"] },

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -86,10 +86,10 @@ export function NewSessionDialog({
     setError("");
     setAvailability({});
     setAuth(undefined);
-    void invoke<DirectoryGrant>("default_directory")
+    void invoke<DirectoryGrant | null>("default_directory")
       .then((selected) => {
-        if (disposed) void invoke("revoke_directory", { rootId: selected.id });
-        else {
+        if (disposed && selected) void invoke("revoke_directory", { rootId: selected.id });
+        else if (selected) {
           setDirectory(selected);
           setPath(selected.path);
         }

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -20,12 +20,10 @@ interface Buffer {
 const buffers = new Map<string, Buffer>();
 const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 
-// A program names the window it runs in with OSC 0 or 2, and an agent names it with a short summary of
-// what the session is doing. The title arrives in the output whether or not the session is the one on
-// screen, so it is read here, where every session's bytes land, rather than from the single terminal
-// that happens to be mounted.
+// Titles and working directories arrive whether or not the session is visible, so their shared OSC
+// owner lives here where every session's output arrives rather than in the mounted terminal.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
-const TITLE = /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+const METADATA = /\x1b\]([027]);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 
 // The same sequence begun but not yet terminated, which the chunk that ends it completes. A title may
 // hold an escape of its own, so the payload ends only at a terminator, and a lone escape is kept
@@ -54,8 +52,8 @@ export function syncTerminalTheme(theme: Theme) {
   }
 }
 
-// Returns the last window title the chunk set, empty when it set none.
-export function appendOutput(sessionId: string, data: number[]): string {
+// Returns the last title and directory the chunk set, empty when it set neither.
+export function appendOutput(sessionId: string, data: number[]) {
   const bytes = new Uint8Array(data);
   const buffer = buffers.get(sessionId) ?? {
     chunks: [],
@@ -86,15 +84,17 @@ export function appendOutput(sessionId: string, data: number[]): string {
 
   const text = buffer.tail + decoded;
   let title = "";
-  let read = 0;
-  TITLE.lastIndex = 0;
-  for (let match = TITLE.exec(text); match; match = TITLE.exec(text)) {
-    title = match[1];
-    read = TITLE.lastIndex;
+  let path = "";
+  METADATA.lastIndex = 0;
+  for (let match = METADATA.exec(text); match; match = METADATA.exec(text)) {
+    if (match[1] === "7") {
+      if (match[2].startsWith("file://"))
+        path = decodeURIComponent(new URL(match[2]).pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+    } else title = match[2];
   }
-  const tail = text.slice(read).match(UNTERMINATED)?.[0] ?? "";
+  const tail = text.match(UNTERMINATED)?.[0] ?? "";
   buffer.tail = tail.length > MAX_TAIL ? "" : tail;
-  return title;
+  return { title, path };
 }
 
 export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) => void) {

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -82,10 +82,12 @@ function storedFontSize(): number {
 export function TerminalView({
   sessionId,
   theme,
+  active,
   onPrompt,
 }: {
   sessionId: string;
   theme: Theme;
+  active: boolean;
   onPrompt: (text: string) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -190,7 +192,6 @@ export function TerminalView({
       return false;
     });
     resize();
-    terminal.focus();
 
     return () => {
       window.clearTimeout(settle);
@@ -201,6 +202,10 @@ export function TerminalView({
       terminalRef.current = null;
     };
   }, [sessionId]);
+
+  useEffect(() => {
+    if (active) terminalRef.current?.focus();
+  }, [active]);
 
   useEffect(() => {
     if (terminalRef.current) terminalRef.current.options.theme = themes[theme];


### PR DESCRIPTION
## Summary
- stop silently granting the entire home directory when no project has been chosen
- remove the 0.0.11 Git/GitHub snapshot caches so every session uses the same live Git panel owner
- route every file and folder icon through the single shared FileIcon owner, retaining known-format colors and grey fallbacks
- keep one bounded xterm instance mounted for every running session so switching tabs preserves terminal state and history
- keep xterm’s lazy stylesheet from repainting the terminal viewport black
- follow shell `cd` changes through the shared session directory so the path, Files, Git, search, restart, and persistence stay aligned

Files and Git each have one shared component with no harness-specific rendering.

## Validation
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- focused split OSC title and working-directory parsing
- macOS bash and zsh prompt integration emitted OSC 7 working directories
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Fixes workspace regressions by preventing implicit home-directory access and keeping session state, terminal metadata, file views, and Git data synchronized.

### 📊 Key Changes

- `default_directory` now returns no grant when no valid previous project exists; session sign-in falls back to the project chooser instead of granting the home directory.
- Added `follow_directory` to preserve the existing root ID while updating a shell session’s directory from OSC 7 working-directory events; session paths and grants now track shell `cd` changes.
- All running sessions keep a mounted `TerminalView`, switching visibility and focus with the active tab so terminal history and state persist.
- Replaced separate Git and GitHub snapshot caches with panel-local reads on mount and refresh; usage caching remains session-based.
- Centralized directory and file rendering through `FileIcon`, preserving known file-type colors and using grey fallbacks; xterm viewport styling is scoped to session terminals.

### 🎯 Purpose & Impact

- Starting a session without a remembered project now requires choosing a project rather than silently exposing the home directory.
- Shell directory changes propagate to Files, Git, search, restart, and persisted session state through the shared directory grant.
- Switching between running session tabs preserves each terminal’s mounted state and history.
- Git and GitHub panels no longer reuse the removed 0.0.11 cross-session snapshot caches; they read current data when opened or refreshed.