### PR TITLE
Search Files and Git panels, batch GitHub checks, scan bare #refs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -613,134 +613,163 @@ struct GitHubItem {
     occurred_at: Option<String>,
 }
 
-// The kind, number and repository a GitHub work-item link names, or nothing if the link is not one.
-fn github_item_parts(url: &str) -> Option<(String, String, &'static str, String)> {
+// The repository and number a GitHub work-item link names, or nothing if the link is not one. Owner
+// and name are embedded in a GraphQL query, so only the characters GitHub itself allows in them pass,
+// and the number has to fit the Int the API takes.
+fn github_item_parts(url: &str) -> Option<(String, String, String)> {
     let mut parts = url.strip_prefix("https://github.com/")?.split('/');
     let owner = parts.next().filter(|part| !part.is_empty())?;
     let repository = parts.next().filter(|part| !part.is_empty())?;
-    let kind = match parts.next()? {
-        "pull" => "pulls",
-        "issues" => "issues",
-        _ => return None,
-    };
-    let number = parts.next()?;
-    if number.is_empty() || !number.chars().all(|digit| digit.is_ascii_digit()) {
+    if [owner, repository].iter().any(|part| {
+        !part
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-._".contains(character))
+    }) {
         return None;
     }
-    Some((
-        owner.to_owned(),
-        repository.to_owned(),
-        kind,
-        number.to_owned(),
-    ))
-}
-
-// What GitHub had to say, as opposed to whether Lite managed to ask. Missing is the only answer that
-// removes a link, so everything that is merely a failure to ask has to arrive as Unknown instead.
-enum Answer {
-    Found(serde_json::Value),
-    Missing,
-    Unknown,
-}
-
-fn gh_api(gh: &Path, endpoint: &str) -> Answer {
-    let Ok(output) = Command::new(gh).args(["api", endpoint]).output() else {
-        return Answer::Unknown;
-    };
-    if output.status.success() {
-        return serde_json::from_slice(&output.stdout).map_or(Answer::Unknown, Answer::Found);
+    if !matches!(parts.next()?, "pull" | "issues") {
+        return None;
     }
-    if String::from_utf8_lossy(&output.stderr).contains("HTTP 404") {
-        Answer::Missing
-    } else {
-        Answer::Unknown
+    let number = parts.next()?;
+    if number.is_empty() || number.len() > 9 || !number.chars().all(|digit| digit.is_ascii_digit())
+    {
+        return None;
     }
+    Some((owner.to_owned(), repository.to_owned(), number.to_owned()))
 }
 
-// A session prints as many links as it prints, and each one checked is a round trip; past a point the
-// panel would be waiting on the network rather than saying what a session did. The rest are shown the
-// way they were printed.
-const CHECKED_GITHUB_ITEMS: usize = 20;
+// A reference waiting on GitHub's answer: the URL a session printed, or the URL guessed from a bare
+// "#12" it printed, which is only shown once GitHub confirms it names real work.
+struct Lookup {
+    owner: String,
+    repository: String,
+    number: String,
+    url: String,
+    guessed: bool,
+}
 
-// A pull request or issue link is read back out of what a session printed, so a number mistyped into
-// the terminal reaches the panel looking exactly like one that exists. GitHub is the only thing that
+// A session prints as many references as it prints, and all of them are asked about in one request;
+// the cap is what one request comfortably carries rather than how long the panel is allowed to wait.
+const CHECKED_GITHUB_ITEMS: usize = 100;
+
+// A pull request or issue reference is read back out of what a session printed, so a number mistyped
+// into the terminal reaches here looking exactly like one that exists. GitHub is the only thing that
 // can tell the two apart, and gh is how Lite asks: it is the tool that printed most of these links, it
 // carries whatever sign-in the person using it has, and asking it is not the same as reading that
-// sign-in. A link is only dropped on evidence that it names nothing; everything else is shown exactly
-// as it was printed, whether gh is missing, the laptop is offline, or the repository is one this
-// sign-in cannot see. That last case is why a 404 alone is not evidence: GitHub answers 404 for a
-// private repository it will not admit to as readily as for a number that was never a pull request.
-// So the repository is asked for too, and only a repository that can be read makes the number a
-// mistake — otherwise a sign-in to the wrong account would quietly delete real work from the panel.
-fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
-    let gh = resolve_executable("gh");
+// sign-in. Every reference goes into a single GraphQL request — one alias each — because a call is a
+// process and a network round trip, and a session's worth of them in a row is a panel that waits on
+// the network instead of saying what the session did. issueOrPullRequest answers for both kinds at
+// once, which is what lets a bare "#12" be asked about without knowing which it names; the canonical
+// URL in the answer replaces the guessed kind. A reference is only dropped on evidence that it names
+// nothing, and the same response carries that evidence: a repository that resolves while its item does
+// not was read and searched. A repository that does not resolve proves nothing — GitHub hides a
+// private repository this sign-in cannot see as readily as one that never existed — so its printed
+// links stay, shown the way they were printed, as they do whenever gh is missing or the laptop is
+// offline. A guessed number is different: it is as easily a line number as a pull request, so without
+// GitHub's confirmation it stays out of the panel entirely.
+fn check_github_items(urls: Vec<String>, guessed: Vec<String>) -> Vec<GitHubItem> {
+    let mut lookups: Vec<Lookup> = Vec::new();
+    let mut seen = HashSet::new();
+    let printed = urls.into_iter().map(|url| (url, false));
+    for (url, guessed) in printed.chain(guessed.into_iter().map(|url| (url, true))) {
+        let Some((owner, repository, number)) = github_item_parts(&url) else {
+            continue;
+        };
+        // A repository is named case-insensitively, so "#12" and a link to it are one reference; the
+        // printed links come first, which keeps a guess from ever shadowing one.
+        if seen.insert((
+            owner.to_lowercase(),
+            repository.to_lowercase(),
+            number.clone(),
+        )) {
+            lookups.push(Lookup {
+                owner,
+                repository,
+                number,
+                url,
+                guessed,
+            });
+        }
+    }
+    if lookups.is_empty() {
+        return Vec::new();
+    }
+    let answer = resolve_executable("gh").and_then(|gh| {
+        let mut query = String::from("query {\n");
+        for (index, lookup) in lookups.iter().take(CHECKED_GITHUB_ITEMS).enumerate() {
+            let Lookup {
+                owner,
+                repository,
+                number,
+                ..
+            } = lookup;
+            query.push_str(&format!(
+                "q{index}: repository(owner: \"{owner}\", name: \"{repository}\") {{ issueOrPullRequest(number: {number}) {{ ...f }} }}\n"
+            ));
+        }
+        query.push_str(
+            "}\nfragment f on IssueOrPullRequest {\n... on Issue { title url state createdAt closedAt }\n... on PullRequest { title url state isDraft createdAt closedAt mergedAt }\n}",
+        );
+        let output = Command::new(gh)
+            .args(["api", "graphql", "-f", &format!("query={query}")])
+            .output()
+            .ok()?;
+        // GraphQL answers what it could resolve and lists the rest as errors in the same body, and gh
+        // prints that body either way; only a body that never arrived is no answer at all.
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).ok()
+    });
     let mut found = Vec::new();
-    let mut readable: HashMap<String, bool> = HashMap::new();
-    let mut checked = 0;
-    for url in urls {
-        let Some((owner, repository, kind, number)) = github_item_parts(&url) else {
-            continue;
-        };
-        let unchecked = GitHubItem {
-            url: url.clone(),
-            title: None,
-            state: None,
-            occurred_at: None,
-        };
-        let (Some(gh), true) = (gh.as_ref(), checked < CHECKED_GITHUB_ITEMS) else {
-            found.push(unchecked);
-            continue;
-        };
-        checked += 1;
-        match gh_api(gh, &format!("repos/{owner}/{repository}/{kind}/{number}")) {
-            Answer::Found(body) => {
-                // Merged and draft are pull-request states of their own; issues only answer open or closed.
-                let state = if kind == "pulls" && body["merged"].as_bool() == Some(true) {
-                    "merged"
-                } else if body["state"].as_str() == Some("closed") {
-                    "closed"
-                } else if kind == "pulls" && body["draft"].as_bool() == Some(true) {
-                    "draft"
-                } else {
-                    "open"
+    for (index, lookup) in lookups.iter().enumerate() {
+        let alias = format!("q{index}");
+        let repository = answer
+            .as_ref()
+            .filter(|_| index < CHECKED_GITHUB_ITEMS)
+            .map(|body| &body["data"][alias.as_str()]);
+        match repository {
+            Some(repository) if repository["issueOrPullRequest"].is_object() => {
+                let item = &repository["issueOrPullRequest"];
+                // Merged and draft are pull-request states of their own; issues only answer open or
+                // closed, and only a pull request carries isDraft at all.
+                let state = match item["state"].as_str() {
+                    Some("MERGED") => "merged",
+                    Some("CLOSED") => "closed",
+                    _ if item["isDraft"].as_bool() == Some(true) => "draft",
+                    _ => "open",
                 };
-                let occurred_at = body[if state == "merged" {
-                    "merged_at"
-                } else if state == "closed" {
-                    "closed_at"
-                } else {
-                    "created_at"
+                let occurred_at = item[match state {
+                    "merged" => "mergedAt",
+                    "closed" => "closedAt",
+                    _ => "createdAt",
                 }]
                 .as_str()
                 .map(str::to_owned);
                 found.push(GitHubItem {
-                    url,
-                    title: body["title"].as_str().map(str::to_owned),
+                    url: item["url"]
+                        .as_str()
+                        .map_or_else(|| lookup.url.clone(), str::to_owned),
+                    title: item["title"].as_str().map(str::to_owned),
                     state: Some(state.to_owned()),
                     occurred_at,
                 });
             }
-            Answer::Missing => {
-                // Asked once per repository rather than once per link: twenty links into one repository
-                // nobody here can read are twenty identical answers.
-                let name = format!("{owner}/{repository}");
-                let readable = *readable.entry(name.clone()).or_insert_with(|| {
-                    matches!(gh_api(gh, &format!("repos/{name}")), Answer::Found(_))
-                });
-                if !readable {
-                    found.push(unchecked);
-                }
-            }
-            Answer::Unknown => found.push(unchecked),
+            // The repository was read and searched, and the number names nothing in it.
+            Some(repository) if !repository.is_null() => {}
+            _ if !lookup.guessed => found.push(GitHubItem {
+                url: lookup.url.clone(),
+                title: None,
+                state: None,
+                occurred_at: None,
+            }),
+            _ => {}
         }
     }
     found
 }
 
-// Each check waits on a process and a network round trip, so the run is moved off the runtime the rest
+// The check waits on a process and a network round trip, so the run is moved off the runtime the rest
 // of Lite's commands share rather than holding one of its workers for the length of it.
 #[tauri::command]
-async fn github_items(urls: Vec<String>) -> Vec<GitHubItem> {
+async fn github_items(urls: Vec<String>, guessed: Vec<String>) -> Vec<GitHubItem> {
     // A run that never finished answered nothing, and nothing is not evidence that a link names
     // nothing, so the links come back the way they were printed rather than as an empty panel.
     let unanswered: Vec<GitHubItem> = urls
@@ -753,7 +782,7 @@ async fn github_items(urls: Vec<String>) -> Vec<GitHubItem> {
             occurred_at: None,
         })
         .collect();
-    tauri::async_runtime::spawn_blocking(move || check_github_items(urls))
+    tauri::async_runtime::spawn_blocking(move || check_github_items(urls, guessed))
         .await
         .unwrap_or(unanswered)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -630,8 +630,11 @@ fn github_item_parts(url: &str) -> Option<(String, String, String)> {
     if !matches!(parts.next()?, "pull" | "issues") {
         return None;
     }
+    // A leading zero would also make the number an invalid GraphQL Int literal, poisoning the batch.
     let number = parts.next()?;
-    if number.is_empty() || number.len() > 9 || !number.chars().all(|digit| digit.is_ascii_digit())
+    if !matches!(number.chars().next(), Some('1'..='9'))
+        || number.len() > 9
+        || !number.chars().all(|digit| digit.is_ascii_digit())
     {
         return None;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2280,6 +2280,7 @@ async fn list_directory(
         if name == ".git"
             || name == "node_modules"
             || name == "target"
+            || name == ".venv"
             || is_sensitive_path(&root, &entry.path())
         {
             continue;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -663,7 +663,8 @@ const CHECKED_GITHUB_ITEMS: usize = 100;
 // process and a network round trip, and a session's worth of them in a row is a panel that waits on
 // the network instead of saying what the session did. issueOrPullRequest answers for both kinds at
 // once, which is what lets a bare "#12" be asked about without knowing which it names; the canonical
-// URL in the answer replaces the guessed kind. A reference is only dropped on evidence that it names
+// URL in the answer replaces the guessed kind, and a printed link naming the wrong kind follows the
+// same redirect GitHub itself answers that link with. A reference is only dropped on evidence that it names
 // nothing, and the same response carries that evidence: a repository that resolves while its item does
 // not was read and searched. A repository that does not resolve proves nothing — GitHub hides a
 // private repository this sign-in cannot see as readily as one that never existed — so its printed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -722,6 +722,20 @@ fn check_github_items(urls: Vec<String>, guessed: Vec<String>) -> Vec<GitHubItem
         // prints that body either way; only a body that never arrived is no answer at all.
         serde_json::from_slice::<serde_json::Value>(&output.stdout).ok()
     });
+    // Dropping a reference takes GitHub's word for it: a NOT_FOUND filed against the alias. An item
+    // that is merely null — a resolver that failed some other way in an otherwise partial answer —
+    // proved nothing.
+    let not_found: HashSet<&str> = answer
+        .as_ref()
+        .and_then(|body| body["errors"].as_array())
+        .map(|errors| {
+            errors
+                .iter()
+                .filter(|error| error["type"].as_str() == Some("NOT_FOUND"))
+                .filter_map(|error| error["path"][0].as_str())
+                .collect()
+        })
+        .unwrap_or_default();
     let mut found = Vec::new();
     for (index, lookup) in lookups.iter().enumerate() {
         let alias = format!("q{index}");
@@ -757,7 +771,7 @@ fn check_github_items(urls: Vec<String>, guessed: Vec<String>) -> Vec<GitHubItem
                 });
             }
             // The repository was read and searched, and the number names nothing in it.
-            Some(repository) if !repository.is_null() => {}
+            Some(repository) if !repository.is_null() && not_found.contains(alias.as_str()) => {}
             _ if !lookup.guessed => found.push(GitHubItem {
                 url: lookup.url.clone(),
                 title: None,

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -73,7 +73,7 @@ const CodePreview = lazy(() => import("@/code-preview"));
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\d+/g;
-const BARE_ITEM = /(?:^|[^\w#])#(\d{1,9})(?!\w)/g;
+const BARE_ITEM = /(?:^|[^\w#])#([1-9]\d{0,8})(?!\w)/g;
 
 function namedInSession(sessionId: string, remote: string) {
   const text = readOutput(sessionId).replace(COLOR, "");
@@ -479,10 +479,14 @@ function FileTree({
     }
   }
 
-  // A search has to see the whole tree, so the first keystroke loads it and a later one retries a
-  // walk that failed; one that succeeded is not repeated.
+  // A search has to see the whole tree, so the first keystroke loads it and the next keystroke — not
+  // the render a failure causes — retries a walk that failed; one that succeeded is not repeated.
+  const attempted = useRef("");
   useEffect(() => {
-    if (query && !walked.current && !expandingAll) void walk(false);
+    if (query && query !== attempted.current && !walked.current && !expandingAll) {
+      attempted.current = query;
+      void walk(false);
+    }
   });
 
   const lowered = query.trim().toLowerCase();

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -489,19 +489,19 @@ function FileTree({
     }
   }
 
-  // A search has to see the whole tree, so the first keystroke loads it and the next query — not the
-  // render a failure causes — retries a walk that failed; one that succeeded is not repeated, and a
-  // cleared search forgets the failure so the same query asks again.
+  const lowered = query.trim().toLowerCase();
+
+  // A search has to see the whole tree, so the first searching keystroke loads it and the next query
+  // — not the render a failure causes — retries a walk that failed; one that succeeded is not
+  // repeated, and a cleared search forgets the failure so the same query asks again.
   const attempted = useRef("");
   useEffect(() => {
-    if (!query) attempted.current = "";
-    else if (query !== attempted.current && !walked.current && !expandingAll) {
-      attempted.current = query;
+    if (!lowered) attempted.current = "";
+    else if (lowered !== attempted.current && !walked.current && !expandingAll) {
+      attempted.current = lowered;
       void walk(false);
     }
   });
-
-  const lowered = query.trim().toLowerCase();
 
   // A folder is worth showing while searching if anything under it matches; only loaded listings can
   // answer, which is what the walk above is for.
@@ -779,11 +779,11 @@ function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: st
 
   // Asking GitHub on mount updates the stale snapshot already painted above.
   useEffect(() => {
-    if (!named.urls.length && !named.guessed.length) {
-      githubItemsCache.set(sessionId, []);
-      return setItems([]);
-    }
+    if (!named.urls.length && !named.guessed.length) return setItems([]);
     let disposed = false;
+    // A remote that arrives after an empty first pass starts a real check, so the panel goes back to
+    // its last checked snapshot — or to checking — rather than staying empty without a word.
+    setItems(githubItemsCache.get(sessionId));
     void invoke<GitHubItem[]>("github_items", { urls: named.urls, guessed: named.guessed })
       .then((checked) => {
         if (!disposed) {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -36,6 +36,7 @@ import {
   type LucideIcon,
   RefreshCw,
   Scale,
+  Search,
   X,
 } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -44,6 +45,7 @@ import { GitHubLogomark, ProviderIcon } from "@/brand-icons";
 import { Badge } from "@/components/ui/badge";
 import { ActionIconButton } from "@/components/ui/button";
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { Item, ItemContent, ItemDescription, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -63,16 +65,25 @@ import {
 const CodePreview = lazy(() => import("@/code-preview"));
 
 // A session's terminal is the only record of what it worked on, so what it named is read back out of
-// the output Lite already keeps. Only what GitHub prints verbatim counts: a whole pull request or issue
-// link. A bare "#12" is as often a line number.
+// the output Lite already keeps: every whole pull request or issue link GitHub prints verbatim, and
+// every bare "#12" the conversation names one by. A bare number is a guess — it is as easily a line
+// number — so it is sent separately and only shown once GitHub confirms it names real work in the
+// session's own repository, which is the only repository a bare number can mean.
 // Only CSI is stripped, so a link inside an OSC hyperlink survives being uncoloured.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\d+/g;
+const BARE_ITEM = /(?:^|[^\w#])#(\d{1,9})(?!\w)/g;
 
-function namedInSession(sessionId: string) {
+function namedInSession(sessionId: string, remote: string) {
   const text = readOutput(sessionId).replace(COLOR, "");
-  return [...new Set(text.match(GITHUB_ITEM) ?? [])];
+  const urls = [...new Set(text.match(GITHUB_ITEM) ?? [])];
+  const guessable = remote.toLowerCase().startsWith("https://github.com/");
+  const numbers = new Set(guessable ? [...text.matchAll(BARE_ITEM)].map((match) => match[1]) : []);
+  for (const url of urls) {
+    if (url.toLowerCase().startsWith(`${remote.toLowerCase()}/`)) numbers.delete(url.split("/").pop() ?? "");
+  }
+  return { urls, guessed: [...numbers].map((number) => `${remote}/issues/${number}`) };
 }
 
 interface GitHubReference {
@@ -330,6 +341,37 @@ function Loading({ label }: { label: string }) {
   );
 }
 
+// The same field the sidebar searches sessions with, placed the same way: it names the panel it
+// narrows, and Escape empties it.
+function SearchInput({
+  value,
+  placeholder,
+  onChange,
+}: {
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="shrink-0 border-b p-2">
+      <InputGroup>
+        <InputGroupAddon>
+          <Search />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={value}
+          placeholder={placeholder}
+          aria-label={placeholder}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") onChange("");
+          }}
+        />
+      </InputGroup>
+    </div>
+  );
+}
+
 // A window that is nearly spent is the one thing here worth a color, so it recolors the bar it fills.
 function Meter({ label, value }: { label: string; value: number }) {
   const bounded = Math.max(0, Math.min(100, value));
@@ -344,7 +386,17 @@ function Meter({ label, value }: { label: string; value: number }) {
   );
 }
 
-function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOpen: (entry: FileEntry) => void }) {
+function FileTree({
+  root,
+  rootId,
+  query,
+  onOpen,
+}: {
+  root: string;
+  rootId: string;
+  query: string;
+  onOpen: (entry: FileEntry) => void;
+}) {
   const [children, setChildren] = useState<Record<string, DirectoryListing & { after: DirectoryCursor | null }>>({});
   // The root is the folder the session works in; showing it shut asks for a click to say what the
   // panel is already for, so it opens with the tree it was asked to show.
@@ -393,16 +445,19 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
     setExpanded(next);
   }
 
-  async function expandAll() {
+  // "Expand all" and search walk the same tree: the one loads it to open it, the other to look
+  // through it, and neither disturbs which folders were open once a search is cleared.
+  const walked = useRef(false);
+  async function walk(expand: boolean) {
     setExpandingAll(true);
     const nextChildren = { ...children };
-    const nextExpanded = new Set<string>();
+    const directories = new Set<string>();
     const pending = [root];
     try {
       while (pending.length) {
         const path = pending.shift();
-        if (!path || nextExpanded.has(path)) continue;
-        nextExpanded.add(path);
+        if (!path || directories.has(path)) continue;
+        directories.add(path);
         const cached = nextChildren[path];
         const listing =
           cached && !cached.after
@@ -414,7 +469,8 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
         );
       }
       setChildren(nextChildren);
-      setExpanded(nextExpanded);
+      if (expand) setExpanded(directories);
+      walked.current = true;
       setError("");
     } catch (reason) {
       setError(String(reason));
@@ -423,44 +479,69 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
     }
   }
 
+  // A search has to see the whole tree, so the first keystroke loads it and a later one retries a
+  // walk that failed; one that succeeded is not repeated.
+  useEffect(() => {
+    if (query && !walked.current && !expandingAll) void walk(false);
+  });
+
+  const lowered = query.trim().toLowerCase();
+
+  // A folder is worth showing while searching if anything under it matches; only loaded listings can
+  // answer, which is what the walk above is for.
+  function subtreeMatches(path: string): boolean {
+    const listing = children[path];
+    return !!listing?.entries.some(
+      (entry) => entry.name.toLowerCase().includes(lowered) || (entry.isDirectory && subtreeMatches(entry.path)),
+    );
+  }
+
   function rows(path: string, depth = 0): React.ReactNode {
     const listing = children[path];
     if (!listing) {
       if (loadingPaths.has(path)) return <Loading label="Reading folder…" />;
       return error ? <p className="p-3 text-xs text-destructive">{error}</p> : null;
     }
+    const entries = lowered
+      ? listing.entries.filter(
+          (entry) => entry.name.toLowerCase().includes(lowered) || (entry.isDirectory && subtreeMatches(entry.path)),
+        )
+      : listing.entries;
     return (
       <>
-        {listing.entries.map((entry) => (
-          <div key={entry.path}>
-            <button
-              type="button"
-              className="flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-left text-xs hover:bg-muted"
-              style={{ paddingLeft: `${8 + depth * 14}px` }}
-              data-context-value={entry.path}
-              data-context-label="Copy path"
-              data-context-directory={entry.isDirectory ? "" : undefined}
-              data-context-expanded={entry.isDirectory ? expanded.has(entry.path) : undefined}
-              onClick={() => (entry.isDirectory ? void toggle(entry.path) : onOpen(entry))}
-            >
-              {entry.isDirectory ? (
-                <>
-                  <ChevronRight
-                    className={`size-3.5 text-muted-foreground transition-transform ${expanded.has(entry.path) ? "rotate-90" : ""}`}
-                  />
-                  <Folder className="size-3.5 fill-current text-muted-foreground" />
-                </>
-              ) : (
-                <>
-                  <span className="w-3.5" />
-                  <FileIcon name={entry.name} />
-                </>
-              )}
-              <span className="truncate">{entry.name}</span>
-            </button>
-            {entry.isDirectory && expanded.has(entry.path) ? rows(entry.path, depth + 1) : null}
-          </div>
-        ))}
+        {entries.map((entry) => {
+          const open = entry.isDirectory && (expanded.has(entry.path) || (!!lowered && subtreeMatches(entry.path)));
+          return (
+            <div key={entry.path}>
+              <button
+                type="button"
+                className="flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-left text-xs hover:bg-muted"
+                style={{ paddingLeft: `${8 + depth * 14}px` }}
+                data-context-value={entry.path}
+                data-context-label="Copy path"
+                data-context-directory={entry.isDirectory ? "" : undefined}
+                data-context-expanded={entry.isDirectory ? open : undefined}
+                onClick={() => (entry.isDirectory ? void toggle(entry.path) : onOpen(entry))}
+              >
+                {entry.isDirectory ? (
+                  <>
+                    <ChevronRight
+                      className={`size-3.5 text-muted-foreground transition-transform ${open ? "rotate-90" : ""}`}
+                    />
+                    <Folder className="size-3.5 fill-current text-muted-foreground" />
+                  </>
+                ) : (
+                  <>
+                    <span className="w-3.5" />
+                    <FileIcon name={entry.name} />
+                  </>
+                )}
+                <span className="truncate">{entry.name}</span>
+              </button>
+              {open ? rows(entry.path, depth + 1) : null}
+            </div>
+          );
+        })}
         {listing.after || listing.nextCursor ? (
           <div className="flex h-7 items-center gap-3 pr-2 text-xs" style={{ paddingLeft: `${30 + depth * 14}px` }}>
             {listing.after ? (
@@ -490,6 +571,7 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
 
   const parts = root.split(/[\\/]/).filter(Boolean);
   const name = parts[parts.length - 1] ?? root;
+  const rootOpen = !!lowered || expanded.has(root);
   return (
     <div className="py-2">
       <div className="flex items-center pr-1">
@@ -499,11 +581,11 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
           data-context-value={root}
           data-context-label="Copy path"
           data-context-directory
-          data-context-expanded={expanded.has(root)}
+          data-context-expanded={rootOpen}
           onClick={() => void toggle(root)}
         >
           <ChevronRight
-            className={`size-3.5 text-muted-foreground transition-transform ${expanded.has(root) ? "rotate-90" : ""}`}
+            className={`size-3.5 text-muted-foreground transition-transform ${rootOpen ? "rotate-90" : ""}`}
           />
           <Folder className="size-3.5 fill-current text-muted-foreground" />
           <span className="truncate">{name}</span>
@@ -514,7 +596,7 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
           aria-label="Expand all folders"
           data-context-expand-files
           disabled={expandingAll}
-          onClick={() => void expandAll()}
+          onClick={() => void walk(true)}
         >
           {expandingAll ? <Spinner /> : <ChevronsUpDown />}
         </ActionIconButton>
@@ -529,7 +611,10 @@ function FileTree({ root, rootId, onOpen }: { root: string; rootId: string; onOp
           <ChevronsDownUp />
         </ActionIconButton>
       </div>
-      {expanded.has(root) ? rows(root, 1) : null}
+      {lowered && !expandingAll && children[root] && !subtreeMatches(root) ? (
+        <p className="px-3 py-2 text-xs text-muted-foreground">No matches</p>
+      ) : null}
+      {rootOpen ? rows(root, 1) : null}
     </div>
   );
 }
@@ -538,6 +623,7 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   const [selected, setSelected] = useState<FileEntry | null>(null);
   const [source, setSource] = useState("");
   const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
 
   async function openFile(entry: FileEntry) {
     setSelected(entry);
@@ -579,8 +665,9 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   }
   return (
     <div data-context-files className="flex h-full min-h-0 flex-col">
+      <SearchInput value={query} placeholder="Search files" onChange={setQuery} />
       <ScrollArea className="min-h-0 flex-1">
-        <FileTree root={root} rootId={rootId} onOpen={(entry) => void openFile(entry)} />
+        <FileTree root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
       </ScrollArea>
     </div>
   );
@@ -666,29 +753,31 @@ export function clearInspectorCache(sessionId: string, rootId: string) {
 function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: string; remote: string }) {
   // A mount revalidates the cached snapshot, and the refresh button mounts the panel again. Nothing
   // watches Git or GitHub between those explicit reads.
-  const named = useMemo(() => namedInSession(sessionId), [sessionId]);
+  const named = useMemo(() => namedInSession(sessionId, remote), [sessionId, remote]);
   const [status, setStatus] = useState<GitStatus | null | undefined>(() => gitStatusCache.get(rootId));
   const [items, setItems] = useState<GitHubItem[] | undefined>(() => githubItemsCache.get(sessionId));
   const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
 
   // Asking GitHub on mount updates the stale snapshot already painted above.
   useEffect(() => {
-    if (!named.length) {
+    if (!named.urls.length && !named.guessed.length) {
       githubItemsCache.set(sessionId, []);
       return setItems([]);
     }
     let disposed = false;
-    void invoke<GitHubItem[]>("github_items", { urls: named })
+    void invoke<GitHubItem[]>("github_items", { urls: named.urls, guessed: named.guessed })
       .then((checked) => {
         if (!disposed) {
           githubItemsCache.set(sessionId, checked);
           setItems(checked);
         }
       })
-      // A link that could not be checked is still a link, so it is shown the way it was printed.
+      // A link that could not be checked is still a link, so it is shown the way it was printed; a
+      // guessed number without GitHub's confirmation is not.
       .catch(() => {
         if (!disposed) {
-          const unchecked = named.map((url) => ({ url, title: null, state: null, occurredAt: null }));
+          const unchecked = named.urls.map((url) => ({ url, title: null, state: null, occurredAt: null }));
           githubItemsCache.set(sessionId, unchecked);
           setItems(unchecked);
         }
@@ -717,17 +806,40 @@ function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: st
   }, [rootId]);
 
   const repositories = repositoryGroups(remote, status ?? null, items ?? []);
+  // Searching narrows each card to what matches — a changed path, an item's title or number, or the
+  // repository's own name — and drops the cards left holding nothing.
+  const lowered = query.trim().toLowerCase();
+  const shown = lowered
+    ? repositories
+        .map((repository) => ({
+          ...repository,
+          changes: repository.changes.filter((change) => change.slice(3).toLowerCase().includes(lowered)),
+          items: repository.items.filter(
+            (item) => `#${item.number}`.includes(lowered) || item.title?.toLowerCase().includes(lowered),
+          ),
+        }))
+        .filter(
+          (repository) =>
+            repository.name.toLowerCase().includes(lowered) || repository.changes.length || repository.items.length,
+        )
+    : repositories;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <SearchInput value={query} placeholder="Search changes and items" onChange={setQuery} />
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-3 p-3">
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
           {!error && status === undefined ? <Loading label="Reading Git status…" /> : null}
-          {repositories.map((repository) => (
+          {shown.map((repository) => (
             <RepositoryCard key={(repository.url ?? repository.path)?.toLowerCase()} repository={repository} />
           ))}
-          {items === undefined && named.length ? <Loading label="Checking GitHub links…" /> : null}
+          {lowered && repositories.length && !shown.length ? (
+            <p className="text-sm text-muted-foreground">No matches</p>
+          ) : null}
+          {items === undefined && (named.urls.length || named.guessed.length) ? (
+            <Loading label="Checking GitHub links…" />
+          ) : null}
           {status === null && items && !repositories.length ? (
             <Empty>
               <EmptyHeader>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -487,11 +487,13 @@ function FileTree({
     }
   }
 
-  // A search has to see the whole tree, so the first keystroke loads it and the next keystroke — not
-  // the render a failure causes — retries a walk that failed; one that succeeded is not repeated.
+  // A search has to see the whole tree, so the first keystroke loads it and the next query — not the
+  // render a failure causes — retries a walk that failed; one that succeeded is not repeated, and a
+  // cleared search forgets the failure so the same query asks again.
   const attempted = useRef("");
   useEffect(() => {
-    if (query && query !== attempted.current && !walked.current && !expandingAll) {
+    if (!query) attempted.current = "";
+    else if (query !== attempted.current && !walked.current && !expandingAll) {
       attempted.current = query;
       void walk(false);
     }
@@ -532,7 +534,7 @@ function FileTree({
                 data-context-value={entry.path}
                 data-context-label="Copy path"
                 data-context-directory={entry.isDirectory ? "" : undefined}
-                data-context-expanded={entry.isDirectory ? open : undefined}
+                data-context-expanded={entry.isDirectory ? expanded.has(entry.path) : undefined}
                 onClick={() => (entry.isDirectory ? void toggle(entry.path) : onOpen(entry))}
               >
                 {entry.isDirectory ? (
@@ -593,7 +595,7 @@ function FileTree({
           data-context-value={root}
           data-context-label="Copy path"
           data-context-directory
-          data-context-expanded={rootOpen}
+          data-context-expanded={expanded.has(root)}
           onClick={() => void toggle(root)}
         >
           <ChevronRight

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -458,12 +458,20 @@ function FileTree({
         const path = pending.shift();
         if (!path || directories.has(path)) continue;
         directories.add(path);
-        const cached = nextChildren[path];
-        const listing =
-          cached && !cached.after
-            ? cached
-            : { ...(await invoke<DirectoryListing>("list_directory", { rootId, path, after: null })), after: null };
-        nextChildren[path] = listing;
+        // A directory is walked through every page it has: a walk that silently stopped at the first
+        // 250 entries would answer "No matches" about a file that exists.
+        let listing = nextChildren[path];
+        if (!listing || listing.after || listing.nextCursor) {
+          let entries: FileEntry[] = [];
+          let cursor: DirectoryCursor | null = null;
+          do {
+            const page: DirectoryListing = await invoke("list_directory", { rootId, path, after: cursor });
+            entries = entries.concat(page.entries);
+            cursor = page.nextCursor;
+          } while (cursor);
+          listing = { entries, nextCursor: null, after: null };
+          nextChildren[path] = listing;
+        }
         pending.push(
           ...listing.entries.filter((entry) => entry.isDirectory && !entry.isSymlink).map((entry) => entry.path),
         );
@@ -616,7 +624,12 @@ function FileTree({
         </ActionIconButton>
       </div>
       {lowered && !expandingAll && children[root] && !subtreeMatches(root) ? (
-        <p className="px-3 py-2 text-xs text-muted-foreground">No matches</p>
+        // A walk that failed did not prove absence, so its error takes the place of "No matches".
+        error ? (
+          <p className="p-3 text-xs text-destructive">{error}</p>
+        ) : (
+          <p className="px-3 py-2 text-xs text-muted-foreground">No matches</p>
+        )
       ) : null}
       {rootOpen ? rows(root, 1) : null}
     </div>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -78,12 +78,14 @@ const BARE_ITEM = /(?:^|[^\w#])#([1-9]\d{0,8})(?!\w)/g;
 function namedInSession(sessionId: string, remote: string) {
   const text = readOutput(sessionId).replace(COLOR, "");
   const urls = [...new Set(text.match(GITHUB_ITEM) ?? [])];
-  const guessable = remote.toLowerCase().startsWith("https://github.com/");
-  const numbers = new Set(guessable ? [...text.matchAll(BARE_ITEM)].map((match) => match[1]) : []);
+  // A guess is spelled with the lowercase host the checker strips, however the remote cased it.
+  const prefix = "https://github.com/";
+  const base = remote.toLowerCase().startsWith(prefix) ? prefix + remote.slice(prefix.length) : "";
+  const numbers = new Set(base ? [...text.matchAll(BARE_ITEM)].map((match) => match[1]) : []);
   for (const url of urls) {
-    if (url.toLowerCase().startsWith(`${remote.toLowerCase()}/`)) numbers.delete(url.split("/").pop() ?? "");
+    if (url.toLowerCase().startsWith(`${base.toLowerCase()}/`)) numbers.delete(url.split("/").pop() ?? "");
   }
-  return { urls, guessed: [...numbers].map((number) => `${remote}/issues/${number}`) };
+  return { urls, guessed: [...numbers].map((number) => `${base}/issues/${number}`) };
 }
 
 interface GitHubReference {
@@ -850,7 +852,7 @@ function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: st
           {shown.map((repository) => (
             <RepositoryCard key={(repository.url ?? repository.path)?.toLowerCase()} repository={repository} />
           ))}
-          {lowered && repositories.length && !shown.length ? (
+          {lowered && status !== undefined && items && repositories.length && !shown.length ? (
             <p className="text-sm text-muted-foreground">No matches</p>
           ) : null}
           {items === undefined && (named.urls.length || named.guessed.length) ? (

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -623,13 +623,10 @@ function FileTree({
           <ChevronsDownUp />
         </ActionIconButton>
       </div>
-      {lowered && !expandingAll && children[root] && !subtreeMatches(root) ? (
-        // A walk that failed did not prove absence, so its error takes the place of "No matches".
-        error ? (
-          <p className="p-3 text-xs text-destructive">{error}</p>
-        ) : (
-          <p className="px-3 py-2 text-xs text-muted-foreground">No matches</p>
-        )
+      {/* A walk that failed searched a partial tree, so its error shows over whatever it did find. */}
+      {lowered && error ? <p className="p-3 text-xs text-destructive">{error}</p> : null}
+      {lowered && !error && !expandingAll && children[root] && !subtreeMatches(root) ? (
+        <p className="px-3 py-2 text-xs text-muted-foreground">No matches</p>
       ) : null}
       {rootOpen ? rows(root, 1) : null}
     </div>


### PR DESCRIPTION
## What

- **Search in the Files panel**: a search field above the tree (same field the sidebar searches sessions with, Escape clears). The first keystroke loads the tree the same way *Expand all* does, then filters by file and folder name, keeping ancestor folders of matches visible and leaving your manually opened folders untouched once the search is cleared.
- **Search in the Git panel**: the same field narrows repository cards to matching changed paths, pull request / issue titles and numbers, and repository names, dropping cards left holding nothing.
- **GitHub checks in one round trip**: `github_items` previously ran one `gh api` process + network round trip per link, serially, and stopped checking after 20 — everything past that rendered unchecked. All references now go into a single `gh api graphql` request (one `issueOrPullRequest` alias each), the cap rises to 100, and the per-repository readability probe is deleted: the same response proves whether a repository resolved while its item did not (a true miss, dropped) or did not resolve at all (unreadable, links stay as printed).
- **Bare `#12` references count**: session output is scanned for bare numbers, guessed against the session's GitHub remote, and asked about in the same request. `issueOrPullRequest` answers without knowing the kind, and the canonical URL in the answer corrects the guess. A bare number is as easily a line number, so it appears only once GitHub confirms it — printed links keep their show-unless-proven-missing behavior.

## Why

Search was missing from both panels; the PR/issue surface was slow (20 serial round trips), silently capped, and blind to the `#12` form most conversations use.

## Validation

- `bun run check`, `bun run build`, `cargo fmt --check`, `cargo check` all pass.
- The generated GraphQL shape verified live against ultralytics/lite: found items return canonical URL + state, a missing number resolves the repository but nulls the item, an unreadable repository nulls at the repository level, all in one response.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added search to the Files and Git panels, replaced serial GitHub lookups with a batched GraphQL request, and enabled confirmed bare `#number` references in Git output.

### 📊 Key Changes
- Added Files-panel search that loads the full tree on first use, matches file and folder names, preserves ancestor folders, and supports Escape-to-clear.
- Added Git-panel search across repository names, changed paths, and pull request or issue titles and numbers, removing repository cards with no matches.
- Consolidated GitHub issue and pull request checks into one GraphQL request, increased the checked-reference limit from 20 to 100, deduplicated references, and preserved printed links when lookup results are unavailable.
- Scanned session output for bare `#number` references associated with the session’s GitHub remote; confirmed references use GitHub’s canonical URL, while unconfirmed guesses are omitted.
- Excluded `.venv` directories from file-tree listings.

### 🎯 Purpose & Impact
- Files and Git workflows can now be narrowed directly within their panels.
- GitHub reference checks handle more links with a single external request and distinguish missing items from repositories that cannot be read.
- Bare issue or pull request numbers appear only after GitHub confirms them, reducing false positives from ordinary numbers in session output.