### PR TITLE
Fix Claude descendant session status

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -2013,6 +2014,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2177,6 +2187,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3417,6 +3437,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,7 +3497,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3545,7 +3579,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3723,7 +3757,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3748,7 +3782,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4515,7 +4549,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4539,7 +4573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.20",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4595,11 +4629,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -4609,6 +4655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4645,7 +4700,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4690,6 +4756,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4828,6 +4904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5070,7 +5155,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.11"
+version = "0.0.12"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 toml_edit = "0.25"
 atomicwrites = "0.4.4"
 portable-pty = "0.9.0"
+sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 tauri-plugin-dialog = "2.7.2"
 tungstenite = "0.30"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -508,8 +508,7 @@ fn claude_settings(app: &AppHandle, session_id: &str) -> Result<PathBuf, String>
                 "PostToolUseFailure": tool_hook(),
                 "PermissionDenied": tool_hook(),
                 "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
-                "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }],
-                "Stop": [{ "hooks": [{ "type": "command", "command": activity }] }]
+                "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }]
             }
         })
         .to_string()
@@ -558,24 +557,6 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
                 && error.kind() != std::io::ErrorKind::NotFound
             {
                 return Err(error.to_string());
-            }
-        }
-        "Stop" => {
-            for entry in fs::read_dir(directory)
-                .map_err(|error| error.to_string())?
-                .flatten()
-            {
-                fs::remove_file(entry.path()).map_err(|error| error.to_string())?;
-            }
-            for task in input
-                .get("background_tasks")
-                .and_then(serde_json::Value::as_array)
-                .into_iter()
-                .flatten()
-            {
-                if let Some(key) = activity_key(task, "id") {
-                    fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
-                }
             }
         }
         _ => {}
@@ -2331,6 +2312,11 @@ fn delete_session_data(
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => return Err(error.to_string()),
         }
+    }
+    if let Err(error) = fs::remove_dir_all(directory.join(format!("activity-{session_id}")))
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error.to_string());
     }
     update_provider_session(&app, &provider_sessions, &session_id, None).map(|_| ())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -528,7 +528,9 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
     let input: serde_json::Value =
         serde_json::from_reader(std::io::stdin()).map_err(|error| error.to_string())?;
     let directory = Path::new(path);
-    fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+    if !directory.is_dir() {
+        return Ok(());
+    }
     let event = input
         .get("hook_event_name")
         .and_then(serde_json::Value::as_str)
@@ -554,7 +556,11 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
 
 fn claude_shell_running() -> bool {
     let mut system = System::new();
-    system.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().without_tasks(),
+    );
     let Ok(current) = sysinfo::get_current_pid() else {
         return false;
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -474,17 +474,18 @@ fn claude_session_exists(app: &AppHandle, session_id: &str) -> bool {
     })
 }
 
-fn claude_settings(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
+fn claude_settings(app: &AppHandle, session_id: &str, run_id: &str) -> Result<PathBuf, String> {
     let directory = app
         .path()
         .app_data_dir()
         .map_err(|error| error.to_string())?;
     let settings_path = directory.join(format!("claude-{session_id}.json"));
     let usage_path = directory.join(format!("usage-{session_id}.json"));
-    let activity_path = directory.join(format!("activity-{session_id}"));
-    if activity_path.exists() {
-        fs::remove_dir_all(&activity_path).map_err(|error| error.to_string())?;
+    let activity_directory = directory.join(format!("activity-{session_id}"));
+    if activity_directory.exists() {
+        fs::remove_dir_all(&activity_directory).map_err(|error| error.to_string())?;
     }
+    let activity_path = activity_directory.join(run_id);
     fs::create_dir_all(&activity_path).map_err(|error| error.to_string())?;
     let executable = std::env::current_exe().map_err(|error| error.to_string())?;
     let status = format!(
@@ -2109,7 +2110,7 @@ async fn spawn_session(
         )?
     };
     if !signing_in && agent == "claude" {
-        let settings = claude_settings(&app, &session_id)?;
+        let settings = claude_settings(&app, &session_id, &run_id)?;
         command.args(["--settings", &path_text(&settings)]);
     }
     command.cwd(path_text(&cwd));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -444,6 +444,10 @@ fn shell_quote(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\\\""))
 }
 
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 fn provider_home(app: &AppHandle, variable: &str, fallback: &str) -> Result<PathBuf, String> {
     std::env::var_os(variable)
         .filter(|home| !home.is_empty())
@@ -497,16 +501,12 @@ fn claude_settings(app: &AppHandle, session_id: &str) -> Result<PathBuf, String>
         shell_quote(&path_text(&executable)),
         shell_quote(&path_text(&activity_path))
     );
-    let tool_hook = || serde_json::json!([{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }]);
     write_atomic(
         &settings_path,
         serde_json::json!({
             "statusLine": { "type": "command", "command": status, "refreshInterval": 1 },
             "hooks": {
-                "PreToolUse": tool_hook(),
-                "PostToolUse": tool_hook(),
-                "PostToolUseFailure": tool_hook(),
-                "PermissionDenied": tool_hook(),
+                "PreToolUse": [{ "matcher": "Bash|PowerShell", "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }]
             }
@@ -537,22 +537,55 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
         .get("hook_event_name")
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
-    let key = activity_key(
-        &input,
-        if event.starts_with("Subagent") {
-            "agent_id"
-        } else {
-            "tool_use_id"
-        },
-    );
     match event {
-        "PreToolUse" | "SubagentStart" => {
-            if let Some(key) = key {
+        "PreToolUse" => {
+            // The hook runs before permission and returns before a background command exits, so the
+            // command itself owns the marker from its actual start through shell cleanup.
+            let Some(key) = activity_key(&input, "tool_use_id") else {
+                return Ok(());
+            };
+            let Some(mut tool_input) = input.get("tool_input").cloned() else {
+                return Ok(());
+            };
+            let Some(command) = tool_input
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+            else {
+                return Ok(());
+            };
+            let marker = path_text(&directory.join(key));
+            let command = if input.get("tool_name").and_then(serde_json::Value::as_str)
+                == Some("PowerShell")
+            {
+                let marker = powershell_quote(&marker);
+                format!(
+                    "New-Item -ItemType File -Force -Path {marker} | Out-Null; try {{\n{command}\n}} finally {{ Remove-Item -Force -LiteralPath {marker} }}"
+                )
+            } else {
+                let marker = shell_quote(&marker);
+                format!(
+                    "touch {marker}; trap {} EXIT\n{command}",
+                    shell_quote(&format!("rm -f {marker}"))
+                )
+            };
+            tool_input["command"] = command.into();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "updatedInput": tool_input
+                    }
+                })
+            );
+        }
+        "SubagentStart" => {
+            if let Some(key) = activity_key(&input, "agent_id") {
                 fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
             }
         }
-        "PostToolUse" | "PostToolUseFailure" | "PermissionDenied" | "SubagentStop" => {
-            if let Some(key) = key
+        "SubagentStop" => {
+            if let Some(key) = activity_key(&input, "agent_id")
                 && let Err(error) = fs::remove_file(directory.join(key))
                 && error.kind() != std::io::ErrorKind::NotFound
             {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,22 +480,110 @@ fn claude_settings(app: &AppHandle, session_id: &str) -> Result<PathBuf, String>
         .map_err(|error| error.to_string())?;
     let settings_path = directory.join(format!("claude-{session_id}.json"));
     let usage_path = directory.join(format!("usage-{session_id}.json"));
+    let activity_path = directory.join(format!("activity-{session_id}"));
+    if activity_path.exists() {
+        fs::remove_dir_all(&activity_path).map_err(|error| error.to_string())?;
+    }
+    fs::create_dir_all(&activity_path).map_err(|error| error.to_string())?;
     let executable = std::env::current_exe().map_err(|error| error.to_string())?;
-    let command = format!(
-        "{} --claude-statusline {}",
+    let status = format!(
+        "{} --claude-statusline {} {}",
         shell_quote(&path_text(&executable)),
-        shell_quote(&path_text(&usage_path))
+        shell_quote(&path_text(&usage_path)),
+        shell_quote(&path_text(&activity_path))
     );
+    let activity = format!(
+        "{} --claude-activity {}",
+        shell_quote(&path_text(&executable)),
+        shell_quote(&path_text(&activity_path))
+    );
+    let tool_hook = || serde_json::json!([{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }]);
     write_atomic(
         &settings_path,
-        serde_json::json!({ "statusLine": { "type": "command", "command": command } })
-            .to_string()
-            .as_bytes(),
+        serde_json::json!({
+            "statusLine": { "type": "command", "command": status, "refreshInterval": 1 },
+            "hooks": {
+                "PreToolUse": tool_hook(),
+                "PostToolUse": tool_hook(),
+                "PostToolUseFailure": tool_hook(),
+                "PermissionDenied": tool_hook(),
+                "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
+                "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }],
+                "Stop": [{ "hooks": [{ "type": "command", "command": activity }] }]
+            }
+        })
+        .to_string()
+        .as_bytes(),
     )?;
     Ok(settings_path)
 }
 
-pub fn capture_claude_status(path: &str) -> Result<(), String> {
+fn activity_key<'a>(input: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    input
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| {
+            value.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            })
+        })
+}
+
+pub fn capture_claude_activity(path: &str) -> Result<(), String> {
+    let input: serde_json::Value =
+        serde_json::from_reader(std::io::stdin()).map_err(|error| error.to_string())?;
+    let directory = Path::new(path);
+    fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+    let event = input
+        .get("hook_event_name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let key = activity_key(
+        &input,
+        if event.starts_with("Subagent") {
+            "agent_id"
+        } else {
+            "tool_use_id"
+        },
+    );
+    match event {
+        "PreToolUse" | "SubagentStart" => {
+            if let Some(key) = key {
+                fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
+            }
+        }
+        "PostToolUse" | "PostToolUseFailure" | "PermissionDenied" | "SubagentStop" => {
+            if let Some(key) = key
+                && let Err(error) = fs::remove_file(directory.join(key))
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(error.to_string());
+            }
+        }
+        "Stop" => {
+            for entry in fs::read_dir(directory)
+                .map_err(|error| error.to_string())?
+                .flatten()
+            {
+                fs::remove_file(entry.path()).map_err(|error| error.to_string())?;
+            }
+            for task in input
+                .get("background_tasks")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if let Some(key) = activity_key(task, "id") {
+                    fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub fn capture_claude_status(path: &str, activity_path: &str) -> Result<(), String> {
     let input: serde_json::Value =
         serde_json::from_reader(std::io::stdin()).map_err(|error| error.to_string())?;
     let context = input
@@ -542,14 +630,16 @@ pub fn capture_claude_status(path: &str) -> Result<(), String> {
         lifetime_tokens: None,
         windows,
     };
-    write_atomic(
-        Path::new(path),
-        &serde_json::to_vec(&snapshot).map_err(|error| error.to_string())?,
-    )?;
+    let usage = serde_json::to_vec(&snapshot).map_err(|error| error.to_string())?;
+    if !fs::read(path).is_ok_and(|current| current == usage) {
+        write_atomic(Path::new(path), &usage)?;
+    }
+    let working = fs::read_dir(activity_path).is_ok_and(|mut entries| entries.next().is_some());
+    let activity = if working { "working" } else { "idle" };
     if let Some(percent) = snapshot.context_used_percent {
-        println!("Lite · {percent:.0}% context");
+        println!("\x1b]6973;lite-{activity}\x07Lite · {percent:.0}% context");
     } else {
-        println!("Lite");
+        println!("\x1b]6973;lite-{activity}\x07Lite");
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
     thread,
     time::{Duration, SystemTime},
 };
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_updater::UpdaterExt;
@@ -444,10 +445,6 @@ fn shell_quote(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\\\""))
 }
 
-fn powershell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
-}
-
 fn provider_home(app: &AppHandle, variable: &str, fallback: &str) -> Result<PathBuf, String> {
     std::env::var_os(variable)
         .filter(|home| !home.is_empty())
@@ -506,7 +503,6 @@ fn claude_settings(app: &AppHandle, session_id: &str) -> Result<PathBuf, String>
         serde_json::json!({
             "statusLine": { "type": "command", "command": status, "refreshInterval": 1 },
             "hooks": {
-                "PreToolUse": [{ "matcher": "Bash|PowerShell", "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }]
             }
@@ -517,9 +513,9 @@ fn claude_settings(app: &AppHandle, session_id: &str) -> Result<PathBuf, String>
     Ok(settings_path)
 }
 
-fn activity_key<'a>(input: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+fn activity_key(input: &serde_json::Value) -> Option<&str> {
     input
-        .get(field)
+        .get("agent_id")
         .and_then(serde_json::Value::as_str)
         .filter(|value| {
             value.chars().all(|character| {
@@ -538,54 +534,13 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
     match event {
-        "PreToolUse" => {
-            // The hook runs before permission and returns before a background command exits, so the
-            // command itself owns the marker from its actual start through shell cleanup.
-            let Some(key) = activity_key(&input, "tool_use_id") else {
-                return Ok(());
-            };
-            let Some(mut tool_input) = input.get("tool_input").cloned() else {
-                return Ok(());
-            };
-            let Some(command) = tool_input
-                .get("command")
-                .and_then(serde_json::Value::as_str)
-            else {
-                return Ok(());
-            };
-            let marker = path_text(&directory.join(key));
-            let command = if input.get("tool_name").and_then(serde_json::Value::as_str)
-                == Some("PowerShell")
-            {
-                let marker = powershell_quote(&marker);
-                format!(
-                    "New-Item -ItemType File -Force -Path {marker} | Out-Null; try {{\n{command}\n}} finally {{ Remove-Item -Force -LiteralPath {marker} }}"
-                )
-            } else {
-                let marker = shell_quote(&marker);
-                format!(
-                    "touch {marker}; trap {} EXIT\n(\n{command}\n)",
-                    shell_quote(&format!("rm -f {marker}"))
-                )
-            };
-            tool_input["command"] = command.into();
-            println!(
-                "{}",
-                serde_json::json!({
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "updatedInput": tool_input
-                    }
-                })
-            );
-        }
         "SubagentStart" => {
-            if let Some(key) = activity_key(&input, "agent_id") {
+            if let Some(key) = activity_key(&input) {
                 fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
             }
         }
         "SubagentStop" => {
-            if let Some(key) = activity_key(&input, "agent_id")
+            if let Some(key) = activity_key(&input)
                 && let Err(error) = fs::remove_file(directory.join(key))
                 && error.kind() != std::io::ErrorKind::NotFound
             {
@@ -595,6 +550,47 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
         _ => {}
     }
     Ok(())
+}
+
+fn claude_shell_running() -> bool {
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
+    let Ok(current) = sysinfo::get_current_pid() else {
+        return false;
+    };
+    let mut ancestors = HashSet::from([current]);
+    let mut parent = system.process(current).and_then(|process| process.parent());
+    let claude = loop {
+        let Some(pid) = parent else { return false };
+        ancestors.insert(pid);
+        let Some(process) = system.process(pid) else {
+            return false;
+        };
+        let name = process.name().to_string_lossy().to_ascii_lowercase();
+        if name.strip_suffix(".exe").unwrap_or(&name) == "claude" {
+            break pid;
+        }
+        parent = process.parent();
+    };
+    system.processes().iter().any(|(pid, process)| {
+        let name = process.name().to_string_lossy().to_ascii_lowercase();
+        if ancestors.contains(pid)
+            || !matches!(
+                name.strip_suffix(".exe").unwrap_or(&name),
+                "bash" | "cmd" | "dash" | "fish" | "nu" | "powershell" | "pwsh" | "sh" | "zsh"
+            )
+        {
+            return false;
+        }
+        let mut parent = process.parent();
+        while let Some(pid) = parent {
+            if pid == claude {
+                return true;
+            }
+            parent = system.process(pid).and_then(|process| process.parent());
+        }
+        false
+    })
 }
 
 pub fn capture_claude_status(path: &str, activity_path: &str) -> Result<(), String> {
@@ -648,7 +644,8 @@ pub fn capture_claude_status(path: &str, activity_path: &str) -> Result<(), Stri
     if !fs::read(path).is_ok_and(|current| current == usage) {
         write_atomic(Path::new(path), &usage)?;
     }
-    let working = fs::read_dir(activity_path).is_ok_and(|mut entries| entries.next().is_some());
+    let working = fs::read_dir(activity_path).is_ok_and(|mut entries| entries.next().is_some())
+        || claude_shell_running();
     let activity = if working { "working" } else { "idle" };
     if let Some(percent) = snapshot.context_used_percent {
         println!("\x1b]6973;lite-{activity}\x07Lite · {percent:.0}% context");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -564,7 +564,7 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
             } else {
                 let marker = shell_quote(&marker);
                 format!(
-                    "touch {marker}; trap {} EXIT\n{command}",
+                    "touch {marker}; trap {} EXIT\n(\n{command}\n)",
                     shell_quote(&format!("rm -f {marker}"))
                 )
             };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,11 +5,20 @@
 
 fn main() {
     let mut arguments = std::env::args().skip(1);
-    if arguments.next().as_deref() == Some("--claude-statusline") {
-        if let Some(path) = arguments.next() {
-            let _ = lite_lib::capture_claude_status(&path);
+    match arguments.next().as_deref() {
+        Some("--claude-statusline") => {
+            if let (Some(usage), Some(activity)) = (arguments.next(), arguments.next()) {
+                let _ = lite_lib::capture_claude_status(&usage, &activity);
+            }
+            return;
         }
-        return;
+        Some("--claude-activity") => {
+            if let Some(path) = arguments.next() {
+                let _ = lite_lib::capture_claude_activity(&path);
+            }
+            return;
+        }
+        _ => {}
     }
     lite_lib::run()
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1083,10 +1083,10 @@ function App() {
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
-        const { title, path } = appendOutput(payload.sessionId, payload.data);
+        const { title, path, activity } = appendOutput(payload.sessionId, payload.data);
         if (title) markTitle(payload.sessionId, title);
         if (path) markDirectory(payload.sessionId, path);
-        markWorking(payload.sessionId);
+        if (activity !== false) markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -101,6 +101,7 @@ export function appendOutput(sessionId: string, data: number[]) {
   ACTIVITY.lastIndex = 0;
   for (let match = ACTIVITY.exec(text); match; match = ACTIVITY.exec(text)) activity = match[1] === "working";
   const tail = text.match(UNTERMINATED)?.[0] ?? "";
+  if (activity === undefined && tail.startsWith("\x1b]6973;lite-")) activity = false;
   buffer.tail = tail.length > MAX_TAIL ? "" : tail;
   return { title, path, activity };
 }

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -24,6 +24,11 @@ const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 // owner lives here where every session's output arrives rather than in the mounted terminal.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const METADATA = /\x1b\]([027]);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+// Lite's Claude status line reports work that produces no terminal output, such as a parent waiting
+// for subagents or a quiet shell command. The private OSC stays invisible while the shared output
+// owner makes the signal available even when the session's terminal is not mounted.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
+const ACTIVITY = /\x1b\]6973;lite-(working|idle)(?:\x07|\x1b\\)/g;
 
 // The same sequence begun but not yet terminated, which the chunk that ends it completes. A title may
 // hold an escape of its own, so the payload ends only at a terminator, and a lone escape is kept
@@ -85,6 +90,7 @@ export function appendOutput(sessionId: string, data: number[]) {
   const text = buffer.tail + decoded;
   let title = "";
   let path = "";
+  let activity: boolean | undefined;
   METADATA.lastIndex = 0;
   for (let match = METADATA.exec(text); match; match = METADATA.exec(text)) {
     if (match[1] === "7") {
@@ -92,9 +98,11 @@ export function appendOutput(sessionId: string, data: number[]) {
         path = decodeURIComponent(new URL(match[2]).pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
     } else title = match[2];
   }
+  ACTIVITY.lastIndex = 0;
+  for (let match = ACTIVITY.exec(text); match; match = ACTIVITY.exec(text)) activity = match[1] === "working";
   const tail = text.match(UNTERMINATED)?.[0] ?? "";
   buffer.tail = tail.length > MAX_TAIL ? "" : tail;
-  return { title, path };
+  return { title, path, activity };
 }
 
 export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) => void) {


### PR DESCRIPTION
## Summary

- keep Claude sessions working while shell descendants or subagents are still running
- observe shell work from Claude’s existing status-line process without rewriting commands or hook output
- reuse the existing PTY-output quiet timer as the single UI status owner
- clean up scoped subagent activity with the existing session-data owner

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo build --manifest-path src-tauri/Cargo.toml`
- focused subagent start/stop and split idle-heartbeat checks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Claude session status now remains `working` while descendant shell processes or subagents are active, including when no terminal output is produced.

### 📊 Key Changes
- Added `sysinfo`-based process inspection to detect supported shell descendants of Claude.
- Added `SubagentStart` and `SubagentStop` hooks that track active subagents in per-session activity directories.
- Updated the Claude status-line command to refresh every second, combine subagent and shell activity, and emit private activity markers.
- Updated the shared output store and PTY listener to use those markers for the existing working/idle timer without exposing them in terminal output.
- Added cleanup for per-session activity data and incremented the Rust application version to `0.0.12`.

### 🎯 Purpose & Impact
- Claude sessions can remain marked as working while a shell descendant or subagent is active but quiet.
- Subagent activity is scoped to each Claude run and removed when the session data is deleted.
- Existing Claude status-line usage and hook output are preserved while activity state is communicated internally through the status-line output.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
