### PR TITLE
Fix title bar dragging and Lite Dev updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ Useful checks:
 
 ```bash
 bun run check       # Biome and native TypeScript checks
-bun run local       # Lite Dev bundle with a red icon that you can double-click
+bun run local       # Separate Lite Dev app with a red icon and its own app data
 bun run tauri build # Native installer for the current operating system
 ```
+
+Lite Dev follows `origin/main` directly instead of release assets. Its update button fetches main and,
+when a newer commit exists, opens a visible shell session that fast-forwards and rebuilds the app.
 
 The frontend uses React, shadcn/ui Nova with Base UI, Tailwind CSS, Biome, and `tsgo`. Tauri and Rust own local persistence, terminals, Git, files, and provider processes.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsgo --noEmit && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "local": "tauri build --bundles app --config '{\"productName\":\"Lite Dev\",\"bundle\":{\"createUpdaterArtifacts\":false,\"icon\":[\"icons/dev/32x32.png\",\"icons/dev/128x128.png\",\"icons/dev/128x128@2x.png\",\"icons/dev/icon.icns\",\"icons/dev/icon.ico\"]}}'",
+    "local": "tauri build --bundles app --config '{\"productName\":\"Lite Dev\",\"identifier\":\"com.ultralytics.lite.dev\",\"bundle\":{\"createUpdaterArtifacts\":false,\"icon\":[\"icons/dev/32x32.png\",\"icons/dev/128x128.png\",\"icons/dev/128x128@2x.png\",\"icons/dev/icon.icns\",\"icons/dev/icon.ico\"]}}'",
     "check": "bun run lint && bun run typecheck && bun run deadcode",
     "deadcode": "knip",
     "format": "biome check --write .",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2915,18 +2915,25 @@ fn stop_runtime(app: &AppHandle) {
     stop_codex_server(&app.state::<CodexServer>());
 }
 
-// A local build shares its name, version, and data folder with an install, so it names the commit it
-// came from instead of the version it would otherwise be mistaken for. A release returns nothing and
-// the window shows its version.
-// A release cannot update a local build, and installing one would replace the very build being tried
-// out, so a local build asks the working tree it came from whether that tree has moved on instead.
+// A local build names the commit it came from instead of the release version it would otherwise be
+// mistaken for. It follows main directly so fixes can be used before release assets exist.
 #[tauri::command]
 fn local_update() -> Result<Option<String>, String> {
     let built = option_env!("LITE_COMMIT").ok_or("This is not a local build")?;
     let repo = option_env!("LITE_REPO").ok_or("This build did not record where it came from")?;
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
-    let head = command_output(&git, Path::new(repo), &["rev-parse", "--short", "HEAD"])
-        .map_err(|_| format!("Could not read {repo}"))?;
+    command_output(
+        &git,
+        Path::new(repo),
+        &["fetch", "--quiet", "origin", "main"],
+    )
+    .map_err(|_| "Could not fetch origin/main".to_string())?;
+    let head = command_output(
+        &git,
+        Path::new(repo),
+        &["rev-parse", "--short", "origin/main"],
+    )
+    .map_err(|_| format!("Could not read {repo}"))?;
     Ok((head != built).then_some(head))
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1506,7 +1506,7 @@ function App() {
         <div ref={layout} className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
           {/* The window buttons sit inside this bar on macOS, so it doubles as the title bar and drags the window. */}
           <header
-            data-tauri-drag-region
+            data-tauri-drag-region="deep"
             className="relative flex h-9 shrink-0 items-center border-b bg-sidebar text-sidebar-foreground"
           >
             <div
@@ -1548,7 +1548,7 @@ function App() {
                   <span className="min-w-0 truncate text-xs font-medium">{selected.name}</span>
                   <button
                     type="button"
-                    className="min-w-0 flex-1 overflow-hidden text-left font-mono text-[11px] text-muted-foreground hover:text-foreground"
+                    className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground hover:text-foreground"
                     aria-label={`Open ${selected.cwd} in file browser`}
                     onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
                   >
@@ -1570,7 +1570,7 @@ function App() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className={`absolute top-0.5 right-20 min-w-0 gap-1.5 text-muted-foreground ${shut.inspector ? "max-w-56" : "left-[3px] justify-start"}`}
+                    className={`absolute top-0.5 right-20 min-w-0 gap-1.5 text-muted-foreground ${shut.inspector ? "max-w-56" : "max-w-[calc(100%-5.75rem)]"}`}
                     data-context-url={remote}
                     aria-label={`Open ${remote}`}
                     onClick={() => void invoke("open_url", { url: remote })}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1455,7 +1455,7 @@ function App() {
       };
       setUpdateOpen(false);
       createSession(session);
-      runOnStart(session.id, "bun run local");
+      runOnStart(session.id, "git pull --ff-only origin main && bun run local");
     } catch (reason) {
       setRebuilding(false);
       setUpdateError(String(reason));
@@ -1935,7 +1935,7 @@ function App() {
                     ? `Lite ${availableVersion} is ready. Updating stops running sessions; their tabs resume after restart.`
                     : null}
                   {updateStatus === "rebuild"
-                    ? `This build is ${commit} and the tree is now ${availableVersion}. Rebuilding runs bun run local in a shell tab, and replaces this build when it finishes.`
+                    ? `This build is ${commit} and main is now ${availableVersion}. Rebuilding fast-forwards from origin/main in a shell tab, then replaces this build.`
                     : null}
                   {updateStatus === "current" ? (
                     <span className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

- restore window dragging across the nested 0.0.13 title bar
- keep folder and repository click targets limited to their visible labels
- give Lite Dev its own bundle identity and app-data directory
- let Lite Dev check and fast-forward directly from `origin/main` before rebuilding, without release assets

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `bun run local`
- verified bundle name `Lite Dev` and identifier `com.ultralytics.lite.dev`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the Lite window interactions and development build workflow so nested title-bar dragging works reliably and Lite Dev can update directly from `origin/main`.

### 📊 Key Changes

- Changed the title bar to use deep Tauri drag-region behavior, restoring dragging across nested controls.
- Limited folder and repository click targets to their visible label areas instead of allowing them to fill the remaining header space.
- Gave Lite Dev the `com.ultralytics.lite.dev` identifier, separating its bundle identity and app-data location from the release app.
- Changed Lite Dev update checks to fetch and compare against `origin/main`, then rebuild with `git pull --ff-only origin main && bun run local` in a visible shell session.
- Updated the Lite Dev status message and README to describe the `origin/main` update and rebuild flow.

### 🎯 Purpose & Impact

- Users can drag the window from the nested 0.0.13 title bar while folder and repository actions remain confined to their visible labels.
- Lite Dev updates now use the checked-out repository’s `origin/main` branch rather than release assets.
- Lite Dev can be installed and run alongside the release app without sharing its bundle identity or app-data directory.