### PR TITLE
Fix file viewer navigation, zoom, and markdown typography

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.14"
+version = "0.0.15"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/App.css
+++ b/src/App.css
@@ -115,13 +115,13 @@
 }
 
 .markdown-viewer h1 {
-  font-size: 1.5rem;
+  font-size: 1.5em;
 }
 .markdown-viewer h2 {
-  font-size: 1.25rem;
+  font-size: 1.25em;
 }
 .markdown-viewer h3 {
-  font-size: 1.05rem;
+  font-size: 1.05em;
 }
 .markdown-viewer p,
 .markdown-viewer ul,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,7 @@ import { NewSessionDialog } from "@/new-session-dialog";
 import { appendOutput, clearOutput, subscribeOutput, syncTerminalTheme, writeSession } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
 import { applyTheme, initialTheme, type Theme } from "@/theme";
-import { type Agent, folderName, repoName, type Session, sessionLabel } from "@/types";
+import { type Agent, defaultSessionName, repoName, type Session, sessionLabel } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
@@ -600,7 +600,7 @@ function loadSessions(): Session[] {
       .map((session) => ({
         ...session,
         running: false,
-        renamed: session.renamed ?? session.name !== folderName(session.cwd),
+        renamed: session.renamed ?? session.name !== defaultSessionName(session.cwd),
       }));
   } catch {
     return [];
@@ -1149,7 +1149,12 @@ function App() {
       const session = current.find((item) => item.id === sessionId);
       if (!session || session.mode || session.renamed) return current;
       const name = subject(title);
-      if (!name || name === session.name || name === sessionLabel(session) || name === folderName(session.cwd)) {
+      if (
+        !name ||
+        name === session.name ||
+        name === sessionLabel(session) ||
+        name === defaultSessionName(session.cwd)
+      ) {
         return current;
       }
       return current.map((item) => (item.id === sessionId ? { ...item, name } : item));
@@ -1931,7 +1936,9 @@ function App() {
                                   );
                                 setSessions((current) =>
                                   current.map((item) =>
-                                    item.id === session.id && !item.renamed && item.name === folderName(item.cwd)
+                                    item.id === session.id &&
+                                    !item.renamed &&
+                                    item.name === defaultSessionName(item.cwd)
                                       ? { ...item, name: subject(text) }
                                       : item,
                                   ),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,7 @@ import { NewSessionDialog } from "@/new-session-dialog";
 import { appendOutput, clearOutput, subscribeOutput, syncTerminalTheme, writeSession } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
 import { applyTheme, initialTheme, type Theme } from "@/theme";
-import { type Agent, type Session, sessionLabel } from "@/types";
+import { type Agent, folderName, repoName, type Session, sessionLabel } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
@@ -228,6 +228,8 @@ function menuContext(target: EventTarget | null): AppMenuContext {
   const session = target.closest<HTMLElement>("[data-context-session]");
   const surface = session ? null : target.closest<HTMLElement>("[data-context-surface]");
   const files = target.closest<HTMLElement>("[data-context-files]");
+  // The terminal and the file viewer each zoom their own type, so the menu offers whichever owns the click.
+  const zoom = target.closest<HTMLElement>("[data-context-zoom]");
   const selectedText =
     editable instanceof HTMLInputElement || editable instanceof HTMLTextAreaElement
       ? inputSelection(editable)
@@ -248,9 +250,9 @@ function menuContext(target: EventTarget | null): AppMenuContext {
     url: link instanceof HTMLAnchorElement ? link.href : (link?.dataset.contextUrl ?? ""),
     value: value?.dataset.contextValue ?? "",
     valueLabel: value?.dataset.contextLabel ?? "Copy",
-    zoomIn: session?.querySelector<HTMLButtonElement>("[data-context-zoom-in]") ?? null,
-    zoomOut: session?.querySelector<HTMLButtonElement>("[data-context-zoom-out]") ?? null,
-    zoomReset: session?.querySelector<HTMLButtonElement>("[data-context-zoom-reset]") ?? null,
+    zoomIn: zoom?.querySelector<HTMLButtonElement>("[data-context-zoom-in]") ?? null,
+    zoomOut: zoom?.querySelector<HTMLButtonElement>("[data-context-zoom-out]") ?? null,
+    zoomReset: zoom?.querySelector<HTMLButtonElement>("[data-context-zoom-reset]") ?? null,
   };
 }
 
@@ -369,26 +371,27 @@ function AppContextMenu({
               <Trash2 />
               Close session
             </ContextMenuItem>
-            {context.zoomIn ? (
-              <>
-                <ContextMenuSeparator />
-                <ContextMenuItem onClick={() => context.zoomIn?.click()}>
-                  <ZoomIn />
-                  Zoom in
-                  <ContextMenuShortcut>{shortcut}+</ContextMenuShortcut>
-                </ContextMenuItem>
-                <ContextMenuItem onClick={() => context.zoomOut?.click()}>
-                  <ZoomOut />
-                  Zoom out
-                  <ContextMenuShortcut>{shortcut}-</ContextMenuShortcut>
-                </ContextMenuItem>
-                <ContextMenuItem onClick={() => context.zoomReset?.click()}>
-                  <RotateCcw />
-                  Actual size
-                  <ContextMenuShortcut>{shortcut}0</ContextMenuShortcut>
-                </ContextMenuItem>
-              </>
-            ) : null}
+          </>
+        ) : null}
+        {context.zoomIn ? (
+          <>
+            {session ? <ContextMenuSeparator /> : null}
+            <ContextMenuItem onClick={() => context.zoomIn?.click()}>
+              <ZoomIn />
+              Zoom in
+              <ContextMenuShortcut>{shortcut}+</ContextMenuShortcut>
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => context.zoomOut?.click()}>
+              <ZoomOut />
+              Zoom out
+              <ContextMenuShortcut>{shortcut}-</ContextMenuShortcut>
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => context.zoomReset?.click()}>
+              <RotateCcw />
+              Actual size
+              <ContextMenuShortcut>{shortcut}0</ContextMenuShortcut>
+            </ContextMenuItem>
+            {!session && (linkGroup || surfaceGroup) ? <ContextMenuSeparator /> : null}
           </>
         ) : null}
         {context.url ? (
@@ -477,7 +480,7 @@ function AppContextMenu({
             </ContextMenuItem>
           </>
         ) : null}
-        {(linkGroup || surfaceGroup || sessionsGroup) && editGroup ? <ContextMenuSeparator /> : null}
+        {(linkGroup || surfaceGroup || sessionsGroup || context.zoomIn) && editGroup ? <ContextMenuSeparator /> : null}
         {context.editable ? (
           <>
             <ContextMenuItem disabled={!context.selectedText || readonly} onClick={() => edit(context, "cut")}>
@@ -856,15 +859,6 @@ function runOnStart(sessionId: string, command: string) {
     settle = window.setTimeout(send, SETTLE_MS);
   });
   const patience = window.setTimeout(send, GIVE_UP_MS);
-}
-
-function folderName(cwd: string) {
-  return cwd.split(/[\\/]/).filter(Boolean).pop() ?? "Session";
-}
-
-// A remote names a repository; the scheme and host that reach it are the tooltip's job.
-function repoName(url: string) {
-  return url.replace(/^https:\/\/[^/]+\//, "");
 }
 
 // Paths truncate from the right, which hides the part that identifies the folder, so only its tail shows.

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -107,7 +107,7 @@ export default function CodePreview({ path, source }: { path: string; source: st
   const extension = path.split(".").pop()?.toLowerCase() ?? "";
   if (extension === "md" || extension === "mdx") {
     return (
-      <article className="markdown-viewer max-w-none px-6 py-5 text-sm leading-7">
+      <article className="markdown-viewer max-w-none px-6 py-5">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{
@@ -134,7 +134,7 @@ export default function CodePreview({ path, source }: { path: string; source: st
     );
   }
   return (
-    <pre className="flex min-h-full overflow-auto font-mono text-[12.5px] leading-5">
+    <pre className="flex min-h-full overflow-auto font-mono">
       <LineNumbers count={source.split("\n").length} />
       <HighlightedCode source={source} language={extensionLanguages[extension]} className="py-4 pr-4 pl-3" />
     </pre>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -679,9 +679,11 @@ function FileViewer({
 
   // Escape and ArrowLeft step back to the tree from anywhere focus has wandered — after a menu closes,
   // after a click on nothing — but never out from under typing: a terminal, a field, or an open layer
-  // reads its own keys, and a key one of them has already answered is not answered again.
+  // reads its own keys, and a key one of them has already answered is not answered again. The panel
+  // stays mounted behind other tabs and the collapsed rail, so a viewer nobody can see answers nothing.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
+      if (!viewer.current || viewer.current.offsetParent === null) return;
       if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
       if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
       const target = event.target;

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -770,13 +770,15 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
 
   // The tree is hidden behind an open file rather than thrown away, so stepping back returns to the
   // folders exactly as they were left — expanded, loaded, and scrolled — without rereading the disk.
+  // A new root grant is a different tree, so it starts over the way a first open does; the open file
+  // stays, since its content was already read.
   return (
     <div className="flex h-full min-h-0 flex-col">
       {selected ? <FileViewer entry={selected} source={source} error={error} onBack={() => setSelected(null)} /> : null}
       <div data-context-files className={`min-h-0 flex-1 flex-col ${selected ? "hidden" : "flex"}`}>
         <SearchInput value={query} placeholder="Search files" onChange={setQuery} />
         <ScrollArea className="min-h-0 flex-1">
-          <FileTree root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
+          <FileTree key={rootId} root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
         </ScrollArea>
       </div>
     </div>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -2,6 +2,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import {
+  ArrowLeft,
   ChartNoAxesColumn,
   ChevronLeft,
   ChevronRight,
@@ -58,8 +59,10 @@ import {
   type DirectoryCursor,
   type DirectoryListing,
   type FileEntry,
+  folderName,
   type GitStatus,
   providerLabel,
+  repoName,
   type Session,
   sessionLabel,
 } from "@/types";
@@ -143,10 +146,6 @@ interface RepositoryGroup {
   url: string | null;
 }
 
-function repositoryName(url: string) {
-  return url.replace(/^https:\/\/[^/]+\//, "");
-}
-
 function relativeAge(timestamp: string) {
   const seconds = Math.max(0, Math.floor((Date.now() - Date.parse(timestamp)) / 1000));
   if (seconds < 60) return seconds < 10 ? "just now" : `${seconds} sec ago`;
@@ -181,7 +180,7 @@ function repositoryGroups(remote: string, status: GitStatus | null, items: GitHu
       changesTruncated: status.changesTruncated,
       lineDiffs: status.lineDiffs,
       items: [],
-      name: remote ? repositoryName(remote) : status.worktree.split(/[\\/]/).filter(Boolean).pop() || status.worktree,
+      name: remote ? repoName(remote) : folderName(status.worktree) || status.worktree,
       path: status.worktree,
       url: remote || null,
     });
@@ -592,8 +591,7 @@ function FileTree({
     );
   }
 
-  const parts = root.split(/[\\/]/).filter(Boolean);
-  const name = parts[parts.length - 1] ?? root;
+  const name = folderName(root) || root;
   const rootOpen = !!lowered || expanded.has(root);
   return (
     <div className="py-1">
@@ -644,6 +642,113 @@ function FileTree({
   );
 }
 
+// The same size and limits as the terminal's type, stored on its own key: prose and code read at
+// different sizes than a terminal for different people, so each surface remembers its own.
+const PREVIEW_FONT_KEY = "lite.preview.fontSize";
+const MIN_PREVIEW_FONT = 9;
+const MAX_PREVIEW_FONT = 24;
+const DEFAULT_PREVIEW_FONT = 13;
+
+function storedPreviewFontSize(): number {
+  const saved = Number(localStorage.getItem(PREVIEW_FONT_KEY));
+  return saved >= MIN_PREVIEW_FONT && saved <= MAX_PREVIEW_FONT ? saved : DEFAULT_PREVIEW_FONT;
+}
+
+// The preview inherits its type from here, so one zoom scales code, prose, and the line-number gutter
+// together while the header chrome keeps its own size. Zooming lives in this component so a step
+// re-renders the view alone, never the tree hidden behind it.
+function FileViewer({
+  entry,
+  source,
+  error,
+  onBack,
+}: {
+  entry: FileEntry;
+  source: string;
+  error: string;
+  onBack: () => void;
+}) {
+  const [fontSize, setFontSize] = useState(storedPreviewFontSize);
+  const viewer = useRef<HTMLElement>(null);
+
+  // Reading is keyboard work, so the viewer takes focus as it opens and the zoom keys land here
+  // rather than wherever the pointer last was.
+  useEffect(() => {
+    viewer.current?.focus();
+  }, []);
+
+  // Escape and ArrowLeft step back to the tree from anywhere focus has wandered — after a menu closes,
+  // after a click on nothing — but never out from under typing: a terminal, a field, or an open layer
+  // reads its own keys, and a key one of them has already answered is not answered again.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest("input, textarea, [contenteditable=true], [role=dialog], [role=menu], [data-context-session]")
+      )
+        return;
+      event.preventDefault();
+      onBack();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onBack]);
+
+  function zoom(step: -1 | 0 | 1) {
+    const size = step ? Math.min(MAX_PREVIEW_FONT, Math.max(MIN_PREVIEW_FONT, fontSize + step)) : DEFAULT_PREVIEW_FONT;
+    setFontSize(size);
+    localStorage.setItem(PREVIEW_FONT_KEY, String(size));
+  }
+
+  return (
+    <section
+      ref={viewer}
+      aria-label={entry.name}
+      tabIndex={-1}
+      data-context-zoom
+      className="flex min-h-0 flex-1 flex-col outline-none"
+      style={{ fontSize, lineHeight: 1.6 }}
+      onKeyDown={(event) => {
+        if (!(event.metaKey || event.ctrlKey)) return;
+        const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
+        if (!step && event.key !== "0") return;
+        event.preventDefault();
+        zoom(step);
+      }}
+    >
+      <div
+        className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]"
+        data-context-value={entry.path}
+        data-context-label="Copy path"
+      >
+        <ActionIconButton size="icon-sm" tooltip="Back to files" aria-label="Back to files" onClick={onBack}>
+          <ArrowLeft />
+        </ActionIconButton>
+        <FileIcon name={entry.name} />
+        <span className="min-w-0 flex-1 truncate font-medium">{entry.name}</span>
+        <ActionIconButton size="icon-sm" tooltip="Close file" aria-label="Close file" onClick={onBack}>
+          <X />
+        </ActionIconButton>
+      </div>
+      <button type="button" hidden data-context-zoom-in onClick={() => zoom(1)} />
+      <button type="button" hidden data-context-zoom-out onClick={() => zoom(-1)} />
+      <button type="button" hidden data-context-zoom-reset onClick={() => zoom(0)} />
+      <ScrollArea className="min-h-0 flex-1">
+        {error ? (
+          <div className="p-3 text-xs text-muted-foreground">{error}</div>
+        ) : (
+          <Suspense fallback={<Loading label="Opening file…" />}>
+            <CodePreview path={entry.path} source={source} />
+          </Suspense>
+        )}
+      </ScrollArea>
+    </section>
+  );
+}
+
 function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
   const [selected, setSelected] = useState<FileEntry | null>(null);
   const [source, setSource] = useState("");
@@ -661,39 +766,17 @@ function FilesPanel({ root, rootId }: { root: string; rootId: string }) {
     }
   }
 
-  if (selected) {
-    return (
-      <div className="flex h-full min-h-0 flex-col">
-        <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2">
-          <FileIcon name={selected.name} />
-          <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{selected.name}</span>
-          <ActionIconButton
-            size="icon-sm"
-            tooltip="Close file"
-            aria-label="Close file"
-            onClick={() => setSelected(null)}
-          >
-            <X />
-          </ActionIconButton>
-        </div>
+  // The tree is hidden behind an open file rather than thrown away, so stepping back returns to the
+  // folders exactly as they were left — expanded, loaded, and scrolled — without rereading the disk.
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {selected ? <FileViewer entry={selected} source={source} error={error} onBack={() => setSelected(null)} /> : null}
+      <div data-context-files className={`min-h-0 flex-1 flex-col ${selected ? "hidden" : "flex"}`}>
+        <SearchInput value={query} placeholder="Search files" onChange={setQuery} />
         <ScrollArea className="min-h-0 flex-1">
-          {error ? (
-            <div className="p-3 text-xs text-muted-foreground">{error}</div>
-          ) : (
-            <Suspense fallback={<Loading label="Opening file…" />}>
-              <CodePreview path={selected.path} source={source} />
-            </Suspense>
-          )}
+          <FileTree root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
         </ScrollArea>
       </div>
-    );
-  }
-  return (
-    <div data-context-files className="flex h-full min-h-0 flex-col">
-      <SearchInput value={query} placeholder="Search files" onChange={setQuery} />
-      <ScrollArea className="min-h-0 flex-1">
-        <FileTree root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
-      </ScrollArea>
     </div>
   );
 }

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -22,7 +22,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
-import { folderName, type Session, sessionLabel } from "@/types";
+import { defaultSessionName, type Session, sessionLabel } from "@/types";
 
 const choices = [
   ...Object.values(AUTH_PROVIDERS),
@@ -142,7 +142,7 @@ export function NewSessionDialog({
   async function create() {
     const folder = await grant();
     if (!folder) return;
-    const project = folderName(folder.path) || "Session";
+    const project = defaultSessionName(folder.path);
     onCreate({
       id: crypto.randomUUID(),
       agent: choice.agent,

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -22,7 +22,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
-import { type Session, sessionLabel } from "@/types";
+import { folderName, type Session, sessionLabel } from "@/types";
 
 const choices = [
   ...Object.values(AUTH_PROVIDERS),
@@ -142,7 +142,7 @@ export function NewSessionDialog({
   async function create() {
     const folder = await grant();
     if (!folder) return;
-    const project = folder.path.split(/[\\/]/).filter(Boolean).pop() ?? "Session";
+    const project = folderName(folder.path) || "Session";
     onCreate({
       id: crypto.randomUUID(),
       agent: choice.agent,

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -243,7 +243,7 @@ export function TerminalView({
   // them past the edge, which also left the last row below the viewport where the scrollbar could
   // neither show nor reach it.
   return (
-    <div data-context-session={sessionId} className="h-full w-full bg-background p-3">
+    <div data-context-session={sessionId} data-context-zoom className="h-full w-full bg-background p-3">
       <button type="button" hidden data-context-zoom-in onClick={() => zoomRef.current(1)} />
       <button type="button" hidden data-context-zoom-out onClick={() => zoomRef.current(-1)} />
       <button type="button" hidden data-context-zoom-reset onClick={() => zoomRef.current(0)} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,13 @@ export function folderName(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? "";
 }
 
+// A session is named for its folder until someone or something names it better; a root path that
+// names no folder falls back to "Session". Creation and every is-it-still-the-default comparison
+// share this one spelling.
+export function defaultSessionName(cwd: string): string {
+  return folderName(cwd) || "Session";
+}
+
 // A remote names a repository; the scheme and host that reach it are the tooltip's job.
 export function repoName(url: string): string {
   return url.replace(/^https:\/\/[^/]+\//, "");

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,16 @@ export function sessionLabel({ agent, provider }: Pick<Session, "agent" | "provi
   return agentLabels[agent];
 }
 
+// The last real segment of a path, on either separator; empty when the path has none.
+export function folderName(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? "";
+}
+
+// A remote names a repository; the scheme and host that reach it are the tooltip's job.
+export function repoName(url: string): string {
+  return url.replace(/^https:\/\/[^/]+\//, "");
+}
+
 export interface FileEntry {
   name: string;
   path: string;


### PR DESCRIPTION
Fixes the file viewer UX in the inspector Files panel, reported from daily use:

- **Closing a file no longer resets the file tree.** The tree previously unmounted whenever a file opened, so stepping back rebuilt it from disk with every folder collapsed. The tree now stays mounted and hidden behind the open file — expanded folders, loaded listings, and scroll position all survive, and nothing is re-read.
- **Back navigation out of a file.** A leading back button joins the existing X, and Escape or ArrowLeft steps back to the tree from anywhere — except while typing in a terminal, a field, or an open dialog or menu, which keep their own keys.
- **File viewer zoom.** Cmd/Ctrl +/−/0 now zooms the preview the way the terminal zooms its type, persisted on its own key with the same 9–24 bounds, and the right-click menu offers the same Zoom in / Zoom out / Actual size items it already offers over a terminal (the menu's zoom lookup is generalized from session-scoped to a shared `data-context-zoom` host).
- **Markdown typography fixed.** The markdown preview was set at double line spacing (`leading-7` on 14px text). Code and markdown now share one inherited 13px/1.6 base — matching the terminal's default type — so the zoom scales prose, code, and the line-number gutter together, and heading sizes moved from rem to em so they scale too.

Deleted: duplicate `folderName` (4 copies across App, inspector, and the new-session dialog) and `repoName` (2 copies) now live once in `types.ts`; the fixed `text-[12.5px]`/`text-sm leading-7` preview sizes are gone in favor of the single inherited base.

Version bumped to 0.0.15.

Validated visually by driving the frontend with a mocked Tauri bridge: tree state survives close (screenshots), Escape/ArrowLeft return from both markdown and code views, zoom steps 13→15px and resets, and the viewer context menu shows the zoom group.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the inspector file viewer to preserve file-tree state, support back navigation and zoom controls, and use consistent scalable typography, with the application version bumped to 0.0.15.

### 📊 Key Changes

- Kept the `FileTree` mounted and hidden while a file is open, preserving expanded folders, loaded listings, and scroll position without rereading the directory.
- Added file-viewer back navigation through the back button, Escape, and ArrowLeft, while excluding terminals, editable fields, dialogs, and menus.
- Added independent file-preview zoom from 9–24px with Cmd/Ctrl `+`, `-`, and `0`, persisted under `lite.preview.fontSize`; the viewer context menu now exposes Zoom in, Zoom out, and Actual size.
- Unified markdown and code previews around an inherited 13px/1.6 base so zoom scales prose, code, headings, and line numbers together; markdown headings now use scalable `em` sizing.
- Centralized `folderName`, `defaultSessionName`, and `repoName` in `src/types.ts`, removing duplicate helpers from the app, inspector, and new-session dialog.

### 🎯 Purpose & Impact

- Closing or navigating back from a file returns users to the same file-tree state instead of rebuilding a collapsed tree.
- Keyboard and context-menu workflows now work consistently across terminal and file-preview zoom surfaces, while preview typography scales as a single unit.
- The frontend behavior was visually checked with a mocked Tauri bridge for tree-state preservation, keyboard navigation, zoom steps and reset, and viewer context-menu zoom actions.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
