### PR TITLE
Fix native window close after session actions

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,10 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "core:window:allow-start-dragging", "core:window:allow-is-fullscreen"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-destroy",
+    "core:window:allow-start-dragging",
+    "core:window:allow-is-fullscreen"
+  ]
 }


### PR DESCRIPTION
## Summary

Allow the existing close-request handler to destroy the main window after pending session cleanup completes.

The handler already calls `window.destroy()`, but the main-window capability did not permit that command, leaving the intercepted macOS close request open.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Enabled the main window to be destroyed so the existing close-request handler can complete native window closure after session cleanup.

### 📊 Key Changes

- Added `core:window:allow-destroy` to the `main` window permissions in `src-tauri/capabilities/default.json`.
- Preserved the existing window permissions for default operations, drag handling, and fullscreen checks.

### 🎯 Purpose & Impact

- Intercepted macOS close requests can now execute the handler’s existing `window.destroy()` call after pending session cleanup, allowing the main window to close.