### PR TITLE
Stop terminal counters resolving as pull requests

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.15"
+version = "0.0.16"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -83,7 +83,7 @@ const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\
 // Not preceded by a path character, so the fragment of a documentation link is not read as a reference.
 const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
 const BARE_ITEM =
-  /(?:^|[^\w#])(?:prs?|pulls?|issues?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|see|at|in|on|and|to)\s+#([1-9]\d{0,8})(?!\w)/gi;
+  /(?:^|[^\w#])(?:prs?|pull(?:s|\s+requests?)?|issues?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|see|at|in|on|and|to)\s+#([1-9]\d{0,8})(?!\w)/gi;
 const SCANNED_OUTPUT = 50_000;
 
 function namedInSession(sessionId: string, remote: string) {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -70,27 +70,40 @@ import {
 const CodePreview = lazy(() => import("@/code-preview"));
 
 // A session's terminal is the only record of what it worked on, so what it named is read back out of
-// the output Lite already keeps: every whole pull request or issue link GitHub prints verbatim, and
-// every bare "#12" the conversation names one by. A bare number is a guess — it is as easily a line
-// number — so it is sent separately and only shown once GitHub confirms it names real work in the
-// session's own repository, which is the only repository a bare number can mean.
+// the output Lite already keeps: every whole pull request or issue link GitHub prints verbatim, the
+// "owner/repo#12" GitHub itself links work by, and the bare "#12" a conversation names one by. Neither
+// short form is a link, so both are sent separately and only shown once GitHub confirms them, and a
+// bare number names no repository so it can only mean the session's own. A bare number is also how a
+// terminal counts things that are not work, as in "[Image #1]" or "Task #3", so only one a verb or a
+// preposition introduces is read as a reference, and only recent output is read at all.
 // Only CSI is stripped, so a link inside an OSC hyperlink survives being uncoloured.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\d+/g;
-const BARE_ITEM = /(?:^|[^\w#])#([1-9]\d{0,8})(?!\w)/g;
+// Not preceded by a path character, so the fragment of a documentation link is not read as a reference.
+const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
+const BARE_ITEM =
+  /(?:^|[^\w#])(?:prs?|pulls?|issues?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|see|at|in|on|and|to)\s+#([1-9]\d{0,8})(?!\w)/gi;
+const SCANNED_OUTPUT = 50_000;
 
 function namedInSession(sessionId: string, remote: string) {
-  const text = readOutput(sessionId).replace(COLOR, "");
+  const buffered = readOutput(sessionId);
+  // The window starts at the line after it opens, so a link is never read as the half of it that fit,
+  // and at the cut itself when the rest of the buffer is one line.
+  const cut = buffered.length - SCANNED_OUTPUT;
+  const text = buffered.slice(cut > 0 ? Math.max(cut, buffered.indexOf("\n", cut) + 1) : 0).replace(COLOR, "");
   const urls = [...new Set(text.match(GITHUB_ITEM) ?? [])];
-  // A guess is spelled with the lowercase host the checker strips, however the remote cased it.
+  // A guess is spelled with the lowercase host the checker strips, and as an issue whichever kind it
+  // names, because the answer names the kind and carries the canonical URL. The checker is also where
+  // a guess is dropped for the printed link to the same item, along with every other way one item is
+  // named twice.
   const prefix = "https://github.com/";
+  const guessed = new Set(
+    [...text.matchAll(QUALIFIED_ITEM)].map((match) => `${prefix}${match[1]}/${match[2]}/issues/${match[3]}`),
+  );
   const base = remote.toLowerCase().startsWith(prefix) ? prefix + remote.slice(prefix.length) : "";
-  const numbers = new Set(base ? [...text.matchAll(BARE_ITEM)].map((match) => match[1]) : []);
-  for (const url of urls) {
-    if (url.toLowerCase().startsWith(`${base.toLowerCase()}/`)) numbers.delete(url.split("/").pop() ?? "");
-  }
-  return { urls, guessed: [...numbers].map((number) => `${base}/issues/${number}`) };
+  if (base) for (const match of text.matchAll(BARE_ITEM)) guessed.add(`${base}/issues/${match[1]}`);
+  return { urls, guessed: [...guessed] };
 }
 
 interface GitHubReference {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -73,9 +73,8 @@ const CodePreview = lazy(() => import("@/code-preview"));
 // the output Lite already keeps: every whole pull request or issue link GitHub prints verbatim, the
 // "owner/repo#12" GitHub itself links work by, and the bare "#12" a conversation names one by. Neither
 // short form is a link, so both are sent separately and only shown once GitHub confirms them, and a
-// bare number names no repository so it can only mean the session's own. A bare number is also how a
-// terminal counts things that are not work, as in "[Image #1]" or "Task #3", so only one a verb or a
-// preposition introduces is read as a reference, and only recent output is read at all.
+// bare number names no repository so it can only mean the session's own. It is also how a terminal
+// counts what is not work, as in "[Image #1]", so only one a verb or a preposition introduces counts.
 // Only CSI is stripped, so a link inside an OSC hyperlink survives being uncoloured.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
@@ -88,15 +87,11 @@ const SCANNED_OUTPUT = 50_000;
 
 function namedInSession(sessionId: string, remote: string) {
   const buffered = readOutput(sessionId);
-  // The window starts at the line after it opens, so a link is never read as the half of it that fit,
-  // and at the cut itself when the rest of the buffer is one line.
+  // The window opens at a line boundary, so a link is never read as the half of it that fit.
   const cut = buffered.length - SCANNED_OUTPUT;
   const text = buffered.slice(cut > 0 ? Math.max(cut, buffered.indexOf("\n", cut) + 1) : 0).replace(COLOR, "");
   const urls = [...new Set(text.match(GITHUB_ITEM) ?? [])];
-  // A guess is spelled with the lowercase host the checker strips, and as an issue whichever kind it
-  // names, because the answer names the kind and carries the canonical URL. The checker is also where
-  // a guess is dropped for the printed link to the same item, along with every other way one item is
-  // named twice.
+  // A guess is spelled with the lowercase host the checker strips, and as an issue whichever kind it names.
   const prefix = "https://github.com/";
   const guessed = new Set(
     [...text.matchAll(QUALIFIED_ITEM)].map((match) => `${prefix}${match[1]}/${match[2]}/issues/${match[3]}`),


### PR DESCRIPTION
A session prints a pasted screenshot as `[Image #1]`, and the Git panel read that number as a reference to the repository the session is in.

<img width="2404" height="1188" alt="CleanShot 2026-08-10 at 00 55 40@2x" src="https://github.com/user-attachments/assets/409cabf1-9701-4d28-980a-cf8c5b761775" />

In local Claude Code and Codex transcripts, most bare `#N` is a counter, not a reference:

| counter | hits |
| --- | ---: |
| `[Image #N]` (Codex) | 11,307 |
| `Hyp #N` (Claude Code) | 911 |
| `Task #N` (Claude Code) | 647 |
| `[Image #N]` (Claude Code) | 600 |
| `run #N` (Claude Code) | 210 |

- 59% of Codex bare-`#N` hits (12,520 of 21,293) are `#1` to `#10`, which resolve in nearly every repository
- the keyword guard cuts bare matches 85%, and keeps `see #58`, `closes #123`, `look at #22001`
- `owner/repo#12` now matches too: 402 `ultralytics/actions#N`, 192 `.github#N` in Codex transcripts
- the scan reads the last 50k characters, not the full 1 MB buffer
- the frontend guess/link dedupe is deleted, `check_github_items` already does it
