### PR TITLE
Add agent attention notifications

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -561,6 +561,7 @@ fn claude_settings(app: &AppHandle, session_id: &str, run_id: &str) -> Result<Pa
     write_atomic(
         &settings_path,
         serde_json::json!({
+            "preferredNotifChannel": "iterm2",
             "statusLine": { "type": "command", "command": status, "refreshInterval": 1 },
             "hooks": {
                 "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
@@ -2036,6 +2037,10 @@ fn agent_command(
         }
         "codex" => {
             let mut command = agent_builder(agent)?;
+            // Codex otherwise suppresses notifications while its terminal is focused and its automatic
+            // method falls back to BEL for Lite's generic TERM. Keep the override local to this launch.
+            command.args(["-c", r#"tui.notification_method="osc9""#]);
+            command.args(["-c", r#"tui.notification_condition="always""#]);
             // Providers are selected per launch so the user's default Codex provider stays untouched.
             if let Some(provider) = codex_provider(provider) {
                 let key = saved_api_key(app, agent, Some(provider.id)).is_some();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1874,7 +1874,9 @@ function App() {
                                 variant="ghost"
                                 size="icon-sm"
                                 aria-pressed={session.id === selectedId}
-                                aria-label={session.name}
+                                aria-label={
+                                  attention.includes(session.id) ? `${session.name}; needs attention` : session.name
+                                }
                                 data-context-session={session.id}
                                 className={
                                   session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"
@@ -2242,6 +2244,8 @@ function App() {
                 <Button
                   variant="destructive"
                   onClick={() => {
+                    attentionRef.current = [];
+                    setAttention([]);
                     void Promise.all(
                       sessions.map(async (session) => {
                         runs.current.delete(session.id);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -632,19 +632,23 @@ function SessionBadge({
   session,
   agent = session.agent,
   active,
+  attention,
   starting,
   working,
 }: {
   session: Session;
   agent?: Agent;
   active: boolean;
+  attention: boolean;
   starting: boolean;
   working: boolean;
 }) {
   const status = SESSION_STATUS[!session.running ? "disconnected" : working ? "working" : "idle"];
   const ring = active ? "ring-sidebar-accent" : "ring-sidebar";
   return (
-    <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
+    <span
+      className={`relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background ${attention ? "border-sky-500 ring-2 ring-sky-500/70 ring-offset-1 ring-offset-sidebar" : ""}`}
+    >
       <ProviderIcon agent={agent} provider={session.provider} />
       {starting ? (
         <Spinner
@@ -654,7 +658,7 @@ function SessionBadge({
         <span
           role="img"
           className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${ring} ${status.dot}`}
-          aria-label={status.label}
+          aria-label={attention ? `${status.label}; needs attention` : status.label}
         />
       )}
     </span>
@@ -710,6 +714,7 @@ function SessionRow({
   session,
   agent,
   active,
+  attention,
   starting,
   working,
   renaming,
@@ -722,6 +727,7 @@ function SessionRow({
   session: Session;
   agent?: Agent;
   active: boolean;
+  attention: boolean;
   starting: boolean;
   working: boolean;
   renaming: boolean;
@@ -750,7 +756,14 @@ function SessionRow({
       className={`flex-nowrap transition-[color,background-color,opacity] active:opacity-70 ${active ? "bg-sidebar-accent text-sidebar-accent-foreground" : "hover:bg-sidebar-accent/60"}`}
     >
       <ItemMedia>
-        <SessionBadge session={session} agent={agent} active={active} starting={starting} working={working} />
+        <SessionBadge
+          session={session}
+          agent={agent}
+          active={active}
+          attention={attention}
+          starting={starting}
+          working={working}
+        />
       </ItemMedia>
       {renaming ? (
         <Input
@@ -900,6 +913,7 @@ function commandAgent(command: string): Agent | undefined {
 function App() {
   const [sessions, setSessions] = useState<Session[]>(loadSessions);
   const [selectedId, setSelectedId] = useState(() => sessions[0]?.id ?? "");
+  const [attention, setAttention] = useState<string[]>([]);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [closingAll, setClosingAll] = useState(false);
@@ -938,6 +952,7 @@ function App() {
   const updateDialog = useRef<HTMLDivElement>(null);
   const runs = useRef(new Map<string, string>());
   const sessionsRef = useRef(sessions);
+  const attentionRef = useRef<string[]>([]);
   const workTimers = useRef(new Map<string, number>());
   const pendingCleanups = useRef(new Set<() => Promise<void>>());
   const resumed = useRef("");
@@ -946,6 +961,21 @@ function App() {
   const selectedRef = useRef<Session>(undefined);
   const closeRef = useRef<(session: Session) => void>(() => {});
   const openRef = useRef<(session: Session) => void>(() => {});
+  const markAttention = useCallback((sessionId: string) => {
+    const current = attentionRef.current;
+    if (current[current.length - 1] === sessionId) return;
+    const next = current.filter((id) => id !== sessionId);
+    next.push(sessionId);
+    attentionRef.current = next;
+    setAttention(next);
+  }, []);
+  const clearAttention = useCallback((sessionId: string) => {
+    const current = attentionRef.current;
+    if (!current.includes(sessionId)) return;
+    const next = current.filter((id) => id !== sessionId);
+    attentionRef.current = next;
+    setAttention(next);
+  }, []);
   const selected = useMemo(() => sessions.find((session) => session.id === selectedId), [sessions, selectedId]);
   const selectedStarting = selected ? startingIds.has(selected.id) : false;
   // A session is found by what names it: the subject it was given and the folder it works in.
@@ -962,6 +992,7 @@ function App() {
   selectedRef.current = selected;
   closeRef.current = closeSession;
   openRef.current = (session) => {
+    clearAttention(session.id);
     setSelectedId(session.id);
     if (!session.running && !startingIds.has(session.id)) void launch(session, true);
   };
@@ -1040,6 +1071,21 @@ function App() {
     return () => void closing.then((unlisten) => unlisten());
   }, []);
 
+  // Opening a session reads its current notifications. A later notification remains highlighted until
+  // the user returns to that session, including when it arrives in the already selected session.
+  useEffect(() => {
+    if (selectedId && document.hasFocus()) clearAttention(selectedId);
+  }, [selectedId, clearAttention]);
+
+  useEffect(() => {
+    const readSelected = () => {
+      const sessionId = selectedRef.current?.id;
+      if (sessionId) clearAttention(sessionId);
+    };
+    window.addEventListener("focus", readSelected);
+    return () => window.removeEventListener("focus", readSelected);
+  }, [clearAttention]);
+
   // The shortcuts a terminal app is expected to answer. The terminal keeps every key Lite does not claim.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -1047,7 +1093,14 @@ function App() {
       if (event.key === "n") setNewSessionOpen(true);
       else if (event.key === ",") setSettingsOpen(true);
       else if (event.key === "w" && selectedRef.current) closeRef.current(selectedRef.current);
-      else if (event.key >= "1" && event.key <= "9") {
+      else if (event.shiftKey && event.key.toLowerCase() === "u") {
+        const target = [...attentionRef.current]
+          .reverse()
+          .map((id) => sessionsRef.current.find((session) => session.id === id))
+          .find((session) => session !== undefined);
+        if (!target) return;
+        openRef.current(target);
+      } else if (event.key >= "1" && event.key <= "9") {
         // The numbers count the sessions the sidebar is showing, so a search narrows them with the list.
         const target = visibleRef.current[Number(event.key) - 1];
         if (!target) return;
@@ -1181,9 +1234,10 @@ function App() {
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
-        const { title, path, activity } = appendOutput(payload.sessionId, payload.data);
+        const { title, path, activity, notification } = appendOutput(payload.sessionId, payload.data);
         if (title) markTitle(payload.sessionId, title);
         if (path) markDirectory(payload.sessionId, path);
+        if (notification) markAttention(payload.sessionId);
         if (activity !== false) markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
@@ -1229,7 +1283,7 @@ function App() {
       for (const timer of timers.values()) window.clearTimeout(timer);
       timers.clear();
     };
-  }, [markDirectory, markWorking, markTitle]);
+  }, [markAttention, markDirectory, markWorking, markTitle]);
 
   const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return true;
@@ -1376,6 +1430,7 @@ function App() {
   // session it resumed by id is retained only until the shared Undo window expires.
   function restartSession(session: Session, select = true) {
     if (startingIds.has(session.id)) return;
+    clearAttention(session.id);
     const fresh: Session = { ...session, id: crypto.randomUUID(), providerSessionId: undefined, running: false };
     const restarted = restartSessionNow(session, fresh, select);
     sessionUndoToast(
@@ -1499,6 +1554,7 @@ function App() {
   // metadata and directory grant remain until the toast closes without being undone.
   function closeSession(session: Session) {
     if (startingIds.has(session.id)) return;
+    clearAttention(session.id);
     const index = sessions.findIndex((item) => item.id === session.id);
     const wasSelected = selectedId === session.id;
     const nextSelectedId = sessions.find((item) => item.id !== session.id)?.id ?? "";
@@ -1831,6 +1887,7 @@ function App() {
                               session={session}
                               agent={shellAgents.get(session.id)}
                               active={session.id === selectedId}
+                              attention={attention.includes(session.id)}
                               starting={startingIds.has(session.id)}
                               working={working.has(session.id)}
                             />
@@ -1888,6 +1945,7 @@ function App() {
                             session={session}
                             agent={shellAgents.get(session.id)}
                             active={session.id === selectedId}
+                            attention={attention.includes(session.id)}
                             starting={startingIds.has(session.id)}
                             working={working.has(session.id)}
                             renaming={renamingId === session.id}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -521,12 +521,17 @@ function AppContextMenu({
 // Long enough that the gaps between an agent's own writes do not flicker the dot.
 const QUIET_MS = 1200;
 
-// Three states the sidebar dot tells apart: the terminal is gone, it is up and quiet, or it is up and
-// producing output. Color carries the state when motion is suppressed, and animation only reinforces it.
+// Four states the sidebar dot tells apart: the terminal is gone, it is up and quiet, it is producing
+// output, or it needs the user. Color carries the state when motion is suppressed, and animation only
+// reinforces it.
 const SESSION_STATUS = {
   disconnected: { dot: "bg-muted-foreground/40", label: "Disconnected" },
   idle: { dot: "bg-success", label: "Connected, idle" },
   working: { dot: "bg-sky-500 animate-pulse motion-reduce:animate-none", label: "Connected, working" },
+  attention: {
+    dot: "bg-orange-500 animate-pulse motion-reduce:animate-none",
+    label: "Connected, needs attention",
+  },
 } as const;
 
 // A local build names its commit and is red, so it is never mistaken for the installed copy.
@@ -643,12 +648,11 @@ function SessionBadge({
   starting: boolean;
   working: boolean;
 }) {
-  const status = SESSION_STATUS[!session.running ? "disconnected" : working ? "working" : "idle"];
+  const status =
+    SESSION_STATUS[!session.running ? "disconnected" : attention ? "attention" : working ? "working" : "idle"];
   const ring = active ? "ring-sidebar-accent" : "ring-sidebar";
   return (
-    <span
-      className={`relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background ${attention ? "border-sky-500 ring-2 ring-sky-500/70 ring-offset-1 ring-offset-sidebar" : ""}`}
-    >
+    <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
       <ProviderIcon agent={agent} provider={session.provider} />
       {starting ? (
         <Spinner
@@ -658,7 +662,7 @@ function SessionBadge({
         <span
           role="img"
           className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ${ring} ${status.dot}`}
-          aria-label={attention ? `${status.label}; needs attention` : status.label}
+          aria-label={status.label}
         />
       )}
     </span>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -529,7 +529,7 @@ const SESSION_STATUS = {
   idle: { dot: "bg-success", label: "Connected, idle" },
   working: { dot: "bg-sky-500 animate-pulse motion-reduce:animate-none", label: "Connected, working" },
   attention: {
-    dot: "bg-orange-500 animate-pulse motion-reduce:animate-none",
+    dot: "bg-amber-500 animate-attention motion-reduce:animate-none",
     label: "Connected, needs attention",
   },
 } as const;
@@ -1076,7 +1076,7 @@ function App() {
   }, []);
 
   // Opening a session reads its current notifications. A later notification remains highlighted until
-  // the user returns to that session, including when it arrives in the already selected session.
+  // the user returns to that session.
   useEffect(() => {
     if (selectedId && document.hasFocus()) clearAttention(selectedId);
   }, [selectedId, clearAttention]);
@@ -1241,7 +1241,8 @@ function App() {
         const { title, path, activity, notification } = appendOutput(payload.sessionId, payload.data);
         if (title) markTitle(payload.sessionId, title);
         if (path) markDirectory(payload.sessionId, path);
-        if (notification) markAttention(payload.sessionId);
+        if (notification && (selectedRef.current?.id !== payload.sessionId || !document.hasFocus()))
+          markAttention(payload.sessionId);
         if (activity !== false) markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,7 @@
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --animate-attention: attention 1.5s ease-in-out infinite;
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -54,6 +55,16 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+@keyframes attention {
+  0%,
+  100% {
+    background-color: var(--color-amber-500);
+  }
+  50% {
+    background-color: var(--success);
+  }
 }
 
 :root {

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -29,6 +29,11 @@ const METADATA = /\x1b\]([027]);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 // owner makes the signal available even when the session's terminal is not mounted.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const ACTIVITY = /\x1b\]6973;lite-(working|idle)(?:\x07|\x1b\\)/g;
+// Common terminal notification protocols share the OSC owner with titles and working directories.
+// Lite needs only the signal for its in-app attention state; the terminal still owns rendering and
+// the notification payload is not retained separately from the bounded output buffer.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a terminal notification is defined by them
+const NOTIFICATION = /\x1b\](?:9;[^\x07\x1b]*|99;[^\x07\x1b]*|777;notify;[^\x07\x1b]*)(?:\x07|\x1b\\)/;
 
 // The same sequence begun but not yet terminated, which the chunk that ends it completes. A title may
 // hold an escape of its own, so the payload ends only at a terminator, and a lone escape is kept
@@ -91,6 +96,7 @@ export function appendOutput(sessionId: string, data: number[]) {
   let title = "";
   let path = "";
   let activity: boolean | undefined;
+  const notification = NOTIFICATION.test(text);
   METADATA.lastIndex = 0;
   for (let match = METADATA.exec(text); match; match = METADATA.exec(text)) {
     if (match[1] === "7") {
@@ -103,7 +109,7 @@ export function appendOutput(sessionId: string, data: number[]) {
   const tail = text.match(UNTERMINATED)?.[0] ?? "";
   if (activity === undefined && tail.startsWith("\x1b]6973;lite-")) activity = false;
   buffer.tail = tail.length > MAX_TAIL ? "" : tail;
-  return { title, path, activity };
+  return { title, path, activity, notification };
 }
 
 export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) => void) {

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -33,7 +33,11 @@ const ACTIVITY = /\x1b\]6973;lite-(working|idle)(?:\x07|\x1b\\)/g;
 // Lite needs only the signal for its in-app attention state; the terminal still owns rendering and
 // the notification payload is not retained separately from the bounded output buffer.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a terminal notification is defined by them
-const NOTIFICATION = /\x1b\](?:9;[^\x07\x1b]*|99;[^\x07\x1b]*|777;notify;[^\x07\x1b]*)(?:\x07|\x1b\\)/;
+const NOTIFICATION = /\x1b\](?:9;(?!4;)[^\x07\x1b]*|99;[^\x07\x1b]*|777;notify;[^\x07\x1b]*)(?:\x07|\x1b\\)/;
+// A bare bell is the portable fallback used by agent harnesses and shells. Remove completed OSC first
+// because their bell terminator is framing, not a notification of its own.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
+const OSC_OR_BELL = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|(\x07)/g;
 
 // The same sequence begun but not yet terminated, which the chunk that ends it completes. A title may
 // hold an escape of its own, so the payload ends only at a terminator, and a lone escape is kept
@@ -96,7 +100,10 @@ export function appendOutput(sessionId: string, data: number[]) {
   let title = "";
   let path = "";
   let activity: boolean | undefined;
-  const notification = NOTIFICATION.test(text);
+  let notification = NOTIFICATION.test(text);
+  OSC_OR_BELL.lastIndex = 0;
+  for (let match = OSC_OR_BELL.exec(text); !notification && match; match = OSC_OR_BELL.exec(text))
+    notification = Boolean(match[1]);
   METADATA.lastIndex = 0;
   for (let match = METADATA.exec(text); match; match = METADATA.exec(text)) {
     if (match[1] === "7") {


### PR DESCRIPTION
## Summary

Adds local in-app attention for every Lite harness through the terminal protocols they already emit. No watcher, transcript polling, telemetry, desktop notification, or global CLI configuration is added.

## What changed

- Parse OSC 9 notifications, OSC 99, OSC 777, and bare BEL in `output-store.ts`, the existing bounded owner for every PTY stream. OSC 9 progress updates are excluded.
- Use the same shared path for Claude Code, Codex, Gemini CLI, Kimi Code, Qwen Code, and shell sessions. Claude and Codex receive launch-local notification settings; the other harnesses keep their own notification behavior and portable BEL/OSC fallback.
- Mark only background or unfocused sessions unread, clear them when viewed, and jump to the newest with `Cmd/Ctrl+Shift+U`.
- Animate the status dot between the official amber warning and green success tokens. Reduced-motion users receive a static amber status.

## Resource use

Notification recognition runs only while already-bounded PTY chunks are being processed. It adds no timer, filesystem read, watcher, retained payload, or background task; unread state is bounded by the open session list.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Parser checks for OSC 9, OSC 9 progress, OSC 99, metadata framing, bare BEL, and split sequences

Codex configuration reference: https://developers.openai.com/codex/config-reference