### PR TITLE
Report agent session context

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1213,9 +1213,7 @@ fn codex_requests(
     codex_requests_once(&endpoint, requests)
 }
 
-// The newest token count in a thread's rollout file, less the baseline Codex itself discounts.
-fn codex_context(path: &Path) -> Option<UsageSnapshot> {
-    const BASELINE_TOKENS: u64 = 12_000;
+fn file_tail(path: &Path) -> Option<String> {
     const TAIL_BYTES: u64 = 256 * 1024;
     let mut file = fs::File::open(path).ok()?;
     let length = file.metadata().ok()?.len();
@@ -1223,7 +1221,13 @@ fn codex_context(path: &Path) -> Option<UsageSnapshot> {
         .ok()?;
     let mut tail = Vec::new();
     file.take(TAIL_BYTES).read_to_end(&mut tail).ok()?;
-    let (tokens, window) = String::from_utf8_lossy(&tail)
+    Some(String::from_utf8_lossy(&tail).into_owned())
+}
+
+// The newest token count in a thread's rollout file, less the baseline Codex itself discounts.
+fn codex_context(path: &Path) -> Option<UsageSnapshot> {
+    const BASELINE_TOKENS: u64 = 12_000;
+    let (tokens, window) = file_tail(path)?
         .lines()
         .rev()
         .filter(|line| line.contains("token_count"))
@@ -1247,6 +1251,41 @@ fn codex_context(path: &Path) -> Option<UsageSnapshot> {
         context_tokens: Some(tokens),
         ..UsageSnapshot::default()
     })
+}
+
+fn native_context(path: &Path, agent: &str) -> Option<UsageSnapshot> {
+    file_tail(path)?
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find_map(|record| match agent {
+            "gemini"
+                if record.get("type").and_then(serde_json::Value::as_str) == Some("gemini") =>
+            {
+                let tokens = record.pointer("/tokens/input")?.as_u64()?;
+                (tokens > 0).then(|| UsageSnapshot {
+                    context_tokens: Some(tokens),
+                    ..UsageSnapshot::default()
+                })
+            }
+            "qwen"
+                if record.get("type").and_then(serde_json::Value::as_str) == Some("assistant") =>
+            {
+                let tokens = record
+                    .pointer("/usageMetadata/promptTokenCount")?
+                    .as_u64()?;
+                let window = record.get("contextWindowSize")?.as_u64()?;
+                (tokens > 0 && window > 0).then(|| UsageSnapshot {
+                    context_used_percent: Some(
+                        (tokens as f64 / window as f64 * 100.0).clamp(0.0, 100.0),
+                    ),
+                    context_window: Some(window),
+                    context_tokens: Some(tokens),
+                    ..UsageSnapshot::default()
+                })
+            }
+            _ => None,
+        })
 }
 
 fn codex_usage(server: &CodexServer, thread_id: Option<&str>) -> Result<UsageSnapshot, String> {
@@ -1945,55 +1984,101 @@ fn qwen_home(app: &AppHandle) -> Result<PathBuf, String> {
     provider_home(app, "QWEN_HOME", ".qwen")
 }
 
-fn native_session_exists(app: &AppHandle, agent: &str, session_id: &str) -> bool {
+fn native_session_path(app: &AppHandle, agent: &str, session_id: &str) -> Option<PathBuf> {
     let (home, directory) = match agent {
         "gemini" => (gemini_home(app), "tmp"),
         "qwen" => (qwen_home(app), "projects"),
-        _ => return false,
+        _ => return None,
     };
-    let Ok(projects) =
-        home.and_then(|home| fs::read_dir(home.join(directory)).map_err(|error| error.to_string()))
-    else {
-        return false;
-    };
+    let projects = home
+        .and_then(|home| fs::read_dir(home.join(directory)).map_err(|error| error.to_string()))
+        .ok()?;
     let expected = if agent == "qwen" {
         format!("{session_id}.jsonl")
     } else {
         format!("-{}.jsonl", session_id.chars().take(8).collect::<String>())
     };
-    projects.flatten().take(512).any(|project| {
-        fs::read_dir(project.path().join("chats")).is_ok_and(|chats| {
-            chats.flatten().take(512).any(|chat| {
+    projects.flatten().take(512).find_map(|project| {
+        if agent == "qwen" {
+            let path = project.path().join("chats").join(&expected);
+            return path.is_file().then_some(path);
+        }
+        fs::read_dir(project.path().join("chats"))
+            .ok()?
+            .flatten()
+            .take(512)
+            .find_map(|chat| {
                 let name = chat.file_name();
                 let name = name.to_string_lossy();
-                if agent == "qwen" {
-                    name == expected
+                if name.ends_with(&expected)
+                    && fs::File::open(chat.path()).is_ok_and(|file| {
+                        BufReader::new(file)
+                            .lines()
+                            .next()
+                            .and_then(Result::ok)
+                            .and_then(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
+                            .and_then(|value| {
+                                value
+                                    .get("sessionId")
+                                    .and_then(serde_json::Value::as_str)
+                                    .map(str::to_owned)
+                            })
+                            .is_some_and(|id| id == session_id)
+                    })
+                {
+                    Some(chat.path())
                 } else {
-                    name.ends_with(&expected)
-                        && fs::File::open(chat.path()).is_ok_and(|file| {
-                            BufReader::new(file)
-                                .lines()
-                                .next()
-                                .and_then(Result::ok)
-                                .and_then(|line| {
-                                    serde_json::from_str::<serde_json::Value>(&line).ok()
-                                })
-                                .and_then(|value| {
-                                    value
-                                        .get("sessionId")
-                                        .and_then(serde_json::Value::as_str)
-                                        .map(str::to_owned)
-                                })
-                                .is_some_and(|id| id == session_id)
-                        })
+                    None
                 }
             })
-        })
     })
+}
+
+fn native_session_exists(app: &AppHandle, agent: &str, session_id: &str) -> bool {
+    native_session_path(app, agent, session_id).is_some()
 }
 
 fn kimi_home(app: &AppHandle) -> Result<PathBuf, String> {
     provider_home(app, "KIMI_CODE_HOME", ".kimi-code")
+}
+
+fn kimi_context(app: &AppHandle, session_id: &str) -> Option<UsageSnapshot> {
+    let sessions = fs::read_dir(kimi_home(app).ok()?.join("sessions")).ok()?;
+    let path = sessions
+        .flatten()
+        .take(512)
+        .map(|workspace| {
+            workspace
+                .path()
+                .join(session_id)
+                .join("agents/main/wire.jsonl")
+        })
+        .find(|path| path.is_file())?;
+    file_tail(&path)?
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find_map(|record| {
+            if record.get("type").and_then(serde_json::Value::as_str) != Some("usage.record")
+                || record.get("usageScope").and_then(serde_json::Value::as_str) != Some("turn")
+            {
+                return None;
+            }
+            let usage = record.get("usage")?;
+            let tokens = [
+                "inputOther",
+                "inputCacheRead",
+                "inputCacheCreation",
+                "output",
+            ]
+            .iter()
+            .filter_map(|key| usage.get(key).and_then(serde_json::Value::as_u64))
+            .sum();
+            (tokens > 0).then(|| UsageSnapshot {
+                context_tokens: Some(tokens),
+                ..UsageSnapshot::default()
+            })
+        })
 }
 
 // Kimi groups sessions under an opaque per-directory key that its workspace index maps back to a path.
@@ -3195,6 +3280,16 @@ async fn read_usage(
     if agent == "codex" && codex_provider(provider.as_deref()).is_some() {
         return Ok(None);
     }
+    let provider_session_id = if agent == "codex" || agent == "kimi" {
+        provider_sessions
+            .0
+            .lock()
+            .map_err(|error| error.to_string())?
+            .get(&session_id)
+            .cloned()
+    } else {
+        None
+    };
     match agent.as_str() {
         "claude" => {
             let directory = app
@@ -3271,17 +3366,13 @@ async fn read_usage(
                 || !usage.windows.is_empty())
             .then_some(usage))
         }
-        "codex" => {
-            // The thread is discovered after the session starts, so it is read here, not passed in.
-            let thread_id = provider_sessions
-                .0
-                .lock()
-                .map_err(|error| error.to_string())?
-                .get(&session_id)
-                .cloned();
-            codex_usage(&codex_server, thread_id.as_deref()).map(Some)
-        }
-        "gemini" | "kimi" | "qwen" | "shell" => Ok(None),
+        "codex" => codex_usage(&codex_server, provider_session_id.as_deref()).map(Some),
+        "gemini" | "qwen" => Ok(native_session_path(&app, &agent, &session_id)
+            .and_then(|path| native_context(&path, &agent))),
+        "kimi" => Ok(provider_session_id
+            .as_deref()
+            .and_then(|id| kimi_context(&app, id))),
+        "shell" => Ok(None),
         _ => Err("Unknown session type".into()),
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1213,27 +1213,21 @@ fn codex_requests(
     codex_requests_once(&endpoint, requests)
 }
 
-// Codex records what a thread holds in context only in the thread's own rollout file, and the newest
-// count sits at its end. The tail is read rather than the file so a long thread stays cheap, and a
-// line the CLI is still writing simply fails to parse and is passed over.
-fn codex_context(path: &Path) -> Option<(f64, u64, u64)> {
+// The newest token count in a thread's rollout file, less the baseline Codex itself discounts.
+fn codex_context(path: &Path) -> Option<UsageSnapshot> {
     const BASELINE_TOKENS: u64 = 12_000;
+    const TAIL_BYTES: u64 = 256 * 1024;
     let mut file = fs::File::open(path).ok()?;
     let length = file.metadata().ok()?.len();
-    file.seek(SeekFrom::Start(length.saturating_sub(256 * 1024)))
+    file.seek(SeekFrom::Start(length.saturating_sub(TAIL_BYTES)))
         .ok()?;
     let mut tail = Vec::new();
-    file.read_to_end(&mut tail).ok()?;
+    file.take(TAIL_BYTES).read_to_end(&mut tail).ok()?;
     let (tokens, window) = String::from_utf8_lossy(&tail)
         .lines()
         .rev()
+        .filter(|line| line.contains("token_count"))
         .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-        .filter(|event| {
-            event
-                .pointer("/payload/type")
-                .and_then(serde_json::Value::as_str)
-                == Some("token_count")
-        })
         .find_map(|event| {
             let info = event.pointer("/payload/info")?;
             Some((
@@ -1243,15 +1237,16 @@ fn codex_context(path: &Path) -> Option<(f64, u64, u64)> {
                     .and_then(serde_json::Value::as_u64)?,
             ))
         })?;
-    // Codex measures the window the user can fill, past the system prompt and tool instructions that
-    // are always in it, so the panel reports the share the Codex CLI itself would report.
     let effective = window.checked_sub(BASELINE_TOKENS)?;
-    let used = tokens.saturating_sub(BASELINE_TOKENS);
-    Some((
-        (used as f64 / effective as f64 * 100.0).clamp(0.0, 100.0),
-        tokens,
-        window,
-    ))
+    Some(UsageSnapshot {
+        context_used_percent: Some(
+            (tokens.saturating_sub(BASELINE_TOKENS) as f64 / effective as f64 * 100.0)
+                .clamp(0.0, 100.0),
+        ),
+        context_window: Some(window),
+        context_tokens: Some(tokens),
+        ..UsageSnapshot::default()
+    })
 }
 
 fn codex_usage(server: &CodexServer, thread_id: Option<&str>) -> Result<UsageSnapshot, String> {
@@ -1319,14 +1314,11 @@ fn codex_usage(server: &CodexServer, thread_id: Option<&str>) -> Result<UsageSna
         .and_then(serde_json::Value::as_str)
         .and_then(|path| codex_context(Path::new(path)));
     Ok(UsageSnapshot {
-        context_used_percent: context.map(|(percent, _, _)| percent),
-        context_window: context.map(|(_, _, window)| window),
-        context_tokens: context.map(|(_, tokens, _)| tokens),
         lifetime_tokens: summary
             .and_then(|value| value.pointer("/summary/lifetimeTokens"))
             .and_then(serde_json::Value::as_u64),
         windows,
-        ..UsageSnapshot::default()
+        ..context.unwrap_or_default()
     })
 }
 
@@ -3194,10 +3186,10 @@ async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<S
 async fn read_usage(
     app: AppHandle,
     codex_server: State<'_, CodexServer>,
+    provider_sessions: State<'_, ProviderSessions>,
     agent: String,
     provider: Option<String>,
     session_id: String,
-    provider_session_id: Option<String>,
 ) -> Result<Option<UsageSnapshot>, String> {
     // A custom-provider Codex session does not bill OpenAI, so OpenAI account limits are not its usage.
     if agent == "codex" && codex_provider(provider.as_deref()).is_some() {
@@ -3279,7 +3271,16 @@ async fn read_usage(
                 || !usage.windows.is_empty())
             .then_some(usage))
         }
-        "codex" => codex_usage(&codex_server, provider_session_id.as_deref()).map(Some),
+        "codex" => {
+            // The thread is discovered after the session starts, so it is read here, not passed in.
+            let thread_id = provider_sessions
+                .0
+                .lock()
+                .map_err(|error| error.to_string())?
+                .get(&session_id)
+                .cloned();
+            codex_usage(&codex_server, thread_id.as_deref()).map(Some)
+        }
         "gemini" | "kimi" | "qwen" | "shell" => Ok(None),
         _ => Err("Unknown session type".into()),
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
-    io::{BufRead, BufReader, Read, Write},
+    io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{
@@ -1213,14 +1213,60 @@ fn codex_requests(
     codex_requests_once(&endpoint, requests)
 }
 
-fn codex_usage(server: &CodexServer) -> Result<UsageSnapshot, String> {
-    let responses = codex_requests(
-        server,
-        &[
-            (1, "account/rateLimits/read", serde_json::json!({})),
-            (2, "account/usage/read", serde_json::json!({})),
-        ],
-    )?;
+// Codex records what a thread holds in context only in the thread's own rollout file, and the newest
+// count sits at its end. The tail is read rather than the file so a long thread stays cheap, and a
+// line the CLI is still writing simply fails to parse and is passed over.
+fn codex_context(path: &Path) -> Option<(f64, u64, u64)> {
+    const BASELINE_TOKENS: u64 = 12_000;
+    let mut file = fs::File::open(path).ok()?;
+    let length = file.metadata().ok()?.len();
+    file.seek(SeekFrom::Start(length.saturating_sub(256 * 1024)))
+        .ok()?;
+    let mut tail = Vec::new();
+    file.read_to_end(&mut tail).ok()?;
+    let (tokens, window) = String::from_utf8_lossy(&tail)
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|event| {
+            event
+                .pointer("/payload/type")
+                .and_then(serde_json::Value::as_str)
+                == Some("token_count")
+        })
+        .find_map(|event| {
+            let info = event.pointer("/payload/info")?;
+            Some((
+                info.pointer("/last_token_usage/total_tokens")
+                    .and_then(serde_json::Value::as_u64)?,
+                info.get("model_context_window")
+                    .and_then(serde_json::Value::as_u64)?,
+            ))
+        })?;
+    // Codex measures the window the user can fill, past the system prompt and tool instructions that
+    // are always in it, so the panel reports the share the Codex CLI itself would report.
+    let effective = window.checked_sub(BASELINE_TOKENS)?;
+    let used = tokens.saturating_sub(BASELINE_TOKENS);
+    Some((
+        (used as f64 / effective as f64 * 100.0).clamp(0.0, 100.0),
+        tokens,
+        window,
+    ))
+}
+
+fn codex_usage(server: &CodexServer, thread_id: Option<&str>) -> Result<UsageSnapshot, String> {
+    let mut requests = vec![
+        (1, "account/rateLimits/read", serde_json::json!({})),
+        (2, "account/usage/read", serde_json::json!({})),
+    ];
+    if let Some(thread_id) = thread_id {
+        requests.push((
+            3,
+            "thread/read",
+            serde_json::json!({"threadId": thread_id, "includeTurns": false}),
+        ));
+    }
+    let responses = codex_requests(server, &requests)?;
     let rates = responses.get(&1);
     let summary = responses.get(&2);
 
@@ -1267,7 +1313,15 @@ fn codex_usage(server: &CodexServer) -> Result<UsageSnapshot, String> {
             });
         }
     }
+    let context = responses
+        .get(&3)
+        .and_then(|response| response.pointer("/thread/path"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|path| codex_context(Path::new(path)));
     Ok(UsageSnapshot {
+        context_used_percent: context.map(|(percent, _, _)| percent),
+        context_window: context.map(|(_, _, window)| window),
+        context_tokens: context.map(|(_, tokens, _)| tokens),
         lifetime_tokens: summary
             .and_then(|value| value.pointer("/summary/lifetimeTokens"))
             .and_then(serde_json::Value::as_u64),
@@ -3143,6 +3197,7 @@ async fn read_usage(
     agent: String,
     provider: Option<String>,
     session_id: String,
+    provider_session_id: Option<String>,
 ) -> Result<Option<UsageSnapshot>, String> {
     // A custom-provider Codex session does not bill OpenAI, so OpenAI account limits are not its usage.
     if agent == "codex" && codex_provider(provider.as_deref()).is_some() {
@@ -3224,7 +3279,7 @@ async fn read_usage(
                 || !usage.windows.is_empty())
             .then_some(usage))
         }
-        "codex" => codex_usage(&codex_server).map(Some),
+        "codex" => codex_usage(&codex_server, provider_session_id.as_deref()).map(Some),
         "gemini" | "kimi" | "qwen" | "shell" => Ok(None),
         _ => Err("Unknown session type".into()),
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1291,11 +1291,18 @@ fn native_context(path: &Path, agent: &str) -> Option<UsageSnapshot> {
         })
 }
 
-fn codex_usage(server: &CodexServer, thread_id: Option<&str>) -> Result<UsageSnapshot, String> {
-    let mut requests = vec![
-        (1, "account/rateLimits/read", serde_json::json!({})),
-        (2, "account/usage/read", serde_json::json!({})),
-    ];
+fn codex_usage(
+    server: &CodexServer,
+    thread_id: Option<&str>,
+    account: bool,
+) -> Result<UsageSnapshot, String> {
+    let mut requests = Vec::new();
+    if account {
+        requests.extend([
+            (1, "account/rateLimits/read", serde_json::json!({})),
+            (2, "account/usage/read", serde_json::json!({})),
+        ]);
+    }
     if let Some(thread_id) = thread_id {
         requests.push((
             3,
@@ -3283,10 +3290,6 @@ async fn read_usage(
     provider: Option<String>,
     session_id: String,
 ) -> Result<Option<UsageSnapshot>, String> {
-    // A custom-provider Codex session does not bill OpenAI, so OpenAI account limits are not its usage.
-    if agent == "codex" && codex_provider(provider.as_deref()).is_some() {
-        return Ok(None);
-    }
     let provider_session_id = if agent == "codex" || agent == "kimi" {
         provider_sessions
             .0
@@ -3373,7 +3376,15 @@ async fn read_usage(
                 || !usage.windows.is_empty())
             .then_some(usage))
         }
-        "codex" => codex_usage(&codex_server, provider_session_id.as_deref()).map(Some),
+        "codex" => {
+            // Custom providers have local thread context but do not bill OpenAI, so omit only the
+            // account requests rather than omitting the whole session.
+            let account = codex_provider(provider.as_deref()).is_none();
+            if !account && provider_session_id.is_none() {
+                return Ok(None);
+            }
+            codex_usage(&codex_server, provider_session_id.as_deref(), account).map(Some)
+        }
         "gemini" | "qwen" => Ok(native_session_path(&app, &agent, &session_id)
             .and_then(|path| native_context(&path, &agent))),
         "kimi" => Ok(provider_session_id

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1242,7 +1242,9 @@ fn codex_context(path: &Path) -> Option<UsageSnapshot> {
                     .and_then(serde_json::Value::as_u64)?,
             ))
         })?;
-    let effective = window.checked_sub(BASELINE_TOKENS)?;
+    let effective = window
+        .checked_sub(BASELINE_TOKENS)
+        .filter(|effective| *effective > 0)?;
     Some(UsageSnapshot {
         context_used_percent: Some(
             (tokens.saturating_sub(BASELINE_TOKENS) as f64 / effective as f64 * 100.0)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1225,7 +1225,7 @@ fn file_tail(path: &Path) -> Option<String> {
     Some(String::from_utf8_lossy(&tail).into_owned())
 }
 
-// The newest token count in a thread's rollout file, less the baseline Codex itself discounts.
+// Codex defines context as raw total tokens, including reasoning, less its discounted baseline.
 fn codex_context(path: &Path) -> Option<UsageSnapshot> {
     const BASELINE_TOKENS: u64 = 12_000;
     let (tokens, window) = file_tail(path)?

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -977,11 +977,10 @@ function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: st
 // Each harness and provider reports what it reports; Lite never fills the gap with a number of its own.
 function missingUsage(session: Session): string {
   if (session.agent === "shell") return "Shell sessions report no provider usage.";
-  if (session.agent === "kimi") return "Kimi Code keeps session usage inside its own terminal view.";
   if (session.agent === "codex" && session.provider && session.provider !== "openai")
     return `${providerLabel(session.provider)} publishes no account limits locally. Codex reports this session's usage in the terminal.`;
   if (session.agent === "claude") return "Account limits appear after any Lite Claude session receives a response.";
-  return "This provider reports no usage locally.";
+  return `${sessionLabel(session)} reports session context after its first response.`;
 }
 
 function UsagePanel({ session }: { session: Session }) {
@@ -1030,9 +1029,13 @@ function UsagePanel({ session }: { session: Session }) {
             </Empty>
           ) : (
             <ItemGroup>
-              {usage.contextUsedPercent != null ? (
+              {usage.contextUsedPercent != null || usage.contextTokens != null ? (
                 <Item variant="outline" className="flex-col items-stretch">
-                  <Meter label="Session context" value={usage.contextUsedPercent} />
+                  {usage.contextUsedPercent != null ? (
+                    <Meter label="Session context" value={usage.contextUsedPercent} />
+                  ) : (
+                    <ItemDescription>Session context</ItemDescription>
+                  )}
                   {usage.contextTokens != null ? (
                     <ItemDescription className="tabular-nums">
                       {formatNumber.format(usage.contextTokens)}
@@ -1045,9 +1048,7 @@ function UsagePanel({ session }: { session: Session }) {
                 </Item>
               ) : (
                 <ItemDescription>
-                  {session.agent === "codex"
-                    ? "Codex reports this session's context after its first response."
-                    : "This provider does not report per-session context."}
+                  Session context appears after this harness reports its first response.
                 </ItemDescription>
               )}
               {usage.windows.map((window) => (

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -995,7 +995,6 @@ function UsagePanel({ session }: { session: Session }) {
       agent: session.agent,
       provider: session.provider,
       sessionId: session.id,
-      providerSessionId: session.providerSessionId,
     })
       .then((next) => {
         if (!disposed) {
@@ -1009,7 +1008,7 @@ function UsagePanel({ session }: { session: Session }) {
     return () => {
       disposed = true;
     };
-  }, [session.agent, session.provider, session.id, session.providerSessionId]);
+  }, [session.agent, session.provider, session.id]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -987,6 +987,7 @@ function UsagePanel({ session }: { session: Session }) {
       agent: session.agent,
       provider: session.provider,
       sessionId: session.id,
+      providerSessionId: session.providerSessionId,
     })
       .then((next) => {
         if (!disposed) {
@@ -1000,7 +1001,7 @@ function UsagePanel({ session }: { session: Session }) {
     return () => {
       disposed = true;
     };
-  }, [session.agent, session.provider, session.id]);
+  }, [session.agent, session.provider, session.id, session.providerSessionId]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -1037,7 +1038,9 @@ function UsagePanel({ session }: { session: Session }) {
                 </Item>
               ) : (
                 <ItemDescription>
-                  {session.agent === "codex" ? "The Codex CLI" : "This provider"} does not report per-session context.
+                  {session.agent === "codex"
+                    ? "Codex reports this session's context after its first response."
+                    : "This provider does not report per-session context."}
                 </ItemDescription>
               )}
               {usage.windows.map((window) => (

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -978,7 +978,7 @@ function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: st
 function missingUsage(session: Session): string {
   if (session.agent === "shell") return "Shell sessions report no provider usage.";
   if (session.agent === "codex" && session.provider && session.provider !== "openai")
-    return `${providerLabel(session.provider)} publishes no account limits locally. Codex reports this session's usage in the terminal.`;
+    return `${providerLabel(session.provider)} publishes no account limits locally. Session context appears after the first response.`;
   if (session.agent === "claude") return "Account limits appear after any Lite Claude session receives a response.";
   return `${sessionLabel(session)} reports session context after its first response.`;
 }


### PR DESCRIPTION
## Summary

Reports session context for every model-backed Lite harness from the durable usage records each harness already owns. Shell remains explicitly unsupported because it has no model context.

## What changed

- Claude Code keeps its existing usage adapter.
- Codex batches `thread/read` into the existing OpenAI app-server request and reads the latest rollout token event.
- Custom-provider Codex sessions request only their local thread, with no OpenAI account calls.
- Gemini CLI and Qwen Code read the active session transcript already used for resume discovery.
- Kimi Code reads the active main-agent usage record using the Lite-owned provider-session mapping.
- The inspector renders an exact meter when the harness records a context window and a token count when it records only tokens.

## Resource use

Reads happen only when the usage panel opens or the user refreshes it. Transcript reads are capped at the final 256 KiB, directory discovery is bounded, and there are no watchers, timers, retained transcript data, or background work. OpenAI Codex adds no round trip; custom providers make one local thread request because they intentionally skip the OpenAI account batch.

## Correctness

Codex mirrors its own raw-total and 12k discounted-baseline calculation. Qwen records both prompt tokens and its context window. Gemini and Kimi do not persist an authoritative window in the durable record Lite reads, so Lite reports tokens without inventing a percentage.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`