### PR TITLE
Paste what the macOS clipboard holds

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1860,6 +1860,8 @@ name = "lite"
 version = "0.0.16"
 dependencies = [
  "atomicwrites",
+ "objc2-app-kit",
+ "objc2-foundation",
  "portable-pty",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,3 +37,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSPasteboard"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSData"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3371,6 +3371,20 @@ fn startup_ready(app: AppHandle) {
 //
 // Only the fields NSAboutPanel actually renders are set. It ignores authors, comments, license and
 // website, so setting those here would look thorough and show nothing.
+// macOS carries one clipboard text in two flavors, and the older is declared in the encoding the system
+// was configured for decades ago. A reader that asks for a string is handed that one and decodes UTF-8
+// as Mac Roman, the webview included, so the bytes are read and decoded here instead.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+fn read_clipboard() -> Result<String, String> {
+    let text = objc2_app_kit::NSPasteboard::generalPasteboard()
+        .dataForType(&objc2_foundation::NSString::from_str(
+            "public.utf8-plain-text",
+        ))
+        .ok_or("The clipboard holds no text")?;
+    String::from_utf8(text.to_vec()).map_err(|error| error.to_string())
+}
+
 #[cfg(target_os = "macos")]
 fn describe_app(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     use tauri::menu::{AboutMetadata, Menu, MenuItemKind, PredefinedMenuItem};
@@ -3412,6 +3426,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            #[cfg(target_os = "macos")]
+            read_clipboard,
             choose_directory,
             follow_directory,
             github_items,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ import { applyTheme, initialTheme, type Theme } from "@/theme";
 import { type Agent, defaultSessionName, repoName, type Session, sessionLabel } from "@/types";
 import "./App.css";
 
+const MAC = navigator.platform.includes("Mac");
 const STORAGE_KEY = "lite.sessions.v1";
 // The width each side collapses to: one icon button and the room around it.
 const RAIL = 44;
@@ -273,14 +274,10 @@ function writeClipboard(text: string) {
   void navigator.clipboard.writeText(text).catch(() => undefined);
 }
 
-function edit(context: AppMenuContext, command: "cut" | "paste" | "selectAll") {
-  const element = context.editable;
-  if (!element) return;
-  element.focus();
-  if (document.execCommand(command)) return;
-  if (command !== "paste") return;
-  void navigator.clipboard
-    .readText()
+// Only the macOS webview decodes clipboard text as Mac Roman, so only there is the text asked for rather
+// than taken from the event, and only there does Lite have a command to ask with.
+function pasteInto(element: HTMLElement) {
+  void invoke<string>("read_clipboard")
     .then((text) => {
       if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
         element.setRangeText(text, element.selectionStart ?? 0, element.selectionEnd ?? 0, "end");
@@ -288,6 +285,14 @@ function edit(context: AppMenuContext, command: "cut" | "paste" | "selectAll") {
       } else document.execCommand("insertText", false, text);
     })
     .catch(() => undefined);
+}
+
+function edit(context: AppMenuContext, command: "cut" | "paste" | "selectAll") {
+  const element = context.editable;
+  if (!element) return;
+  element.focus();
+  if (command === "paste" && MAC) pasteInto(element);
+  else document.execCommand(command);
 }
 
 function AppContextMenu({
@@ -315,7 +320,7 @@ function AppContextMenu({
 }) {
   const [open, setOpen] = useState(false);
   const [context, setContext] = useState(EMPTY_MENU_CONTEXT);
-  const shortcut = navigator.platform.includes("Mac") ? "⌘" : "Ctrl+";
+  const shortcut = MAC ? "⌘" : "Ctrl+";
   const readonly =
     context.editable instanceof HTMLInputElement || context.editable instanceof HTMLTextAreaElement
       ? context.editable.readOnly || context.editable.disabled
@@ -984,6 +989,20 @@ function App() {
   // restored sessions and the update check remain deliberately non-blocking.
   useEffect(() => {
     void invoke("startup_ready");
+  }, []);
+
+  // Every field pastes what the clipboard holds rather than what the webview made of it. A terminal
+  // paste never arrives here: the terminal owns its own, and takes the event on the way down.
+  useEffect(() => {
+    if (!MAC) return;
+    const paste = (event: ClipboardEvent) => {
+      const element = event.target;
+      if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) return;
+      event.preventDefault();
+      pasteInto(element);
+    };
+    document.addEventListener("paste", paste);
+    return () => document.removeEventListener("paste", paste);
   }, []);
 
   useEffect(() => {

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -216,9 +216,20 @@ export function TerminalView({
       return false;
     });
     resize();
+    // Taken on the way down, because the terminal's own paste waits at the element below and would
+    // otherwise paste the text a second time. It still pastes, brackets and all, the way a program asked.
+    const paste = (event: ClipboardEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      void invoke<string>("read_clipboard")
+        .then((text) => terminal.paste(text))
+        .catch(() => undefined);
+    };
+    if (navigator.platform.includes("Mac")) container.addEventListener("paste", paste, true);
 
     return () => {
       window.clearTimeout(settle);
+      container.removeEventListener("paste", paste, true);
       observer.disconnect();
       input.dispose();
       unsubscribe();


### PR DESCRIPTION
Pasting anything above ASCII into Lite on macOS produces mojibake, in the terminal and in every input. Typing the same characters is fine, and so is copying out of Lite, so a session that pastes a path, a prompt, or a name gets a corrupted one.

- macOS keeps one clipboard text in two flavors and synthesizes the one a reader asks for when the writer did not provide it, transcoding UTF-8 through the Mac Roman system encoding on the way. Anything that asks for a string gets the transcode, the webview included, so `α` arrives as `Œ±` and `ü` as `√º`.
- Reading the raw bytes of `public.utf8-plain-text` gets the text itself, so `read_clipboard` returns those and pastes are served from it rather than from the paste event.
- The terminal keeps its own paste and calls `terminal.paste`, since only it knows whether the program it runs asked for a bracketed one, and it takes the event on the way down so xterm does not paste a second copy underneath.
- macOS only, in Rust and in the interface: no other platform transcodes, so no other platform pays for a command or a listener. Cargo.lock grows by 2 lines, since the AppKit bindings were already in the tree.

```
clipboard bytes   ce b1        α
webview paste     e2 8c 92 c2 b1   Œ±
read_clipboard    ce b1        α
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds reliable macOS clipboard text pasting across Lite inputs and the terminal by reading UTF-8 clipboard data natively through Tauri.

### 📊 Key Changes
- Adds macOS-only Rust dependencies and a `read_clipboard` Tauri command using `NSPasteboard`.
- Routes macOS paste actions in inputs, textareas, context menus, and the terminal through the native clipboard reader.
- Prevents duplicate terminal pastes while preserving terminal paste behavior.
- Keeps existing non-macOS clipboard behavior unchanged.

### 🎯 Purpose & Impact
- Fixes incorrect character decoding when pasting text from the macOS clipboard.
- Ensures users paste the clipboard’s actual UTF-8 text, including into terminal sessions.
- Introduces macOS-specific dependencies and behavior that should be validated across supported macOS environments.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
