### PR TITLE
Recover sessions after worktree removal

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ const MAX_FILE_BYTES: u64 = 500_000;
 const DIRECTORY_PAGE_SIZE: usize = 250;
 const MAX_GIT_CHANGES: usize = 500;
 const MAX_GIT_DIFF_BYTES: u64 = 1_000_000;
+const MISSING_DIRECTORY: &str = "The selected folder no longer exists";
 const CODEX_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 // Requests stay bounded so an app server that never answers surfaces an error instead of a stuck tab.
 const CODEX_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
@@ -226,8 +227,7 @@ fn root_path(roots: &Roots, root_id: &str) -> Result<PathBuf, String> {
     let root = roots
         .get(root_id)
         .ok_or("Folder permission is no longer available")?;
-    let root =
-        fs::canonicalize(root).map_err(|_| "The selected folder no longer exists".to_owned())?;
+    let root = fs::canonicalize(root).map_err(|_| MISSING_DIRECTORY.to_owned())?;
     if is_sensitive_root(&root) {
         Err("Credential and configuration folders cannot be opened".into())
     } else {
@@ -459,14 +459,23 @@ async fn forget_worktree(
 }
 
 // worktree add has already run when these are reached, so a failure after it puts the folder and
-// branch back rather than leaving an orphan nothing can clean up. Both removals are always
-// attempted — one failing must not strand the other — and a rollback that fails is said out
-// loud: the caller's error alone would strand the worktree without a word about where.
-fn undo_worktree(git: &Path, repo: &Path, worktree: &Path, branch: &str) -> Result<(), String> {
+// newly made branch back rather than leaving an orphan nothing can clean up. A branch that survived
+// a missing worktree is preserved, and a rollback that fails says where the folder may remain.
+fn undo_worktree(
+    git: &Path,
+    repo: &Path,
+    worktree: &Path,
+    branch: &str,
+    delete_branch: bool,
+) -> Result<(), String> {
     let target = path_text(worktree);
     let removed = command_output(git, repo, &["worktree", "remove", "--force", &target]);
-    let branch_gone = command_output(git, repo, &["branch", "-D", branch]);
-    removed.and(branch_gone).map(|_| ())
+    if delete_branch {
+        let branch_gone = command_output(git, repo, &["branch", "-D", branch]);
+        removed.and(branch_gone).map(|_| ())
+    } else {
+        removed.map(|_| ())
+    }
 }
 
 // On a clean rollback the repository's mark goes too: nothing is left to prove. On a failed one
@@ -479,10 +488,16 @@ fn fail_with_rollback(
     worktree: &Path,
     branch: &str,
     root_id: &str,
+    rollback: Option<(bool, bool)>,
 ) -> String {
-    match undo_worktree(git, repo, worktree, branch) {
+    let Some((delete_branch, remove_mark)) = rollback else {
+        return error;
+    };
+    match undo_worktree(git, repo, worktree, branch, delete_branch) {
         Ok(()) => {
-            remove_repo_mark(git, repo, root_id);
+            if remove_mark {
+                remove_repo_mark(git, repo, root_id);
+            }
             error
         }
         Err(rollback) => format!(
@@ -2821,7 +2836,7 @@ async fn spawn_session(
         .contains_key(&root_id)
     {
         uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
-        let path = fs::canonicalize(cwd).map_err(|_| "The selected folder no longer exists")?;
+        let path = fs::canonicalize(cwd).map_err(|_| MISSING_DIRECTORY)?;
         if is_sensitive_root(&path) {
             return Err("Credential and configuration folders cannot be opened".into());
         }
@@ -3679,8 +3694,8 @@ async fn git_repo(app: AppHandle, path: String) -> Result<Option<Repository>, St
     }))
 }
 
-// A session that shares its project with another gets the next numbered sibling folder. The branch
-// is new, so the name the dialog suggests is validated the way git would before anything is created.
+// A session that shares its project with another gets the next numbered sibling folder. A missing
+// worktree this grant already owns is recreated here too, through the same marks and transaction.
 #[tauri::command]
 async fn create_worktree(
     app: AppHandle,
@@ -3688,23 +3703,68 @@ async fn create_worktree(
     root_id: String,
     branch: String,
 ) -> Result<DirectoryGrant, String> {
-    let folder = root_path(&roots, &root_id)?;
+    grant_known(roots.inner(), &root_id)?;
+    create_worktree_inner(&app, roots.inner(), root_id, branch)
+}
+
+fn create_worktree_inner(
+    app: &AppHandle,
+    roots: &Roots,
+    root_id: String,
+    branch: String,
+) -> Result<DirectoryGrant, String> {
+    let (folder, recovery) = match root_path(roots, &root_id) {
+        Ok(folder) => (folder, None),
+        Err(error) => {
+            let record = worktrees_path(app)?.join(&root_id);
+            let recorded = read_worktree_record(&record).ok_or(error)?;
+            (PathBuf::from(&recorded.main), Some(recorded))
+        }
+    };
+    let restoring = recovery.is_some();
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
     // Anchored at the main checkout even when the session's folder is itself a linked worktree.
     let repo = main_checkout(&git, &folder)?;
-    let checkout = command_output(&git, &folder, &["rev-parse", "--show-toplevel"])
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| repo.clone());
-    let candidate = next_worktree(&git, &repo, &checkout)?;
-    let branch = match branch.trim() {
-        "" => candidate.branch.as_str(),
-        branch => branch,
+    let candidate = match recovery.as_ref() {
+        Some(recorded) => {
+            if !repo_mark_present(&git, &repo, &root_id, &recorded.branch) {
+                return Err(
+                    "Lite cannot prove this repository is the one it created the worktree in; nothing is restored"
+                        .into(),
+                );
+            }
+            let path = PathBuf::from(&recorded.path);
+            if !path.is_dir() && worktree_registered(&git, &repo, &path)? {
+                return Err(
+                    "Git still registers this missing worktree; repair or remove it with Git before restoring the session"
+                        .into(),
+                );
+            }
+            WorktreeCandidate {
+                path,
+                branch: recorded.branch.clone(),
+            }
+        }
+        None => {
+            let checkout = command_output(&git, &folder, &["rev-parse", "--show-toplevel"])
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| repo.clone());
+            next_worktree(&git, &repo, &checkout)?
+        }
+    };
+    let branch = match recovery.as_ref() {
+        Some(_) => candidate.branch.as_str(),
+        None => match branch.trim() {
+            "" => candidate.branch.as_str(),
+            branch => branch,
+        },
     };
     command_output(&git, &repo, &["check-ref-format", "--branch", branch])
         .map_err(|_| format!("“{branch}” is not a valid branch name"))?;
     // A retry resumes the worktree this grant already marked; a new create takes the next free
     // numbered sibling. Nothing else at a candidate path is ever adopted.
     let owned = owned_worktree(&git, &repo, &root_id, branch);
+    let created = owned.is_none();
     let worktree = match owned.as_ref() {
         Some(worktree) => worktree.clone(),
         None => candidate.path,
@@ -3713,7 +3773,12 @@ async fn create_worktree(
     // be: a worktree made from a feature worktree keeps the feature's commits. An empty
     // repository has no HEAD; current git starts the unborn branch without a start point, older
     // git needs --orphan for the same start, and the record simply has no ancestor to check later.
-    let head = command_output(&git, &folder, &["rev-parse", "HEAD"]).ok();
+    let head = match recovery.as_ref() {
+        Some(recorded) => (!recorded.head.is_empty()).then(|| recorded.head.clone()),
+        None => command_output(&git, &folder, &["rev-parse", "HEAD"]).ok(),
+    };
+    let delete_branch = !restoring || !branch_exists(&git, &repo, branch)?;
+    let rollback = created.then_some((delete_branch, !restoring));
     let target = path_text(&worktree);
     let mut args = vec!["worktree", "add", "-b", branch, &target];
     if let Some(head) = head.as_deref() {
@@ -3758,7 +3823,7 @@ async fn create_worktree(
         Ok(admin) => PathBuf::from(admin),
         Err(error) => {
             return Err(fail_with_rollback(
-                error, &git, &repo, &worktree, branch, &root_id,
+                error, &git, &repo, &worktree, branch, &root_id, rollback,
             ));
         }
     };
@@ -3770,13 +3835,14 @@ async fn create_worktree(
             &worktree,
             branch,
             &root_id,
+            rollback,
         ));
     }
     let main_git = match command_output(&git, &repo, &["rev-parse", "--absolute-git-dir"]) {
         Ok(main_git) => PathBuf::from(main_git),
         Err(error) => {
             return Err(fail_with_rollback(
-                error, &git, &repo, &worktree, branch, &root_id,
+                error, &git, &repo, &worktree, branch, &root_id, rollback,
             ));
         }
     };
@@ -3785,11 +3851,11 @@ async fn create_worktree(
         branch.as_bytes(),
     ) {
         return Err(fail_with_rollback(
-            error, &git, &repo, &worktree, branch, &root_id,
+            error, &git, &repo, &worktree, branch, &root_id, rollback,
         ));
     }
     if let Err(error) = record_worktree(
-        &app,
+        app,
         &root_id,
         &worktree,
         branch,
@@ -3798,20 +3864,63 @@ async fn create_worktree(
         head.as_deref().unwrap_or(""),
     ) {
         return Err(fail_with_rollback(
-            error, &git, &repo, &worktree, branch, &root_id,
+            error, &git, &repo, &worktree, branch, &root_id, rollback,
         ));
     }
-    match grant_directory(&app, &roots, worktree.clone(), Some(root_id.clone())) {
+    match grant_directory(app, roots, worktree.clone(), Some(root_id.clone())) {
         Ok(grant) => Ok(grant),
         Err(error) => {
-            if let Ok(directory) = worktrees_path(&app) {
+            if !restoring
+                && created
+                && let Ok(directory) = worktrees_path(app)
+            {
                 let _ = forget_record(&directory.join(&root_id));
             }
             Err(fail_with_rollback(
-                error, &git, &repo, &worktree, branch, &root_id,
+                error, &git, &repo, &worktree, branch, &root_id, rollback,
             ))
         }
     }
+}
+
+#[tauri::command]
+async fn restore_worktree(
+    app: AppHandle,
+    roots: State<'_, Roots>,
+    root_id: String,
+    owned_only: bool,
+) -> Result<Option<DirectoryGrant>, String> {
+    uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid grant ID")?;
+    if !roots
+        .0
+        .lock()
+        .map_err(|error| error.to_string())?
+        .contains_key(&root_id)
+    {
+        return Ok(None);
+    }
+    match root_path(roots.inner(), &root_id) {
+        Ok(_) => return Ok(None),
+        Err(error) if error == MISSING_DIRECTORY => {}
+        Err(error) => return Err(error),
+    }
+    let record = worktrees_path(&app)?.join(&root_id);
+    let recorded = read_worktree_record(&record).ok_or(MISSING_DIRECTORY)?;
+    // A running shell may have left its healthy owned tree and lost only the folder it cd'd into;
+    // live recovery leaves that process alone, while startup returns it to the tree it can launch in.
+    if Path::new(&recorded.path).is_dir() {
+        if owned_only {
+            return Ok(None);
+        }
+        return grant_directory(
+            &app,
+            roots.inner(),
+            PathBuf::from(recorded.path),
+            Some(root_id),
+        )
+        .map(Some);
+    }
+    create_worktree_inner(&app, roots.inner(), root_id, String::new()).map(Some)
 }
 
 // What closing a worktree session needs to know before it asks. recorded is false when Lite has
@@ -4423,6 +4532,7 @@ pub fn run() {
             git_remote,
             git_repo,
             create_worktree,
+            restore_worktree,
             worktree_state,
             remove_worktree,
             forget_worktree,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3762,6 +3762,12 @@ fn create_worktree_inner(
     // A retry resumes the worktree this grant already marked; a new create takes the next free
     // numbered sibling. Nothing else at a candidate path is ever adopted.
     let owned = owned_worktree(&git, &repo, &root_id, branch);
+    if restoring && owned.as_ref().is_some_and(|path| path != &candidate.path) {
+        return Err(
+            "Git registers this worktree at a different path; move it back or remove it with Git before restoring the session"
+                .into(),
+        );
+    }
     let created = owned.is_none();
     let worktree = match owned.as_ref() {
         Some(worktree) => worktree.clone(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,7 +79,6 @@ struct PtySession {
 }
 
 fn stop_pty(session: &mut PtySession) -> Result<(), String> {
-    session.alive.store(false, Ordering::Relaxed);
     let running = session
         .child
         .try_wait()
@@ -88,10 +87,12 @@ fn stop_pty(session: &mut PtySession) -> Result<(), String> {
     let kill_error = running
         .then(|| session.child.kill().err().map(|error| error.to_string()))
         .flatten();
-    match session.child.wait() {
-        Ok(_) => Ok(()),
-        Err(error) => Err(kill_error.unwrap_or_else(|| error.to_string())),
-    }
+    session
+        .child
+        .wait()
+        .map_err(|error| kill_error.unwrap_or_else(|| error.to_string()))?;
+    session.alive.store(false, Ordering::Relaxed);
+    Ok(())
 }
 
 #[derive(Default)]
@@ -3284,13 +3285,10 @@ fn resize_session(
 
 #[tauri::command]
 fn stop_session(sessions: State<Sessions>, session_id: String) -> Result<(), String> {
-    if let Some(mut session) = sessions
-        .0
-        .lock()
-        .map_err(|error| error.to_string())?
-        .remove(&session_id)
-    {
-        stop_pty(&mut session)?;
+    let mut sessions = sessions.0.lock().map_err(|error| error.to_string())?;
+    if let Some(session) = sessions.get_mut(&session_id) {
+        stop_pty(session)?;
+        sessions.remove(&session_id);
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3903,20 +3903,25 @@ async fn restore_worktree(
     {
         return Ok(None);
     }
-    match root_path(roots.inner(), &root_id) {
-        Ok(_) => return Ok(None),
-        Err(error) if error == MISSING_DIRECTORY => {}
+    let current = match root_path(roots.inner(), &root_id) {
+        Ok(path) => Some(path),
+        Err(error) if error == MISSING_DIRECTORY => None,
         Err(error) => return Err(error),
-    }
+    };
     let record = worktrees_path(&app)?.join(&root_id);
-    let recorded = read_worktree_record(&record).ok_or(MISSING_DIRECTORY)?;
+    let Some(recorded) = read_worktree_record(&record) else {
+        return current.map_or_else(|| Err(MISSING_DIRECTORY.into()), |_| Ok(None));
+    };
+    let path = PathBuf::from(&recorded.path);
+    if current
+        .as_ref()
+        .is_some_and(|current| fs::canonicalize(&path).ok().as_ref() != Some(current))
+    {
+        return Ok(None);
+    }
     // A running shell may have left its healthy owned tree and lost only the folder it cd'd into;
     // live recovery leaves that process alone, while startup returns it to the tree it can launch in.
-    let path = PathBuf::from(&recorded.path);
     if path.is_dir() {
-        if owned_only {
-            return Ok(None);
-        }
         let git = resolve_executable("git").unwrap_or_else(|| "git".into());
         let main = PathBuf::from(&recorded.main);
         let owner = command_output(&git, &path, &["rev-parse", "--absolute-git-dir"])
@@ -3930,6 +3935,9 @@ async fn restore_worktree(
                 "The folder at the recorded path is not the worktree Lite created; nothing is restored"
                     .into(),
             );
+        }
+        if owned_only {
+            return Ok(None);
         }
         return grant_directory(&app, roots.inner(), path, Some(root_id)).map(Some);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3912,17 +3912,26 @@ async fn restore_worktree(
     let recorded = read_worktree_record(&record).ok_or(MISSING_DIRECTORY)?;
     // A running shell may have left its healthy owned tree and lost only the folder it cd'd into;
     // live recovery leaves that process alone, while startup returns it to the tree it can launch in.
-    if Path::new(&recorded.path).is_dir() {
+    let path = PathBuf::from(&recorded.path);
+    if path.is_dir() {
         if owned_only {
             return Ok(None);
         }
-        return grant_directory(
-            &app,
-            roots.inner(),
-            PathBuf::from(recorded.path),
-            Some(root_id),
-        )
-        .map(Some);
+        let git = resolve_executable("git").unwrap_or_else(|| "git".into());
+        let main = PathBuf::from(&recorded.main);
+        let owner = command_output(&git, &path, &["rev-parse", "--absolute-git-dir"])
+            .ok()
+            .and_then(|admin| fs::read_to_string(PathBuf::from(admin).join("lite")).ok());
+        if !repo_mark_present(&git, &main, &root_id, &recorded.branch)
+            || !worktree_registered(&git, &main, &path)?
+            || owner.as_deref().map(str::trim) != Some(root_id.as_str())
+        {
+            return Err(
+                "The folder at the recorded path is not the worktree Lite created; nothing is restored"
+                    .into(),
+            );
+        }
+        return grant_directory(&app, roots.inner(), path, Some(root_id)).map(Some);
     }
     create_worktree_inner(&app, roots.inner(), root_id, String::new()).map(Some)
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1416,6 +1416,9 @@ function App() {
         });
         const live = sessionsRef.current.find((item) => item.id === session.id);
         if (!folder || !live?.running || closingIds.current.has(session.id) || closingAllRef.current) return;
+        setStartingIds((current) => new Set(current).add(session.id));
+        await invoke("stop_session", { sessionId: session.id });
+        stopped = true;
         runs.current.delete(session.id);
         setShellAgents((current) => {
           if (!current.has(session.id)) return current;
@@ -1423,9 +1426,6 @@ function App() {
           next.delete(session.id);
           return next;
         });
-        setStartingIds((current) => new Set(current).add(session.id));
-        stopped = true;
-        await invoke("stop_session", { sessionId: session.id });
         const current = sessionsRef.current.find((item) => item.id === session.id) ?? live;
         // Keep the terminal mounted while its write queue holds later keystrokes behind recovery;
         // launch marks it disconnected if the replacement process cannot start.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,14 @@ import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { clearUsageCache, Inspector } from "@/inspector";
 import { NewSessionDialog } from "@/new-session-dialog";
-import { appendOutput, clearOutput, subscribeOutput, syncTerminalTheme, writeSession } from "@/output-store";
+import {
+  appendOutput,
+  clearOutput,
+  holdSessionWrites,
+  subscribeOutput,
+  syncTerminalTheme,
+  writeSession,
+} from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
 import { applyTheme, initialTheme, type Theme } from "@/theme";
 import { type Agent, defaultSessionName, repoName, type Session, sessionLabel } from "@/types";
@@ -924,6 +931,7 @@ function App() {
   // Bulk close is running: the dialog stays up and sessions stay untouched until every stop and
   // cleanup has settled, so nothing can be reopened under its own cleanup.
   const [closingAllRunning, setClosingAllRunning] = useState(false);
+  const closingAllRef = useRef(false);
   // The worktree session waiting on the close dialog's answer, with what its tree looked like when asked.
   const [closingWorktree, setClosingWorktree] = useState<{
     session: Session;
@@ -972,6 +980,8 @@ function App() {
   const [updateError, setUpdateError] = useState("");
   const updateDialog = useRef<HTMLDivElement>(null);
   const runs = useRef(new Map<string, string>());
+  const recoveries = useRef(new Map<string, Promise<void>>());
+  const recoveryFailures = useRef(new Set<string>());
   // Sessions whose worktree the user agreed to force-remove, mapped to whether the approval
   // covered real changes (true) or only ignored files and submodules (false); read at cleanup.
   const forceWorktree = useRef(new Map<string, boolean>());
@@ -993,6 +1003,7 @@ function App() {
   const selectedRef = useRef<Session>(undefined);
   const closeRef = useRef<(session: Session) => void>(() => {});
   const openRef = useRef<(session: Session) => void>(() => {});
+  const recoverRef = useRef<(session: Session) => Promise<void>>(() => Promise.resolve());
   const markAttention = useCallback((sessionId: string) => {
     const current = attentionRef.current;
     if (current[current.length - 1] === sessionId) return;
@@ -1026,7 +1037,10 @@ function App() {
   openRef.current = (session) => {
     clearAttention(session.id);
     setSelectedId(session.id);
-    if (!session.running && !startingIds.has(session.id)) void launch(session, true);
+    if (session.running) {
+      recoveryFailures.current.delete(session.id);
+      void recoverRef.current(session).catch(() => {});
+    } else if (!startingIds.has(session.id)) void launch(session, true);
   };
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
@@ -1111,8 +1125,10 @@ function App() {
 
   useEffect(() => {
     const readSelected = () => {
-      const sessionId = selectedRef.current?.id;
-      if (sessionId) clearAttention(sessionId);
+      const session = selectedRef.current;
+      if (!session) return;
+      clearAttention(session.id);
+      if (session.running) void recoverRef.current(session).catch(() => {});
     };
     window.addEventListener("focus", readSelected);
     return () => window.removeEventListener("focus", readSelected);
@@ -1320,11 +1336,23 @@ function App() {
 
   const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return true;
+    recoveryFailures.current.delete(session.id);
     const runId = crypto.randomUUID();
     runs.current.set(session.id, runId);
     setStartingIds((current) => new Set(current).add(session.id));
     setError("");
     try {
+      if (session.worktree) {
+        const folder = await invoke<{ id: string; path: string } | null>("restore_worktree", {
+          rootId: session.rootId,
+          ownedOnly: false,
+        });
+        if (folder) {
+          setSessions((current) =>
+            current.map((item) => (item.id === session.id ? { ...item, cwd: folder.path } : item)),
+          );
+        }
+      }
       const providerSessionId = await invoke<string | null>("spawn_session", {
         sessionId: session.id,
         runId,
@@ -1365,6 +1393,72 @@ function App() {
       });
     }
   }, []);
+
+  function recoverSession(session: Session): Promise<void> {
+    const pending = recoveries.current.get(session.id);
+    if (pending) return pending;
+    if (recoveryFailures.current.has(session.id)) return Promise.resolve();
+    if (
+      !session.worktree ||
+      startingIds.has(session.id) ||
+      closingIds.current.has(session.id) ||
+      closingAllRef.current
+    ) {
+      return Promise.resolve();
+    }
+    let stopped = false;
+    let cleanup = () => Promise.resolve();
+    const recovery = (async () => {
+      try {
+        const folder = await invoke<{ id: string; path: string } | null>("restore_worktree", {
+          rootId: session.rootId,
+          ownedOnly: true,
+        });
+        const live = sessionsRef.current.find((item) => item.id === session.id);
+        if (!folder || !live?.running || closingIds.current.has(session.id) || closingAllRef.current) return;
+        runs.current.delete(session.id);
+        setShellAgents((current) => {
+          if (!current.has(session.id)) return current;
+          const next = new Map(current);
+          next.delete(session.id);
+          return next;
+        });
+        setStartingIds((current) => new Set(current).add(session.id));
+        stopped = true;
+        await invoke("stop_session", { sessionId: session.id });
+        const current = sessionsRef.current.find((item) => item.id === session.id) ?? live;
+        // Keep the terminal mounted while its write queue holds later keystrokes behind recovery;
+        // launch marks it disconnected if the replacement process cannot start.
+        const restored = { ...current, cwd: folder.path, running: true };
+        setSessions((current) => current.map((item) => (item.id === session.id ? restored : item)));
+        resumed.current = session.id;
+        await launch(restored, true);
+      } catch (reason) {
+        if (stopped) {
+          setSessions((current) =>
+            current.map((item) => (item.id === session.id ? { ...item, running: false } : item)),
+          );
+        }
+        recoveryFailures.current.add(session.id);
+        setError(`Session could not be recovered: ${String(reason)}`);
+        throw reason;
+      } finally {
+        recoveries.current.delete(session.id);
+        pendingCleanups.current.delete(cleanup);
+        setStartingIds((current) => {
+          const next = new Set(current);
+          next.delete(session.id);
+          return next;
+        });
+      }
+    })();
+    cleanup = () => recovery.catch(() => {});
+    recoveries.current.set(session.id, recovery);
+    pendingCleanups.current.add(cleanup);
+    holdSessionWrites(session.id, recovery);
+    return recovery;
+  }
+  recoverRef.current = recoverSession;
 
   // Opening the app, or coming back to a session, brings its provider process back on its own.
   useEffect(() => {
@@ -1461,10 +1555,20 @@ function App() {
 
   // Restarting keeps the tab and its folder but asks the provider for a conversation of its own, so the
   // session it resumed by id is retained only until the shared Undo window expires.
-  function restartSession(session: Session, select = true) {
+  function restartSession(session: Session, select = true, recovered = false) {
     // A close in flight owns this session's fate: restarting now would inherit a worktree the
     // close dialog is about to take away.
-    if (startingIds.has(session.id) || closingIds.current.has(session.id)) return;
+    const recovering = recoveries.current.get(session.id);
+    if (recovering) {
+      const restart = () => {
+        const current = sessionsRef.current.find((item) => item.id === session.id);
+        if (current) restartSession(current, select, true);
+      };
+      void recovering.then(restart, restart);
+      return;
+    }
+    if ((!recovered && startingIds.has(session.id)) || closingIds.current.has(session.id)) return;
+    recoveryFailures.current.delete(session.id);
     clearAttention(session.id);
     const fresh: Session = { ...session, id: crypto.randomUUID(), providerSessionId: undefined, running: false };
     const restarted = restartSessionNow(session, fresh, select);
@@ -1579,6 +1683,7 @@ function App() {
   // Worktree cleanup runs first so a failed removal can restore a session whose provider metadata
   // and folder grant are still intact.
   async function cleanupSession(session: Session): Promise<{ error: string; restorable: boolean }> {
+    recoveryFailures.current.delete(session.id);
     let error = "";
     let restorable = false;
     if (session.worktree) {
@@ -1636,8 +1741,17 @@ function App() {
 
   // A worktree session owns the folder it runs in, so closing one first asks whether the folder
   // and its branch go with the tab. Everything else closes directly.
-  function closeSession(session: Session) {
-    if (startingIds.has(session.id)) return;
+  function closeSession(session: Session, recovered = false) {
+    const recovering = recoveries.current.get(session.id);
+    if (recovering) {
+      const close = () => {
+        const current = sessionsRef.current.find((item) => item.id === session.id);
+        if (current) closeSession(current, true);
+      };
+      void recovering.then(close, close);
+      return;
+    }
+    if (!recovered && startingIds.has(session.id)) return;
     if (!session.worktree) return closeSessionNow(session);
     // One close flow across the app at a time: the dialog is singular, so from probe to answer
     // only one worktree session may be closing at all — a second would overwrite the dialog and
@@ -2187,6 +2301,9 @@ function App() {
                               agent={shellAgents.get(session.id) ?? session.agent}
                               theme={theme}
                               active={selected.running && session.id === selectedId}
+                              working={working.has(session.id)}
+                              starting={startingIds.has(session.id)}
+                              onRecover={() => recoverSession(session)}
                               onPrompt={(text) => {
                                 const agent = session.agent === "shell" ? commandAgent(text) : undefined;
                                 if (agent)
@@ -2461,10 +2578,12 @@ function App() {
                     // A session whose cleanup failed but is restorable keeps its tab: the record
                     // and grant survive for a retry, and they need a row to be retried from.
                     const failed = new Set<string>();
+                    closingAllRef.current = true;
                     setClosingAllRunning(true);
                     // Registered like every other cleanup: closing the app mid-run waits for this
                     // instead of abandoning stops and cleanups half-done.
                     const close = async () => {
+                      await Promise.allSettled([...recoveries.current.values()]);
                       await Promise.all(
                         sessions.map(async (session) => {
                           // A session that cannot be stopped is left alone, still live and still
@@ -2491,6 +2610,7 @@ function App() {
                         }),
                       );
                       setSelectedId(sessions.find((session) => failed.has(session.id))?.id ?? "");
+                      closingAllRef.current = false;
                       setClosingAllRunning(false);
                       setClosingAll(false);
                     };

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -151,6 +151,17 @@ export function clearOutput(sessionId: string) {
 // queue rather than each holding its own — an order that only covers the keyboard is not an order.
 const writes = new Map<string, Promise<unknown>>();
 
+// Recovery replaces a process behind the same session id. Input arriving while it does waits in the
+// existing per-session queue, and a failed replacement releases later writes instead of jamming it.
+export function holdSessionWrites(sessionId: string, wait: Promise<unknown>) {
+  writes.set(
+    sessionId,
+    (writes.get(sessionId) ?? Promise.resolve())
+      .then(() => wait)
+      .catch((reason) => console.error(`Lite could not recover session ${sessionId}:`, reason)),
+  );
+}
+
 export function writeSession(sessionId: string, text: string) {
   const data = Array.from(new TextEncoder().encode(text));
   writes.set(

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -85,20 +85,33 @@ export function TerminalView({
   agent,
   theme,
   active,
+  working,
+  starting,
   onPrompt,
+  onRecover,
 }: {
   sessionId: string;
   agent: Agent;
   theme: Theme;
   active: boolean;
+  working: boolean;
+  starting: boolean;
   onPrompt: (text: string) => void;
+  onRecover: () => Promise<void>;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Held in a ref so a new prompt handler never rebuilds the terminal underneath the session.
   const promptRef = useRef(onPrompt);
   promptRef.current = onPrompt;
+  const recoverRef = useRef(onRecover);
+  recoverRef.current = onRecover;
   const terminalRef = useRef<Terminal | null>(null);
   const zoomRef = useRef<(step: -1 | 0 | 1) => void>(() => undefined);
+  const resizeRef = useRef<() => void>(() => undefined);
+  const checkRef = useRef(true);
+  const workingRef = useRef(working);
+  if (workingRef.current && !working) checkRef.current = true;
+  workingRef.current = working;
   // Read when a terminal is built, so switching sessions paints the new one in the current theme
   // without rebuilding it every time the theme changes.
   const themeRef = useRef(theme);
@@ -139,6 +152,10 @@ export function TerminalView({
     // An event can end mid-sequence, so an unfinished tail waits for the rest instead of being read.
     let pending = "";
     const input = terminal.onData((data) => {
+      if (checkRef.current) {
+        checkRef.current = false;
+        void recoverRef.current().catch(() => {});
+      }
       const buffer = pending + data;
       const partial = buffer.match(PARTIAL);
       pending = partial?.[0] ?? "";
@@ -160,6 +177,7 @@ export function TerminalView({
         rows: terminal.rows,
       });
     };
+    resizeRef.current = resize;
     zoomRef.current = (step) => {
       const size = step ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, terminal.options.fontSize ?? 13) + step) : 13;
       terminal.options.fontSize = size;
@@ -225,12 +243,17 @@ export function TerminalView({
       terminal.dispose();
       terminalRef.current = null;
       zoomRef.current = () => undefined;
+      resizeRef.current = () => undefined;
     };
   }, [sessionId]);
 
   useEffect(() => {
     if (active) terminalRef.current?.focus();
   }, [active]);
+
+  useEffect(() => {
+    if (!starting) requestAnimationFrame(() => resizeRef.current());
+  }, [starting]);
 
   useEffect(() => {
     if (terminalRef.current) terminalRef.current.options.theme = themes[theme];

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -207,7 +207,7 @@ export function TerminalView({
       ) {
         // Returning false leaves the keypress to follow and send a bare carriage return.
         event.preventDefault();
-        writeSession(sessionId, "\x1b\r");
+        terminal.input("\x1b\r");
         return false;
       }
       // xterm defers ASCII capitals to keypress for macOS IMEs. WKWebView also emits text input for


### PR DESCRIPTION
## Summary

- restore a session-owned Git worktree when its directory was removed after the session started
- resume the existing provider conversation across Claude, Codex, Gemini, Kimi, and Qwen, while starting a fresh shell for shell sessions
- recover before launch, when revisiting/focusing a tab, or on the first input after a completed turn without adding polling or background filesystem work
- refuse automatic repair when Git still registers the missing path, preserving manually moved worktrees and their uncommitted data

## Validation

- `bun run check`
- `bun run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Added session-owned Git worktree recovery so sessions can resume after their worktree directory is removed, while protecting worktrees that Git still tracks elsewhere.

### 📊 Key Changes

- Added the `restore_worktree` Tauri command to validate recorded ownership, recreate missing worktrees, and restore directory grants.
- Recovery now runs before launching a session, when revisiting or focusing a tab, and on the first input after a completed turn.
- Existing provider sessions resume through the recovered worktree, while shell sessions start a new shell.
- Automatic repair is refused when Git still registers the missing worktree or records it at another path.
- Session input is queued during recovery, and PTY shutdown now marks sessions inactive only after the child process has exited.

### 🎯 Purpose & Impact

- Removed worktree directories can be recreated from Lite’s recorded repository, branch, path, and commit metadata without polling or background filesystem monitoring.
- Running sessions can recover in place; recovery stops and relaunches the session only after the owned worktree is restored.
- User input arriving during recovery is held and released afterward, while failed recovery reports an error and prevents repeated automatic attempts for that session.
- Normal worktree creation and rollback retain their existing cleanup behavior, with recovery preserving branches that may have survived directory removal.