### PR TITLE
Fix terminal OSC hyperlink activation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.18"
+version = "0.0.19"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -129,6 +129,12 @@ export function TerminalView({
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       fontSize: storedFontSize(),
       lineHeight: 1.25,
+      linkHandler: {
+        activate: (event, url) => {
+          event.preventDefault();
+          void invoke("open_url", { url });
+        },
+      },
       scrollback: 5000,
       theme: themes[themeRef.current],
     });


### PR DESCRIPTION
## Summary

- route xterm OSC 8 hyperlinks through Lite's existing native URL opener
- preserve the current web-link addon behavior for plain-text URLs
- bump the native app patch version from `0.0.18` to `0.0.19`

## Problem

Codex emits semantic terminal links using OSC 8. The web-link addon only handles detected plain-text URLs, so OSC 8 links fell through to xterm's browser-based `confirm`/`window.open` fallback instead of Lite's Tauri `open_url` command. As a result, links that work in a normal terminal were not clickable in Lite.

The shared terminal path covers Claude, Codex, Gemini, Kimi, Qwen, and shell sessions. The existing native URL opener dispatches through macOS `open`, Windows `cmd /c start`, and Linux `xdg-open`.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Configured terminal OSC 8 hyperlinks to use Lite’s native `open_url` handler and bumped the native app patch version to `0.0.19`.

### 📊 Key Changes

- Added an xterm `linkHandler` in `src/terminal.tsx` that prevents the default browser fallback and invokes Tauri’s `open_url` command.
- Preserved the existing web-link addon behavior for plain-text URLs.
- Updated the native package version in `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock` from `0.0.18` to `0.0.19`.

### 🎯 Purpose & Impact

- OSC 8 links emitted by terminal sessions now open through Lite’s native URL handling instead of xterm’s browser-based fallback.
- Plain-text URL detection remains unchanged.
- The shared terminal behavior applies to the existing terminal sessions that use `TerminalView`.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
