### PR TITLE
Refresh Files on every visit

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,13 +4,6 @@
   height: 100%;
 }
 
-/* xterm marks OSC 8 hyperlinks with its dashed underline style. Render that semantic link style the
-   same solid blue used by Lite's light and dark syntax themes. */
-.xterm .xterm-underline-5 {
-  color: var(--syntax-constant) !important;
-  text-decoration-style: solid;
-}
-
 /* Session actions belong to the terminal while the pointer or keyboard is working there. */
 [data-terminal-surface]:hover [data-terminal-action],
 [data-terminal-surface]:has(.xterm.focus) [data-terminal-action] {

--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,13 @@
   height: 100%;
 }
 
+/* xterm marks OSC 8 hyperlinks with its dashed underline style. Render that semantic link style the
+   same solid blue used by Lite's light and dark syntax themes. */
+.xterm .xterm-underline-5 {
+  color: var(--syntax-constant) !important;
+  text-decoration-style: solid;
+}
+
 /* Session actions belong to the terminal while the pointer or keyboard is working there. */
 [data-terminal-surface]:hover [data-terminal-action],
 [data-terminal-surface]:has(.xterm.focus) [data-terminal-action] {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1092,8 +1092,8 @@ export function Inspector({
 }) {
   const [tab, setTab] = useState<string>(TABS[0].value);
   const [visited, setVisited] = useState(() => new Set<string>([TABS[0].value]));
-  // A tab already names the panel it shows, so the panel does not name itself again. One button beside
-  // the tabs rereads whichever is open, by rebuilding it, and only that one ever reads the disk.
+  // A tab already names the panel it shows, so the panel does not name itself again. The refresh button
+  // rebuilds whichever is open, and every explicit Files visit rebuilds that disk snapshot as well.
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
 
   function visitTab(value: string) {
@@ -1105,14 +1105,19 @@ export function Inspector({
     });
   }
 
+  function refreshTab(value: keyof typeof reload) {
+    setReload((counts) => ({ ...counts, [value]: counts[value] + 1 }));
+  }
+
   function selectTab(value: string) {
     setTab(value);
     visitTab(value);
+    if (value === "files") refreshTab(value);
   }
 
   // Collapsed, the panel is the strip of tabs it collapsed from: the one you pick is the one it reopens
-  // on. What it was showing is hidden rather than thrown away, so the file you had open is still open
-  // when it comes back. Hovering or focusing Git explicitly asks that panel to prepare before the click.
+  // on. Hidden panels retain their state except Files, whose explicit visit requests a fresh disk
+  // snapshot. Hovering or focusing Git explicitly asks that panel to prepare before the click.
   const rail = (
     <div
       data-context-surface
@@ -1174,6 +1179,7 @@ export function Inspector({
                         aria-label={label}
                         onPointerEnter={value === "git" ? () => visitTab(value) : undefined}
                         onFocus={value === "git" ? () => visitTab(value) : undefined}
+                        onClick={value === "files" && tab === "files" ? () => refreshTab("files") : undefined}
                       />
                     }
                   >
@@ -1190,7 +1196,7 @@ export function Inspector({
                   tooltip="Refresh"
                   aria-label="Refresh"
                   data-context-refresh
-                  onClick={() => setReload((counts) => ({ ...counts, [tab]: counts[tab as keyof typeof counts] + 1 }))}
+                  onClick={() => refreshTab(tab as keyof typeof reload)}
                 >
                   <RefreshCw />
                 </ActionIconButton>


### PR DESCRIPTION
## Summary

- refresh the Files snapshot whenever the Files tab is selected
- refresh again when the already-selected Files tab is clicked
- reuse the existing remount-based refresh path without watchers or polling

## Problem

The Files panel retained its first directory snapshot while the session changed files on disk. Returning to Files—or clicking Files again—continued to show stale entries until the separate refresh button was used.

## Validation

- `bun run check`
- `bun run build`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The Inspector now refreshes the Files snapshot whenever the Files tab is selected or reselected, preventing stale directory entries without adding watchers or polling.

### 📊 Key Changes

- Added a shared `refreshTab()` helper that increments the existing reload counters.
- Files refreshes when switching to the Files tab.
- Clicking the already-selected Files tab triggers another refresh.
- The existing Refresh button now uses the shared helper while preserving refresh behavior for all tabs.
- Updated Inspector comments to document the Files-specific refresh behavior.

### 🎯 Purpose & Impact

- Returning to Files or clicking Files again now rebuilds its disk snapshot, so directory changes are reflected without using the separate Refresh button.
- Other tabs retain their existing state and refresh behavior.
- No watchers or polling were added.