### PR TITLE
Add terminal action background

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2471,7 +2471,7 @@ function App() {
                     {selected.running ? (
                       <fieldset
                         aria-label="Session actions"
-                        className="absolute top-2 right-2 z-10 hidden items-center gap-0.5"
+                        className="absolute top-2 right-2 z-10 hidden items-center gap-0.5 bg-background"
                         data-terminal-action
                         onMouseDown={(event) => event.preventDefault()}
                       >


### PR DESCRIPTION
## Summary

- add the theme background behind the terminal session actions
- prevent terminal text from showing through the restart and close controls

## Validation

- `bun run check`
- `bun run build`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added the theme background to running terminal session controls so terminal text does not show through the restart and close actions.

### 📊 Key Changes
- Updated the terminal action `<fieldset>` in `src/App.tsx`.
- Added the `bg-background` class to the session action controls.
- Preserved the existing positioning, layering, spacing, and interaction behavior.

### 🎯 Purpose & Impact
- The restart and close controls now display an opaque theme-colored background over the terminal content.
- No other terminal session behavior was changed.