### PR TITLE
Show PR line changes in Git tab

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1008,6 +1008,8 @@ struct GitHubItem {
     title: Option<String>,
     state: Option<String>,
     occurred_at: Option<String>,
+    additions: Option<u64>,
+    deletions: Option<u64>,
 }
 
 // The repository and number a GitHub work-item link names, or nothing if the link is not one. Owner
@@ -1093,7 +1095,7 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
             ));
         }
         query.push_str(
-            "}\nfragment f on IssueOrPullRequest {\n... on Issue { title url state createdAt closedAt }\n... on PullRequest { title url state isDraft createdAt closedAt mergedAt }\n}",
+            "}\nfragment f on IssueOrPullRequest {\n... on Issue { title url state createdAt closedAt }\n... on PullRequest { title url state isDraft createdAt closedAt mergedAt additions deletions }\n}",
         );
         let output = Command::new(gh)
             .args(["api", "graphql", "-f", &format!("query={query}")])
@@ -1149,6 +1151,8 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
                     title: item["title"].as_str().map(str::to_owned),
                     state: Some(state.to_owned()),
                     occurred_at,
+                    additions: item["additions"].as_u64(),
+                    deletions: item["deletions"].as_u64(),
                 });
             }
             // The repository was read and searched, and the number names nothing in it.
@@ -1158,6 +1162,8 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
                 title: None,
                 state: None,
                 occurred_at: None,
+                additions: None,
+                deletions: None,
             }),
         }
     }
@@ -1178,6 +1184,8 @@ async fn github_items(urls: Vec<String>) -> Vec<GitHubItem> {
             title: None,
             state: None,
             occurred_at: None,
+            additions: None,
+            deletions: None,
         })
         .collect();
     tauri::async_runtime::spawn_blocking(move || check_github_items(urls))

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -241,7 +241,7 @@ function GitHubItemList({ label, items }: { label: string; items: RepositoryGrou
               <ItemTitle className="w-full">{title ?? `#${number}`}</ItemTitle>
               {title ? (
                 <div className="flex min-w-0 items-center gap-2">
-                  <ItemDescription className="min-w-0 flex-1 truncate font-mono">
+                  <ItemDescription className="min-w-0 truncate font-mono">
                     #{number}
                     {occurredAt ? ` · ${relativeAge(occurredAt)}` : ""}
                   </ItemDescription>
@@ -251,7 +251,11 @@ function GitHubItemList({ label, items }: { label: string; items: RepositoryGrou
                   {deletions ? (
                     <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{deletions}</span>
                   ) : null}
-                  {state ? <Badge variant={GITHUB_STATE[state]}>{state}</Badge> : null}
+                  {state ? (
+                    <Badge className="ml-auto" variant={GITHUB_STATE[state]}>
+                      {state}
+                    </Badge>
+                  ) : null}
                 </div>
               ) : null}
             </ItemContent>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -125,6 +125,8 @@ interface GitHubItem {
   title: string | null;
   state: keyof typeof GITHUB_STATE | null;
   occurredAt: string | null;
+  additions: number | null;
+  deletions: number | null;
 }
 
 // The colors GitHub itself answers in, so a glance here reads the same as a glance there.
@@ -218,7 +220,7 @@ function GitHubItemList({ label, items }: { label: string; items: RepositoryGrou
     <div className="border-t">
       <p className="px-3 pt-2 pb-1 text-xs font-medium text-muted-foreground">{label}</p>
       <ItemGroup className="has-data-[size=xs]:gap-0">
-        {items.map(({ url, title, state, occurredAt, kind, number }) => (
+        {items.map(({ url, title, state, occurredAt, additions, deletions, kind, number }) => (
           <Item
             key={url}
             size="xs"
@@ -243,6 +245,12 @@ function GitHubItemList({ label, items }: { label: string; items: RepositoryGrou
                     #{number}
                     {occurredAt ? ` · ${relativeAge(occurredAt)}` : ""}
                   </ItemDescription>
+                  {additions ? (
+                    <span className="shrink-0 font-mono text-xs text-green-600 dark:text-green-400">+{additions}</span>
+                  ) : null}
+                  {deletions ? (
+                    <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{deletions}</span>
+                  ) : null}
                   {state ? <Badge variant={GITHUB_STATE[state]}>{state}</Badge> : null}
                 </div>
               ) : null}
@@ -902,7 +910,10 @@ function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: st
       })
       // A link that could not be checked is still explicit, so it is shown the way it was printed.
       .catch(() => {
-        if (!disposed) setItems(urls.map((url) => ({ url, title: null, state: null, occurredAt: null })));
+        if (!disposed)
+          setItems(
+            urls.map((url) => ({ url, title: null, state: null, occurredAt: null, additions: null, deletions: null })),
+          );
       });
     return () => {
       disposed = true;


### PR DESCRIPTION
## Summary

- include pull request additions and deletions in the existing batched GitHub lookup
- show compact `+N` and `-N` counters in each pull request row
- reuse the Git change-list colors without adding requests or background work

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- live `gh api graphql` query against ultralytics/lite PR #74

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

GitHub pull request rows in the Git tab now display compact addition and deletion counts retrieved through the existing batched GraphQL lookup.

### 📊 Key Changes

- Added `additions` and `deletions` fields to the Rust and TypeScript `GitHubItem` models.
- Extended the pull request GraphQL fragment to fetch both line-change counts.
- Displayed non-zero counts as green `+N` and red `-N` indicators in pull request rows.
- Kept issue entries and failed lookups compatible by assigning `null` counts when the values are unavailable.
- Reused the Git change-list color treatment and kept the existing lookup flow without additional requests or background work.

### 🎯 Purpose & Impact

- Users can see each pull request’s additions and deletions directly in the Git tab without opening GitHub.
- Pull request state badges remain visible and are aligned to the right of the row.