### PR TITLE
Align toast timing with shadcn defaults

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1673,6 +1673,7 @@ function App() {
     toastId = toast.add({
       title: `${action} “${session.name}”`,
       type: "success",
+      timeout: 10000,
       onClose: async () => {
         if (!undone) await finish();
         pendingCleanups.current.delete(finish);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1673,7 +1673,6 @@ function App() {
     toastId = toast.add({
       title: `${action} “${session.name}”`,
       type: "success",
-      timeout: 8000,
       onClose: async () => {
         if (!undone) await finish();
         pendingCleanups.current.delete(finish);


### PR DESCRIPTION
## Summary

- extend Undo toasts from 8 to 10 seconds, matching the official Base UI Undo example
- keep all ordinary toasts on the shadcn/Base UI 5-second provider default

## Validation

- `bun run check`
- repo-wide toast timing override audit

## References

- https://base-ui.com/react/components/toast#undo-action
- https://base-ui.com/react/components/toast#provider

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the session action Undo toast timeout from 8 to 10 seconds to align with the referenced Base UI Undo example while leaving ordinary toasts on the provider default.

### 📊 Key Changes
- Changed the `App.tsx` session action toast timeout from `8000` to `10000` milliseconds.
- Applied the longer timeout specifically to the toast that supports Undo through its `onClose` cleanup behavior.
- Made no changes to other toast timing overrides or the provider default.

### 🎯 Purpose & Impact
- Users have 2 additional seconds to use Undo on session action toasts; ordinary toasts retain the existing 5-second provider behavior.