### PR TITLE
Trim repeated work and fix update, zoom, and truncation bugs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.20"
+version = "0.0.21"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2135,6 +2135,10 @@ fn resolve_executable(name: &str) -> Option<PathBuf> {
     })
 }
 
+fn executable_exists(name: &str) -> bool {
+    resolve_executable(name).is_some()
+}
+
 fn agent_executable(agent: &str) -> Option<&'static str> {
     match agent {
         "claude" => Some("claude"),
@@ -2546,8 +2550,7 @@ async fn agent_availability(
         }
         _ => return Err("Unknown session type".into()),
     };
-    let installed = agent_executable(&agent).and_then(resolve_executable);
-    if installed.is_none() {
+    if !agent_executable(&agent).is_some_and(executable_exists) {
         return Ok(Availability {
             available: false,
             installable: true,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2135,10 +2135,6 @@ fn resolve_executable(name: &str) -> Option<PathBuf> {
     })
 }
 
-fn executable_exists(name: &str) -> bool {
-    resolve_executable(name).is_some()
-}
-
 fn agent_executable(agent: &str) -> Option<&'static str> {
     match agent {
         "claude" => Some("claude"),
@@ -2161,8 +2157,10 @@ fn codex_home(app: &AppHandle) -> Result<PathBuf, String> {
     provider_home(app, "CODEX_HOME", ".codex")
 }
 
-// Looks only for the section header. Provider credentials in that file are never read.
-fn codex_declares_provider(app: &AppHandle, provider: &str) -> bool {
+// Whether Codex's own configuration states something, asked line by line so the file is never parsed
+// and never held in memory. Only section headers and key names are ever looked for; provider
+// credentials in that file are never read.
+fn codex_config_states(app: &AppHandle, stated: impl Fn(&str) -> bool) -> bool {
     let Ok(home) = codex_home(app) else {
         return false;
     };
@@ -2172,21 +2170,19 @@ fn codex_declares_provider(app: &AppHandle, provider: &str) -> bool {
     BufReader::new(file)
         .lines()
         .map_while(Result::ok)
-        .any(|line| line.trim() == format!("[model_providers.{provider}]"))
+        .any(|line| stated(&line))
+}
+
+fn codex_declares_provider(app: &AppHandle, provider: &str) -> bool {
+    let header = format!("[model_providers.{provider}]");
+    codex_config_states(app, |line| line.trim() == header)
 }
 
 // A catalog is a replacement rather than a merge, so one the user configured is left to win.
 fn codex_declares_catalog(app: &AppHandle) -> bool {
-    let Ok(home) = codex_home(app) else {
-        return false;
-    };
-    let Ok(file) = fs::File::open(home.join("config.toml")) else {
-        return false;
-    };
-    BufReader::new(file)
-        .lines()
-        .map_while(Result::ok)
-        .any(|line| line.trim_start().starts_with("model_catalog_json"))
+    codex_config_states(app, |line| {
+        line.trim_start().starts_with("model_catalog_json")
+    })
 }
 
 fn codex_profile_exists(app: &AppHandle, provider: &str) -> bool {
@@ -2249,10 +2245,6 @@ fn native_session_path(app: &AppHandle, agent: &str, session_id: &str) -> Option
                 }
             })
     })
-}
-
-fn native_session_exists(app: &AppHandle, agent: &str, session_id: &str) -> bool {
-    native_session_path(app, agent, session_id).is_some()
 }
 
 fn kimi_home(app: &AppHandle) -> Result<PathBuf, String> {
@@ -2554,7 +2546,8 @@ async fn agent_availability(
         }
         _ => return Err("Unknown session type".into()),
     };
-    if !agent_executable(&agent).is_some_and(executable_exists) {
+    let installed = agent_executable(&agent).and_then(resolve_executable);
+    if installed.is_none() {
         return Ok(Availability {
             available: false,
             installable: true,
@@ -2862,7 +2855,7 @@ async fn spawn_session(
     let mut resume = resume
         && match agent.as_str() {
             "claude" => claude_launch.as_ref().is_some_and(|(_, resume)| *resume),
-            "gemini" | "qwen" => native_session_exists(&app, &agent, &session_id),
+            "gemini" | "qwen" => native_session_path(&app, &agent, &session_id).is_some(),
             _ => true,
         };
     // The tab keeps the id it was given so the next launch reopens the same conversation, and a

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { clearUsageCache, Inspector } from "@/inspector";
+import { without } from "@/lib/utils";
 import { NewSessionDialog } from "@/new-session-dialog";
 import {
   appendOutput,
@@ -114,7 +115,7 @@ const SHUT = 140;
 // A side reopens to the share of the window it started with, in the pixels a glide is measured in.
 function share(panel: PanelImperativeHandle | null, portion: string) {
   const size = panel?.getSize();
-  if (!size || !size.asPercentage) return 0;
+  if (!size?.asPercentage) return 0;
   return Math.round((size.inPixels / size.asPercentage) * Number.parseFloat(portion));
 }
 
@@ -1357,11 +1358,7 @@ function App() {
       sessionId,
       window.setTimeout(() => {
         timers.delete(sessionId);
-        setWorking((current) => {
-          const next = new Set(current);
-          next.delete(sessionId);
-          return next;
-        });
+        setWorking((current) => without(current, sessionId));
       }, QUIET_MS),
     );
   }, []);
@@ -1513,11 +1510,7 @@ function App() {
       setError(String(reason));
       return false;
     } finally {
-      setStartingIds((current) => {
-        const next = new Set(current);
-        next.delete(session.id);
-        return next;
-      });
+      setStartingIds((current) => without(current, session.id));
     }
   }, []);
 
@@ -1572,11 +1565,7 @@ function App() {
       } finally {
         recoveries.current.delete(session.id);
         pendingCleanups.current.delete(cleanup);
-        setStartingIds((current) => {
-          const next = new Set(current);
-          next.delete(session.id);
-          return next;
-        });
+        setStartingIds((current) => without(current, session.id));
       }
     })();
     cleanup = () => recovery.catch(() => {});
@@ -1808,7 +1797,7 @@ function App() {
     return true;
   }
 
-  async function restartAllSessions() {
+  function restartAllSessions() {
     for (const session of sessions) restartSession(session, session.id === selectedId);
   }
 
@@ -1998,11 +1987,7 @@ function App() {
     const timer = workTimers.current.get(session.id);
     if (timer) window.clearTimeout(timer);
     workTimers.current.delete(session.id);
-    setWorking((current) => {
-      const next = new Set(current);
-      next.delete(session.id);
-      return next;
-    });
+    setWorking((current) => without(current, session.id));
     setSessions((current) => current.filter((item) => item.id !== session.id));
     if (wasSelected) setSelectedId(nextSelectedId);
 
@@ -2151,7 +2136,7 @@ function App() {
         }}
         onRestartSession={(session) => void restartSession(session)}
         onCloseSession={closeSession}
-        onRestartAll={() => void restartAllSessions()}
+        onRestartAll={restartAllSessions}
         onCloseAll={() => setClosingAll(true)}
       >
         <div ref={layout} className="flex h-screen flex-col overflow-hidden bg-background text-foreground">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { clearUsageCache, Inspector } from "@/inspector";
-import { without } from "@/lib/utils";
+import { swapped, without } from "@/lib/utils";
 import { NewSessionDialog } from "@/new-session-dialog";
 import {
   appendOutput,
@@ -1386,6 +1386,17 @@ function App() {
     });
   }, []);
 
+  // A shell is only running an agent for as long as that agent is running: the badge goes back to the
+  // shell's own when the process ends, and when the session it ran in ends with it.
+  const forgetShellAgent = useCallback((sessionId: string) => {
+    setShellAgents((current) => {
+      if (!current.has(sessionId)) return current;
+      const next = new Map(current);
+      next.delete(sessionId);
+      return next;
+    });
+  }, []);
+
   const markDirectory = useCallback((sessionId: string, path: string) => {
     const session = sessionsRef.current.find((item) => item.id === sessionId);
     if (session?.agent !== "shell" || session.cwd === path) return;
@@ -1416,12 +1427,7 @@ function App() {
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
         runs.current.delete(payload.sessionId);
-        setShellAgents((current) => {
-          if (!current.has(payload.sessionId)) return current;
-          const next = new Map(current);
-          next.delete(payload.sessionId);
-          return next;
-        });
+        forgetShellAgent(payload.sessionId);
         setSessions((current) =>
           current.map((session) => (session.id === payload.sessionId ? { ...session, running: false } : session)),
         );
@@ -1456,7 +1462,7 @@ function App() {
       for (const timer of timers.values()) window.clearTimeout(timer);
       timers.clear();
     };
-  }, [markAttention, markDirectory, markWorking, markTitle]);
+  }, [forgetShellAgent, markAttention, markDirectory, markWorking, markTitle]);
 
   const launch = useCallback(async (session: Session, resume: boolean) => {
     if (runs.current.has(session.id)) return true;
@@ -1540,12 +1546,7 @@ function App() {
         await invoke("stop_session", { sessionId: session.id });
         stopped = true;
         runs.current.delete(session.id);
-        setShellAgents((current) => {
-          if (!current.has(session.id)) return current;
-          const next = new Map(current);
-          next.delete(session.id);
-          return next;
-        });
+        forgetShellAgent(session.id);
         const current = sessionsRef.current.find((item) => item.id === session.id) ?? live;
         // Keep the terminal mounted while its write queue holds later keystrokes behind recovery;
         // launch marks it disconnected if the replacement process cannot start.
@@ -1707,12 +1708,7 @@ function App() {
       restarted,
       () => {
         const restored = { ...session, running: false };
-        setStartingIds((current) => {
-          const next = new Set(current);
-          next.delete(fresh.id);
-          next.add(session.id);
-          return next;
-        });
+        setStartingIds((current) => swapped(current, fresh.id, session.id));
         setSessions((current) => current.map((item) => (item.id === fresh.id ? restored : item)));
         setSelectedId((current) => (current === fresh.id ? session.id : current));
         resumed.current = session.id;
@@ -1722,12 +1718,7 @@ function App() {
           try {
             await invoke("stop_session", { sessionId: fresh.id });
           } catch (reason) {
-            setStartingIds((current) => {
-              const next = new Set(current);
-              next.delete(session.id);
-              next.add(fresh.id);
-              return next;
-            });
+            setStartingIds((current) => swapped(current, session.id, fresh.id));
             const relaunched = { ...fresh, running: false };
             setSessions((current) => current.map((item) => (item.id === session.id ? relaunched : item)));
             setSelectedId((current) => (current === session.id ? fresh.id : current));
@@ -1768,12 +1759,7 @@ function App() {
       await invoke("stop_session", { sessionId: session.id });
     } catch (reason) {
       const restored = { ...session, running: false };
-      setStartingIds((current) => {
-        const next = new Set(current);
-        next.delete(fresh.id);
-        next.add(session.id);
-        return next;
-      });
+      setStartingIds((current) => swapped(current, fresh.id, session.id));
       setSessions((current) => current.map((item) => (item.id === fresh.id ? restored : item)));
       setSelectedId((current) => (current === fresh.id ? session.id : current));
       resumed.current = session.id;

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -54,6 +54,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
+import { without } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput } from "@/output-store";
 import {
   type DirectoryCursor,
@@ -448,11 +449,7 @@ function FileTree({
         setError(String(reason));
       } finally {
         loading.current.delete(path);
-        setLoadingPaths((current) => {
-          const next = new Set(current);
-          next.delete(path);
-          return next;
-        });
+        setLoadingPaths((current) => without(current, path));
       }
     },
     [rootId],
@@ -529,13 +526,24 @@ function FileTree({
   });
 
   // A folder is worth showing while searching if anything under it matches; only loaded listings can
-  // answer, which is what the walk above is for.
-  function subtreeMatches(path: string): boolean {
-    const listing = children[path];
-    return !!listing?.entries.some(
-      (entry) => entry.name.toLowerCase().includes(lowered) || (entry.isDirectory && subtreeMatches(entry.path)),
-    );
-  }
+  // answer, which is what the walk above is for. One pass marks every such folder, because the answer
+  // is asked for twice per row drawn — once to keep the folder and once to open it — and a folder deep
+  // in a tree would otherwise have its whole subtree rescanned once for every ancestor above it.
+  const matching = useMemo(() => {
+    const found = new Set<string>();
+    if (!lowered) return found;
+    const visit = (path: string): boolean => {
+      let inside = false;
+      for (const entry of children[path]?.entries ?? []) {
+        // Always descend: a folder is marked for its own sake, not only for its parent's answer.
+        if ((entry.isDirectory && visit(entry.path)) || entry.name.toLowerCase().includes(lowered)) inside = true;
+      }
+      if (inside) found.add(path);
+      return inside;
+    };
+    visit(root);
+    return found;
+  }, [children, lowered, root]);
 
   function rows(path: string, depth = 0): React.ReactNode {
     const listing = children[path];
@@ -545,13 +553,13 @@ function FileTree({
     }
     const entries = lowered
       ? listing.entries.filter(
-          (entry) => entry.name.toLowerCase().includes(lowered) || (entry.isDirectory && subtreeMatches(entry.path)),
+          (entry) => entry.name.toLowerCase().includes(lowered) || (entry.isDirectory && matching.has(entry.path)),
         )
       : listing.entries;
     return (
       <>
         {entries.map((entry) => {
-          const open = entry.isDirectory && (expanded.has(entry.path) || (!!lowered && subtreeMatches(entry.path)));
+          const open = entry.isDirectory && (expanded.has(entry.path) || matching.has(entry.path));
           return (
             <div key={entry.path}>
               <button
@@ -653,7 +661,7 @@ function FileTree({
       </div>
       {/* A walk that failed searched a partial tree, so its error shows over whatever it did find. */}
       {lowered && error ? <p className="p-3 text-xs text-destructive">{error}</p> : null}
-      {lowered && !error && !expandingAll && children[root] && !subtreeMatches(root) ? (
+      {lowered && !error && !expandingAll && children[root] && !matching.has(root) ? (
         <p className="px-3 py-2 text-xs text-muted-foreground">No matches</p>
       ) : null}
       {rootOpen ? rows(root, 1) : null}
@@ -1204,19 +1212,18 @@ export function Inspector({
                 </Tooltip>
               ))}
             </TabsList>
-            <span className="ml-auto flex items-center">
-              {tab === "usage" && session.agent === "shell" ? null : (
-                <ActionIconButton
-                  size="icon-sm"
-                  tooltip="Refresh"
-                  aria-label="Refresh"
-                  data-context-refresh
-                  onClick={() => refreshTab(tab as keyof typeof reload)}
-                >
-                  <RefreshCw />
-                </ActionIconButton>
-              )}
-            </span>
+            {tab === "usage" && session.agent === "shell" ? null : (
+              <ActionIconButton
+                size="icon-sm"
+                className="ml-auto"
+                tooltip="Refresh"
+                aria-label="Refresh"
+                data-context-refresh
+                onClick={() => refreshTab(tab as keyof typeof reload)}
+              >
+                <RefreshCw />
+              </ActionIconButton>
+            )}
           </div>
           {visited.has("files") ? (
             <TabsContent value="files" keepMounted className="min-h-0 overflow-hidden">

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -54,7 +54,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
-import { without } from "@/lib/utils";
+import { storedFontSize, without, zoomedFontSize } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput } from "@/output-store";
 import {
   type DirectoryCursor,
@@ -669,17 +669,7 @@ function FileTree({
   );
 }
 
-// The same size and limits as the terminal's type, stored on its own key: prose and code read at
-// different sizes than a terminal for different people, so each surface remembers its own.
 const PREVIEW_FONT_KEY = "lite.preview.fontSize";
-const MIN_PREVIEW_FONT = 9;
-const MAX_PREVIEW_FONT = 24;
-const DEFAULT_PREVIEW_FONT = 13;
-
-function storedPreviewFontSize(): number {
-  const saved = Number(localStorage.getItem(PREVIEW_FONT_KEY));
-  return saved >= MIN_PREVIEW_FONT && saved <= MAX_PREVIEW_FONT ? saved : DEFAULT_PREVIEW_FONT;
-}
 
 // The preview inherits its type from here, so one zoom scales code, prose, and the line-number gutter
 // together while the header chrome keeps its own size. Zooming lives in this component so a step
@@ -695,7 +685,7 @@ function FileViewer({
   error: string;
   onBack: () => void;
 }) {
-  const [fontSize, setFontSize] = useState(storedPreviewFontSize);
+  const [fontSize, setFontSize] = useState(() => storedFontSize(PREVIEW_FONT_KEY));
   const viewer = useRef<HTMLElement>(null);
 
   // Reading is keyboard work, so the viewer takes focus as it opens and the zoom keys land here
@@ -727,9 +717,7 @@ function FileViewer({
   }, [onBack]);
 
   function zoom(step: -1 | 0 | 1) {
-    const size = step ? Math.min(MAX_PREVIEW_FONT, Math.max(MIN_PREVIEW_FONT, fontSize + step)) : DEFAULT_PREVIEW_FONT;
-    setFontSize(size);
-    localStorage.setItem(PREVIEW_FONT_KEY, String(size));
+    setFontSize(zoomedFontSize(PREVIEW_FONT_KEY, fontSize, step));
   }
 
   return (

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -54,8 +54,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
-import { storedFontSize, without, zoomedFontSize } from "@/lib/utils";
+import { without } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput } from "@/output-store";
+import { storedFontSize, zoomedFontSize } from "@/theme";
 import {
   type DirectoryCursor,
   type DirectoryListing,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,3 +6,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// A key leaving a set of them. The set comes back untouched when it never held the key, so the panel
+// or the session list behind it is not redrawn for a removal that had already happened.
+export function without(current: Set<string>, key: string): Set<string> {
+  if (!current.has(key)) return current;
+  const next = new Set(current);
+  next.delete(key);
+  return next;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,31 +7,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-// The terminal and the file preview zoom the same way and hold each other to the same sizes, so the
-// bounds are stated once. Each remembers its own size under its own key: prose and code are read at
-// different sizes than a terminal, by different people.
-const MIN_FONT_SIZE = 9;
-const MAX_FONT_SIZE = 24;
-const DEFAULT_FONT_SIZE = 13;
-
-export function storedFontSize(key: string): number {
-  const saved = Number(localStorage.getItem(key));
-  return saved >= MIN_FONT_SIZE && saved <= MAX_FONT_SIZE ? saved : DEFAULT_FONT_SIZE;
-}
-
-// One zoom step from the size showing now; a step of 0 is actual size. The step is taken inside the
-// bounds, never past them, so the smallest size stays a size the reader above will take back.
-export function zoomedFontSize(key: string, from: number, step: -1 | 0 | 1): number {
-  const size = step ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, from + step)) : DEFAULT_FONT_SIZE;
-  localStorage.setItem(key, String(size));
-  return size;
-}
-
 // A key leaving a set of them. The set comes back untouched when it never held the key, so the panel
 // or the session list behind it is not redrawn for a removal that had already happened.
 export function without(current: Set<string>, key: string): Set<string> {
   if (!current.has(key)) return current;
   const next = new Set(current);
   next.delete(key);
+  return next;
+}
+
+// One key taking another's place, which is what a session does to the one it replaces: the tab that
+// was starting stops, and the tab standing in for it starts, in the one change the list redraws for.
+export function swapped(current: Set<string>, from: string, to: string): Set<string> {
+  const next = new Set(current);
+  next.delete(from);
+  next.add(to);
   return next;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,26 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+// The terminal and the file preview zoom the same way and hold each other to the same sizes, so the
+// bounds are stated once. Each remembers its own size under its own key: prose and code are read at
+// different sizes than a terminal, by different people.
+const MIN_FONT_SIZE = 9;
+const MAX_FONT_SIZE = 24;
+const DEFAULT_FONT_SIZE = 13;
+
+export function storedFontSize(key: string): number {
+  const saved = Number(localStorage.getItem(key));
+  return saved >= MIN_FONT_SIZE && saved <= MAX_FONT_SIZE ? saved : DEFAULT_FONT_SIZE;
+}
+
+// One zoom step from the size showing now; a step of 0 is actual size. The step is taken inside the
+// bounds, never past them, so the smallest size stays a size the reader above will take back.
+export function zoomedFontSize(key: string, from: number, step: -1 | 0 | 1): number {
+  const size = step ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, from + step)) : DEFAULT_FONT_SIZE;
+  localStorage.setItem(key, String(size));
+  return size;
+}
+
 // A key leaving a set of them. The set comes back untouched when it never held the key, so the panel
 // or the session list behind it is not redrawn for a removal that had already happened.
 export function without(current: Set<string>, key: string): Set<string> {

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -403,11 +403,13 @@ export function NewSessionDialog({
                   // A registry that could not answer knows of no update, so only one it reported is
                   // offered — by the button and by the mark beside the version alike.
                   const updatable = managed && update === true;
-                  // The label doubles as the switch: nothing to install or update, no button.
+                  // What the button offers, if it is there at all, and the room the tile keeps for it:
+                  // a tile only ever offers the one action, so each reserves the width of its own
+                  // widest label rather than both settling for the wider.
                   const action = state?.installable
-                    ? (["Install", "Installing…"] as const)
+                    ? ({ label: "Install", working: "Installing…", room: "pr-28" } as const)
                     : updatable
-                      ? (["Update", "Updating…"] as const)
+                      ? ({ label: "Update", working: "Updating…", room: "pr-24" } as const)
                       : undefined;
                   const busy = installing === option.id;
                   const authProvider = "configured" in option ? option : undefined;
@@ -418,10 +420,7 @@ export function NewSessionDialog({
                         type="button"
                         size="lg"
                         variant={active ? "secondary" : "outline"}
-                        // The room kept for the button is the room its widest label takes — which is
-                        // “Installing…” beside a spinner — so the agent's name truncates before it
-                        // rather than running underneath it.
-                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-28" : "pr-3"}`}
+                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action?.room ?? "pr-3"}`}
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}
@@ -455,7 +454,7 @@ export function NewSessionDialog({
                           onClick={() => void install(option)}
                         >
                           {busy ? <Spinner /> : null}
-                          {busy ? action[1] : action[0]}
+                          {busy ? action.working : action.label}
                         </Button>
                       ) : null}
                     </div>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -401,10 +401,12 @@ export function NewSessionDialog({
                   const update = updates[option.agent];
                   const managed = option.agent !== "shell" && state && !state.installable;
                   // A registry that could not answer knows of no update, so only one it reported is
-                  // offered. The label doubles as the switch: nothing to install or update, no button.
+                  // offered — by the button and by the mark beside the version alike.
+                  const updatable = managed && update === true;
+                  // The label doubles as the switch: nothing to install or update, no button.
                   const action = state?.installable
                     ? (["Install", "Installing…"] as const)
-                    : managed && update === true
+                    : updatable
                       ? (["Update", "Updating…"] as const)
                       : undefined;
                   const busy = installing === option.id;
@@ -426,7 +428,7 @@ export function NewSessionDialog({
                       >
                         <ProviderIcon agent={option.agent} provider={option.provider} className="size-5" />
                         <div
-                          className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : managed && update === true ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
+                          className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : updatable ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
                         >
                           <span className="block truncate">{sessionLabel(option)}</span>
                           {state && !state.available ? (

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -418,9 +418,10 @@ export function NewSessionDialog({
                         type="button"
                         size="lg"
                         variant={active ? "secondary" : "outline"}
-                        // The room the action button needs is the room its widest state needs, so the
-                        // name truncates before it rather than running under “Installing…”.
-                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-24" : "pr-3"}`}
+                        // The room kept for the button is the room its widest label takes — which is
+                        // “Installing…” beside a spinner — so the agent's name truncates before it
+                        // rather than running underneath it.
+                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-28" : "pr-3"}`}
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -22,10 +22,7 @@ import { Switch } from "@/components/ui/switch";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
 import { defaultSessionName, type Session, sessionLabel } from "@/types";
 
-const choices = [
-  ...Object.values(AUTH_PROVIDERS),
-  { id: "shell", agent: "shell" as const, provider: undefined, description: "Open your default shell" },
-];
+const choices = [...Object.values(AUTH_PROVIDERS), { id: "shell", agent: "shell" as const, provider: undefined }];
 const harnesses = [...new Set(choices.map((option) => option.agent).filter((agent) => agent !== "shell"))];
 
 // The quiet heading that separates the two questions the dialog asks, in the sidebar's own label style.
@@ -403,7 +400,14 @@ export function NewSessionDialog({
                   const state = availability[option.id];
                   const update = updates[option.agent];
                   const managed = option.agent !== "shell" && state && !state.installable;
-                  const installable = state?.installable;
+                  // A registry that could not answer knows of no update, so only one it reported is
+                  // offered. The label doubles as the switch: nothing to install or update, no button.
+                  const action = state?.installable
+                    ? (["Install", "Installing…"] as const)
+                    : managed && update === true
+                      ? (["Update", "Updating…"] as const)
+                      : undefined;
+                  const busy = installing === option.id;
                   const authProvider = "configured" in option ? option : undefined;
                   const authStatus = authProvider ? auth?.find((entry) => entry.name === authProvider.id) : undefined;
                   return (
@@ -412,7 +416,9 @@ export function NewSessionDialog({
                         type="button"
                         size="lg"
                         variant={active ? "secondary" : "outline"}
-                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${installable ? "pr-20" : managed && update !== false && update !== undefined ? "pr-24" : "pr-3"}`}
+                        // The room the action button needs is the room its widest state needs, so the
+                        // name truncates before it rather than running under “Installing…”.
+                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-24" : "pr-3"}`}
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}
@@ -436,7 +442,7 @@ export function NewSessionDialog({
                           )}
                         </div>
                       </Button>
-                      {installable ? (
+                      {action ? (
                         <Button
                           type="button"
                           size="sm"
@@ -445,20 +451,8 @@ export function NewSessionDialog({
                           disabled={Boolean(installing)}
                           onClick={() => void install(option)}
                         >
-                          {installing === option.id ? <Spinner /> : null}
-                          {installing === option.id ? "Installing…" : "Install"}
-                        </Button>
-                      ) : managed && update !== false && update !== undefined ? (
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          className="absolute top-1/2 right-1.5 -translate-y-1/2"
-                          disabled={Boolean(installing)}
-                          onClick={() => void install(option)}
-                        >
-                          {installing === option.id ? <Spinner /> : null}
-                          {installing === option.id ? "Updating…" : "Update"}
+                          {busy ? <Spinner /> : null}
+                          {busy ? action[1] : action[0]}
                         </Button>
                       ) : null}
                     </div>

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -21,14 +21,13 @@ const buffers = new Map<string, Buffer>();
 const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 
 // Titles and working directories arrive whether or not the session is visible, so their shared OSC
-// owner lives here where every session's output arrives rather than in the mounted terminal.
+// owner lives here where every session's output arrives rather than in the mounted terminal. Lite's
+// Claude status line reports work that produces no terminal output — a parent waiting for subagents,
+// a quiet shell command — through a private OSC of its own, which stays invisible and reaches the
+// same owner. They are read in one pass because every byte a session prints goes through it, and a
+// pass per kind is a pass per kind over all of it.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
-const METADATA = /\x1b\]([027]);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
-// Lite's Claude status line reports work that produces no terminal output, such as a parent waiting
-// for subagents or a quiet shell command. The private OSC stays invisible while the shared output
-// owner makes the signal available even when the session's terminal is not mounted.
-// biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
-const ACTIVITY = /\x1b\]6973;lite-(working|idle)(?:\x07|\x1b\\)/g;
+const METADATA = /\x1b\](0|2|7|6973);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 // Common terminal notification protocols share the OSC owner with titles and working directories.
 // Lite needs only the signal for its in-app attention state; the terminal still owns rendering and
 // the notification payload is not retained separately from the bounded output buffer.
@@ -109,10 +108,10 @@ export function appendOutput(sessionId: string, data: number[]) {
     if (match[1] === "7") {
       if (match[2].startsWith("file://"))
         path = decodeURIComponent(new URL(match[2]).pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+    } else if (match[1] === "6973") {
+      if (match[2] === "lite-working" || match[2] === "lite-idle") activity = match[2] === "lite-working";
     } else title = match[2];
   }
-  ACTIVITY.lastIndex = 0;
-  for (let match = ACTIVITY.exec(text); match; match = ACTIVITY.exec(text)) activity = match[1] === "working";
   const tail = text.match(UNTERMINATED)?.[0] ?? "";
   if (activity === undefined && tail.startsWith("\x1b]6973;lite-")) activity = false;
   buffer.tail = tail.length > MAX_TAIL ? "" : tail;

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -46,6 +46,18 @@ const OSC_OR_BELL = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|(\x07)/g;
 // than a title could be is no longer one, so the wait is given up rather than grown.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const UNTERMINATED = /\x1b(?:\](?:(?!\x07|\x1b\\)[\s\S])*)?$/;
+// The folder a session says it is in, as a path. A shell that leaves a bare % in its own path, or
+// names a host no URL can hold, reports one that cannot be read back — and reading it is the last
+// thing this file does before it records where the chunk left off, so a throw here would cost the
+// session every title, folder and activity signal that followed as well. An unreadable path is
+// simply not one, and the folder Lite already knows about stands.
+function reportedPath(url: string): string {
+  try {
+    return decodeURIComponent(new URL(url).pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+  } catch {
+    return "";
+  }
+}
 const MAX_TAIL = 512;
 // Modern TUIs request a report whenever the terminal switches between dark and light. This state is
 // read here, where every session's output arrives, so background sessions and trimmed buffers keep it.
@@ -106,10 +118,10 @@ export function appendOutput(sessionId: string, data: number[]) {
   METADATA.lastIndex = 0;
   for (let match = METADATA.exec(text); match; match = METADATA.exec(text)) {
     if (match[1] === "7") {
-      if (match[2].startsWith("file://"))
-        path = decodeURIComponent(new URL(match[2]).pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+      if (match[2].startsWith("file://")) path = reportedPath(match[2]);
     } else if (match[1] === "6973") {
-      if (match[2] === "lite-working" || match[2] === "lite-idle") activity = match[2] === "lite-working";
+      const working = match[2] === "lite-working";
+      if (working || match[2] === "lite-idle") activity = working;
     } else title = match[2];
   }
   const tail = text.match(UNTERMINATED)?.[0] ?? "";

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -24,8 +24,8 @@ const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 // owner lives here where every session's output arrives rather than in the mounted terminal. Lite's
 // Claude status line reports work that produces no terminal output — a parent waiting for subagents,
 // a quiet shell command — through a private OSC of its own, which stays invisible and reaches the
-// same owner. They are read in one pass because every byte a session prints goes through it, and a
-// pass per kind is a pass per kind over all of it.
+// same owner. One pass reads both: every byte a session prints comes through here, so a second
+// pattern would be a second reading of all of it.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const METADATA = /\x1b\](0|2|7|6973);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 // Common terminal notification protocols share the OSC owner with titles and working directories.

--- a/src/provider-auth.tsx
+++ b/src/provider-auth.tsx
@@ -84,8 +84,6 @@ export const AUTH_PROVIDERS = {
   }
 >;
 
-export type AuthProviderId = keyof typeof AUTH_PROVIDERS;
-
 export interface ProviderAuth {
   name: string;
   keyHint: string | null;
@@ -97,7 +95,7 @@ export function ProviderAuthDescription({
   provider,
   status,
 }: {
-  provider: (typeof AUTH_PROVIDERS)[AuthProviderId];
+  provider: (typeof AUTH_PROVIDERS)[keyof typeof AUTH_PROVIDERS];
   status?: ProviderAuth;
 }) {
   const hint = status?.keyHint ?? status?.cliKeyHint;

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -19,6 +19,7 @@ import {
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
 import { Item, ItemActions, ItemContent, ItemFooter, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { Spinner } from "@/components/ui/spinner";
+import { without } from "@/lib/utils";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
 import type { Agent } from "@/types";
 
@@ -55,12 +56,7 @@ export function SettingsDialog({
   }, [isOpen, read]);
 
   function edit(id: string, open: boolean) {
-    setEditing((current) => {
-      const next = new Set(current);
-      if (open) next.add(id);
-      else next.delete(id);
-      return next;
-    });
+    setEditing((current) => (open ? new Set(current).add(id) : without(current, id)));
     if (!open) setDrafts((current) => ({ ...current, [id]: "" }));
   }
 

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -7,6 +7,7 @@ import { type ITheme, Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 
+import { storedFontSize, zoomedFontSize } from "@/lib/utils";
 import { subscribeOutput, writeSession } from "@/output-store";
 import type { Theme } from "@/theme";
 import type { Agent } from "@/types";
@@ -72,14 +73,6 @@ const SEQUENCES = /\x1b(?:[\]P][\s\S]*?(?:\x07|\x1b\\)|\[[\x30-\x3f]*[ -/]*[@-~]
 const PARTIAL = /\x1b(?:[\]P](?:(?!\x07|\x1b\\)[\s\S])*|\[[\x30-\x3f]*[ -/]*|O)$/;
 
 const FONT_SIZE_KEY = "lite.terminal.fontSize";
-const MIN_FONT_SIZE = 9;
-const MAX_FONT_SIZE = 24;
-const DEFAULT_FONT_SIZE = 13;
-
-function storedFontSize(): number {
-  const saved = Number(localStorage.getItem(FONT_SIZE_KEY));
-  return saved >= MIN_FONT_SIZE && saved <= MAX_FONT_SIZE ? saved : DEFAULT_FONT_SIZE;
-}
 
 export function TerminalView({
   sessionId,
@@ -125,10 +118,13 @@ export function TerminalView({
     const container = containerRef.current;
     if (!container) return;
 
+    // Held here as well as on the terminal, so a zoom step reads the size it last set rather than
+    // asking an option that is typed as though it might never have been given one.
+    let fontSize = storedFontSize(FONT_SIZE_KEY);
     const terminal = new Terminal({
       cursorBlink: true,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-      fontSize: storedFontSize(),
+      fontSize,
       lineHeight: 1.25,
       linkHandler: {
         activate: (event, url) => {
@@ -186,13 +182,8 @@ export function TerminalView({
     };
     resizeRef.current = resize;
     zoomRef.current = (step) => {
-      // Both bounds hold the step, so zooming out at the smallest size stays there rather than
-      // stepping past the size the terminal is willing to read back on the next launch.
-      const size = step
-        ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, (terminal.options.fontSize ?? DEFAULT_FONT_SIZE) + step))
-        : DEFAULT_FONT_SIZE;
-      terminal.options.fontSize = size;
-      localStorage.setItem(FONT_SIZE_KEY, String(size));
+      fontSize = zoomedFontSize(FONT_SIZE_KEY, fontSize, step);
+      terminal.options.fontSize = fontSize;
       requestAnimationFrame(resize);
     };
     // A width change arrives as a stream of frames: a drag, or the ease a collapsing panel runs

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -7,9 +7,8 @@ import { type ITheme, Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 
-import { storedFontSize, zoomedFontSize } from "@/lib/utils";
 import { subscribeOutput, writeSession } from "@/output-store";
-import type { Theme } from "@/theme";
+import { storedFontSize, type Theme, zoomedFontSize } from "@/theme";
 import type { Agent } from "@/types";
 
 // Surface colors follow the app tokens; ANSI colors follow GitHub light and dark, matching the code preview.

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -74,10 +74,11 @@ const PARTIAL = /\x1b(?:[\]P](?:(?!\x07|\x1b\\)[\s\S])*|\[[\x30-\x3f]*[ -/]*|O)$
 const FONT_SIZE_KEY = "lite.terminal.fontSize";
 const MIN_FONT_SIZE = 9;
 const MAX_FONT_SIZE = 24;
+const DEFAULT_FONT_SIZE = 13;
 
 function storedFontSize(): number {
   const saved = Number(localStorage.getItem(FONT_SIZE_KEY));
-  return saved >= MIN_FONT_SIZE && saved <= MAX_FONT_SIZE ? saved : 13;
+  return saved >= MIN_FONT_SIZE && saved <= MAX_FONT_SIZE ? saved : DEFAULT_FONT_SIZE;
 }
 
 export function TerminalView({
@@ -185,7 +186,11 @@ export function TerminalView({
     };
     resizeRef.current = resize;
     zoomRef.current = (step) => {
-      const size = step ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, terminal.options.fontSize ?? 13) + step) : 13;
+      // Both bounds hold the step, so zooming out at the smallest size stays there rather than
+      // stepping past the size the terminal is willing to read back on the next launch.
+      const size = step
+        ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, (terminal.options.fontSize ?? DEFAULT_FONT_SIZE) + step))
+        : DEFAULT_FONT_SIZE;
       terminal.options.fontSize = size;
       localStorage.setItem(FONT_SIZE_KEY, String(size));
       requestAnimationFrame(resize);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,3 +15,24 @@ export function applyTheme(theme: Theme) {
   document.documentElement.style.colorScheme = theme;
   localStorage.setItem(THEME_KEY, theme);
 }
+
+// The other thing Lite remembers about how it looks. The terminal and the file preview zoom the same
+// way and hold each other to the same sizes, so the bounds are stated once; each keeps its own size
+// under its own key, because prose and code are read at different sizes than a terminal is.
+const MIN_FONT_SIZE = 9;
+const MAX_FONT_SIZE = 24;
+const DEFAULT_FONT_SIZE = 13;
+
+export function storedFontSize(key: string): number {
+  const saved = Number(localStorage.getItem(key));
+  return saved >= MIN_FONT_SIZE && saved <= MAX_FONT_SIZE ? saved : DEFAULT_FONT_SIZE;
+}
+
+// One zoom step from the size showing now; a step of 0 is actual size. The step is taken inside the
+// bounds rather than past them, so the smallest size stays a size the reader above will take back —
+// and a step that reaches the size already showing, as held keys at either end do, writes nothing.
+export function zoomedFontSize(key: string, from: number, step: -1 | 0 | 1): number {
+  const size = step ? Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, from + step)) : DEFAULT_FONT_SIZE;
+  if (size !== from) localStorage.setItem(key, String(size));
+  return size;
+}


### PR DESCRIPTION
A performance and cleanup pass over the paths that run most often, plus the bugs found while reading them. Net −10 lines.

## Performance

- **File search walked each subtree once per ancestor.** `subtreeMatches` was asked "does anything under this folder match?" twice for every row drawn, and each ask rescanned the whole subtree beneath it. A single post-order pass now marks every matching folder and the rows read the answer out of a set.
- **Two regex passes over every byte a session prints.** Titles and working directories were read in one pass, Lite's private activity OSC in a second. Both are OSC, so one pass reads them. Verified identical to the two it replaces across 30 cases (terminators, empty payloads, `777;notify`, `69731;`, unterminated tails, interleaving).
- **Set removals re-rendered for removals that had already happened.** Five copies of "copy the set, delete the id, return it" allocated a new set unconditionally. One `without` helper hands the set back untouched when it never held the key.

## Bugs

- **An unanswerable update check offered an Update button.** `updates[agent]` is `null` when the registry could not answer, and `update !== false && update !== undefined` let `null` through. Only an update the registry reported is offered now.
- **Terminal zoom stepped below its own minimum.** `min(MAX, max(MIN, size) + step)` applied the step outside the lower clamp, so zooming out at 9 reached 8 — a size `storedFontSize` refuses, so the next launch silently reset to 13. Both bounds hold the step now.
- **Agent tiles reserved less room for the wider label.** Install rows reserved `pr-20` for "Installing…" while update rows reserved `pr-24` for the narrower "Updating…", so the agent name could truncate under the button.

## Cleanup

- `codex_declares_provider` and `codex_declares_catalog` opened and scanned the same file line by line, differing only in what they looked for; they share one scanner.
- The two near-identical Install/Update buttons are one button whose label is its own switch.
- Deletes: the shell choice's unused `description`, the export-only `AuthProviderId`, the `executable_exists` and `native_session_exists` one-line wrappers, and a `<span>` that existed to carry one class.
- Clears the one Biome warning in the tree (`useOptionalChain` in `share`).

Version 0.0.20 → 0.0.21.

## Validation

`bun run check`, `bun run build`, `cargo fmt --check`, `cargo check`, `cargo test` all clean. Both rewrites were differential-tested against the code they replace: the OSC parse across 30 inputs, the tree search across 15,032 path/query checks on 300 random trees — identical results in every case. Clippy reports only the six warnings already on main.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite 0.0.21 reduces repeated work in file search, output parsing, and state updates while fixing update availability, terminal zoom limits, and agent-tile truncation.

### 📊 Key Changes

- Replaced repeated recursive file-tree searches with one post-order pass that caches matching folders.
- Combined metadata and activity OSC parsing into a single pass, including safe handling for invalid reported paths.
- Added shared set-update helpers to avoid unnecessary re-renders and centralized terminal/file-preview font-size handling with correct bounds.
- Only shows an agent **Update** action when the registry explicitly reports an available update; install and update controls now share one implementation with label-specific spacing.
- Consolidated Codex configuration scanning and removed unused wrappers, types, fields, and markup; version updated from 0.0.20 to 0.0.21.

### 🎯 Purpose & Impact

- Searching loaded directories performs substantially less repeated traversal while preserving matching-folder behavior.
- Session output metadata, working-directory updates, activity state, and titles are processed together; invalid file URLs no longer interrupt metadata handling.
- Zooming out at the minimum remains within the supported font-size range, preventing invalid persisted sizes and later resets.
- Agent names receive spacing appropriate to the displayed action, reducing truncation beneath install or update buttons.
- Shell-agent state is cleared when the process exits or is stopped, and session-start state transitions avoid redundant set allocations.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
