### PR TITLE
Fix chained GitHub command parsing

### DIFF
--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -79,7 +79,7 @@ const CodePreview = lazy(() => import("@/code-preview"));
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\d+/g;
 const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
-const GH_VIEW = /\bgh\s+(issue|pr)\s+view\s+([1-9]\d{0,8})([^;&|\r\n]*)/gi;
+const GH_VIEW = /\bgh\s+(issue|pr)\s+view\s+([1-9]\d{0,8})((?:[^;&|'"\\\r\n]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*)/gi;
 const GH_API =
   /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
 

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -79,7 +79,7 @@ const CodePreview = lazy(() => import("@/code-preview"));
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\d+/g;
 const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
-const GH_VIEW = /\bgh\s+(issue|pr)\s+view\s+([1-9]\d{0,8})([^\r\n]*)/gi;
+const GH_VIEW = /\bgh\s+(issue|pr)\s+view\s+([1-9]\d{0,8})([^;&|\r\n]*)/gi;
 const GH_API =
   /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
 


### PR DESCRIPTION
## Summary

- stop each `gh issue/pr view` match at shell command separators
- keep unqualified commands scoped to the current repository
- detect later commands with their own `-R`/`--repo` repository

## Validation

- `bun run check`
- `bun run build`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated chained GitHub command parsing so `gh issue/pr view` matches stop at shell separators while preserving quoted and escaped arguments.

### 📊 Key Changes

- Replaced the broad `GH_VIEW` match in `src/inspector.tsx` with a shell-aware pattern.
- Prevented matches from consuming subsequent commands separated by `;`, `&`, or `|`.
- Preserved parsing of escaped characters and single- or double-quoted arguments.
- Maintained support for issue and pull request numbers up to eight digits.

### 🎯 Purpose & Impact

- Chained `gh issue view` and `gh pr view` commands can now be identified independently, so later commands and their repository qualifiers are not absorbed into an earlier match.