### PR TITLE
Remember GitHub items for each session

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "atomicwrites",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.21"
+version = "0.0.22"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { clearUsageCache, Inspector } from "@/inspector";
+import { clearInspectorCache, Inspector } from "@/inspector";
 import { swapped, without } from "@/lib/utils";
 import { NewSessionDialog } from "@/new-session-dialog";
 import {
@@ -914,27 +914,27 @@ function SessionRow({
         />
       ) : (
         <div className="min-w-0 flex-1 text-left">
-          {/* Only the visible title owns rename; its hit area stops where its text stops. */}
-          <button
-            type="button"
-            className="group/title flex w-fit max-w-full cursor-pointer items-center gap-1 text-xs font-medium"
-            aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
-            onClick={(event) => {
-              event.stopPropagation();
-              onRenamingChange(true);
-            }}
-            onKeyDown={(event) => {
-              if (!reorderable || !event.altKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
-              event.preventDefault();
-              onMove(event.key === "ArrowUp" ? -1 : 1);
-            }}
-          >
+          <div className="group/title flex w-fit max-w-full items-center gap-1 text-xs font-medium">
             <span className="truncate">{session.name}</span>
-            <Pencil
-              aria-hidden="true"
-              className="size-3 shrink-0 opacity-0 transition-opacity group-hover/title:opacity-100 group-focus-visible/title:opacity-100"
-            />
-          </button>
+            <ActionIconButton
+              size="icon-xs"
+              className="size-4 rounded-sm opacity-0 transition-opacity group-hover/title:opacity-100 focus-visible:opacity-100"
+              tooltip="Rename"
+              aria-label={`Rename ${session.name}`}
+              aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRenamingChange(true);
+              }}
+              onKeyDown={(event) => {
+                if (!reorderable || !event.altKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
+                event.preventDefault();
+                onMove(event.key === "ArrowUp" ? -1 : 1);
+              }}
+            >
+              <Pencil />
+            </ActionIconButton>
+          </div>
           <div
             className="mt-0.5 block w-fit max-w-full truncate font-mono text-[10px] text-muted-foreground"
             title={session.cwd}
@@ -1728,12 +1728,12 @@ function App() {
             }
             await invoke("delete_session_data", { sessionId: session.id }).catch(() => {});
             clearOutput(session.id);
-            clearUsageCache(session.id);
+            clearInspectorCache(session.id);
             return;
           }
           await invoke("delete_session_data", { sessionId: fresh.id }).catch(() => {});
           clearOutput(fresh.id);
-          clearUsageCache(fresh.id);
+          clearInspectorCache(fresh.id);
           await launch(restored, true);
         });
       },
@@ -1742,7 +1742,7 @@ function App() {
           setError(`Session restarted, but local cleanup failed: ${String(reason)}`),
         );
         clearOutput(session.id);
-        clearUsageCache(session.id);
+        clearInspectorCache(session.id);
       },
     );
   }
@@ -1771,7 +1771,7 @@ function App() {
     if (!(await launch(fresh, false))) {
       await invoke("delete_session_data", { sessionId: fresh.id }).catch(() => {});
       clearOutput(fresh.id);
-      clearUsageCache(fresh.id);
+      clearInspectorCache(fresh.id);
       const restored = { ...session, running: false };
       setSessions((current) => current.map((item) => (item.id === fresh.id ? restored : item)));
       setSelectedId((current) => (current === fresh.id ? session.id : current));
@@ -1849,7 +1849,7 @@ function App() {
       error ||= String(reason);
     }
     clearOutput(session.id);
-    clearUsageCache(session.id);
+    clearInspectorCache(session.id);
     if (error) setError(`Session closed, but local cleanup failed: ${error}`);
     return { error, restorable };
   }

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -82,10 +82,12 @@ const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!
 const GH_VIEW = /\bgh\s+(issue|pr)\s+view\s+([1-9]\d{0,8})((?:[^;&|'"\\\r\n]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*)/gi;
 const GH_API =
   /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
+const githubItemsBySession = new Map<string, Set<string>>();
 
 function namedInSession(sessionId: string, remote: string) {
   const text = readOutput(sessionId).slice(-MAX_OUTPUT_BYTES).replace(COLOR, "");
-  const urls = new Set(text.match(GITHUB_ITEM) ?? []);
+  const urls = githubItemsBySession.get(sessionId) ?? new Set<string>();
+  for (const url of text.match(GITHUB_ITEM) ?? []) urls.add(url);
   const prefix = "https://github.com/";
   for (const match of text.matchAll(QUALIFIED_ITEM)) {
     urls.add(`${prefix}${match[1]}/${match[2]}/issues/${match[3]}`);
@@ -99,6 +101,7 @@ function namedInSession(sessionId: string, remote: string) {
   for (const match of text.matchAll(GH_API)) {
     urls.add(`${prefix}${match[1]}/${match[2]}/${match[3].toLowerCase() === "pulls" ? "pull" : "issues"}/${match[4]}`);
   }
+  githubItemsBySession.set(sessionId, urls);
   return [...urls];
 }
 
@@ -884,8 +887,9 @@ function RepositoryCard({ repository }: { repository: RepositoryGroup }) {
 
 const usageCache = new Map<string, UsageSnapshot | null>();
 
-export function clearUsageCache(sessionId: string) {
+export function clearInspectorCache(sessionId: string) {
   usageCache.delete(sessionId);
+  githubItemsBySession.delete(sessionId);
 }
 
 function GitPanel({ rootId, sessionId, remote }: { rootId: string; sessionId: string; remote: string }) {


### PR DESCRIPTION
## Summary
- retain discovered GitHub issues and pull requests until their session is removed
- clear remembered items alongside the inspector session cache
- make only the sidebar pencil control enter title editing
- bump Lite to `0.0.22`

## Validation
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

GitHub issues and pull requests are now remembered per session until cleanup, while renaming is limited to the pencil control and Lite is bumped to `0.0.22`.

### 📊 Key Changes

- Added a per-session `githubItemsBySession` store that accumulates GitHub issue and pull request references discovered by the inspector.
- Updated `clearInspectorCache()` to remove both usage data and remembered GitHub items; session close, restart, and failed-launch cleanup now use it.
- Changed session title editing so only the `ActionIconButton` with the pencil icon activates rename mode.
- Moved the existing Alt+Arrow session-reordering keyboard handling to the pencil control.
- Bumped the Rust package version from `0.0.21` to `0.0.22` and updated the lockfile.

### 🎯 Purpose & Impact

- GitHub items found during a session remain available to the inspector after subsequent output changes, and are removed when that session’s inspector cache is cleared.
- Clicking the session title text no longer starts editing; users must activate the visible or focused Rename pencil control.
- Session cleanup now clears remembered GitHub items along with usage data.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
