### PR TITLE
Improve terminal scroll navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,12 @@ html[data-session-dragging] * {
   display: none;
 }
 
+[data-context-session] .xterm .xterm-scrollable-element > .scrollbar.vertical.invisible.fade {
+  opacity: 1;
+  pointer-events: auto;
+  transition: none;
+}
+
 /* GitHub syntax theme driven by the --syntax-* tokens, so highlighting follows light and dark. */
 .hljs {
   display: block;

--- a/src/App.css
+++ b/src/App.css
@@ -22,16 +22,13 @@ html[data-session-dragging] * {
   height: 0.375rem;
 }
 
-/* xterm draws a scrollbar of its own over the viewport's, and coloring the viewport's makes the
-   platform show it instead of hiding it, so only the one matching the panels is kept. */
-.xterm .xterm-scrollable-element > .scrollbar {
-  display: none;
-}
-
 [data-context-session] .xterm .xterm-viewport {
   background-color: var(--background);
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 40%, transparent) transparent;
+  scrollbar-width: none;
+}
+
+[data-context-session] .xterm .xterm-viewport::-webkit-scrollbar {
+  display: none;
 }
 
 /* GitHub syntax theme driven by the --syntax-* tokens, so highlighting follows light and dark. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
+  ArrowDownToLine,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -2460,6 +2461,20 @@ function App() {
                         data-terminal-action
                         onMouseDown={(event) => event.preventDefault()}
                       >
+                        <ActionIconButton
+                          size="icon-sm"
+                          tooltip="Scroll to bottom"
+                          aria-label="Scroll to bottom"
+                          onClick={() =>
+                            document
+                              .querySelector<HTMLElement>(
+                                `[data-context-session="${CSS.escape(selected.id)}"] [data-terminal-scroll-bottom]`,
+                              )
+                              ?.click()
+                          }
+                        >
+                          <ArrowDownToLine />
+                        </ActionIconButton>
                         <SessionActionButtons
                           name={selected.name}
                           onRestart={() => void restartSession(selected)}

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -16,6 +16,9 @@ const themes: Record<Theme, ITheme> = {
   light: {
     background: "#ffffff",
     foreground: "#0a0a0a",
+    scrollbarSliderBackground: "#6e778166",
+    scrollbarSliderHoverBackground: "#6e778199",
+    scrollbarSliderActiveBackground: "#6e7781cc",
     cursor: "#0a0a0a",
     cursorAccent: "#ffffff",
     selectionBackground: "#0969da33",
@@ -39,6 +42,9 @@ const themes: Record<Theme, ITheme> = {
   dark: {
     background: "#0a0a0a",
     foreground: "#fafafa",
+    scrollbarSliderBackground: "#8b949e66",
+    scrollbarSliderHoverBackground: "#8b949e99",
+    scrollbarSliderActiveBackground: "#8b949ecc",
     cursor: "#fafafa",
     cursorAccent: "#0a0a0a",
     selectionBackground: "#58a6ff40",
@@ -125,6 +131,7 @@ export function TerminalView({
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       fontSize,
       lineHeight: 1.25,
+      overviewRuler: { width: 6 },
       linkHandler: {
         activate: (event, url) => {
           event.preventDefault();
@@ -271,6 +278,7 @@ export function TerminalView({
       <button type="button" hidden data-context-zoom-in onClick={() => zoomRef.current(1)} />
       <button type="button" hidden data-context-zoom-out onClick={() => zoomRef.current(-1)} />
       <button type="button" hidden data-context-zoom-reset onClick={() => zoomRef.current(0)} />
+      <button type="button" hidden data-terminal-scroll-bottom onClick={() => terminalRef.current?.scrollToBottom()} />
       <div ref={containerRef} className="h-full w-full" />
     </div>
   );


### PR DESCRIPTION
## Summary
- show xterm’s persistent cross-platform position scrollbar instead of relying on auto-hidden platform scrollbars
- match Lite’s compact 6 px panel scrollbar width and theme it for light and dark modes
- add a one-click action that scrolls the active terminal to the latest output

## Validation
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `bun run tauri dev`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved terminal scroll navigation by making xterm’s 6 px scrollbar persistently visible and adding a control to jump the active terminal to the latest output.

### 📊 Key Changes

- Hid the platform viewport scrollbar and kept xterm’s vertical scrollbar visible without fade or pointer-event disabling.
- Configured a 6 px terminal overview ruler to match Lite’s compact panel scrollbar width.
- Added light and dark theme colors for the scrollbar slider, hover, and active states.
- Added a “Scroll to bottom” terminal action that calls xterm’s `scrollToBottom()` for the selected session.

### 🎯 Purpose & Impact

- Users can consistently drag the visible terminal scrollbar and quickly return to the newest output from the terminal action bar.