### PR TITLE
Add grouped session navigation and Git diff review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: ultralytics/actions/retry@main
         with:
-          bun-version: latest
+          retries: 3
+          retry_delay_seconds: 20
+          timeout_minutes: 10
+          run: npm install --global bun@latest
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.23"
+version = "0.0.24"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3657,7 +3657,14 @@ async fn git_diff(
         &["rev-parse", "--show-toplevel"],
     )?)
     .map_err(|error| error.to_string())?;
-    let file = repository.join(relative);
+    let file = relative
+        .components()
+        .fold(repository.clone(), |mut file, component| {
+            if let Component::Normal(part) = component {
+                file.push(part);
+            }
+            file
+        });
     let mut ancestor = file.as_path();
     while !ancestor.exists() {
         ancestor = ancestor

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3556,8 +3556,13 @@ fn bounded_git_changes(
                 .read_until(0, &mut source)
                 .map_err(|error| error.to_string())?;
         }
-        let Ok(path) = String::from_utf8(record[3..].to_vec()) else {
-            continue;
+        let path = match String::from_utf8(record[3..].to_vec()) {
+            Ok(path) => path,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("Git status contains a non-UTF-8 path".into());
+            }
         };
         changes.push(GitChange { status, path });
         if changes.len() > MAX_GIT_CHANGES {
@@ -3652,11 +3657,19 @@ async fn git_diff(
     if is_sensitive_path(&granted, &file) || is_sensitive_path(&granted, &ancestor) {
         return Err("Sensitive files are hidden from Git diffs".into());
     }
+    let pathspec = path_text(relative);
     let file = path_text(&file);
     let untracked = !command_output(
         &git,
         &repository,
-        &["ls-files", "--others", "--exclude-standard", "--", &file],
+        &[
+            "--literal-pathspecs",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "--",
+            &pathspec,
+        ],
     )?
     .is_empty();
     if untracked {
@@ -3669,6 +3682,7 @@ async fn git_diff(
                 "--no-index",
                 "--no-ext-diff",
                 "--no-textconv",
+                "--no-renames",
                 "--no-color",
                 "--",
                 null,
@@ -3678,13 +3692,20 @@ async fn git_diff(
         );
     }
     let head = command_output(&git, &repository, &["rev-parse", "--verify", "HEAD"]).is_ok();
-    let mut args = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-color"];
+    let mut args = vec![
+        "--literal-pathspecs",
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        "--no-color",
+    ];
     if head {
         args.push("HEAD");
     } else {
         args.push("--cached");
     }
-    args.extend(["--", &file]);
+    args.extend(["--", &pathspec]);
     bounded_git_output(&git, &repository, &args, &[0])
 }
 
@@ -3711,6 +3732,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         &git,
         &repository,
         &[
+            "--literal-pathspecs",
             "status",
             "--porcelain=v1",
             "-z",
@@ -3723,7 +3745,15 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
     let mut line_diffs = Command::new(&git)
         .arg("-C")
         .arg(&repository)
-        .args(["diff", "--numstat", "-z", "HEAD", "--", &scope_text])
+        .args([
+            "--literal-pathspecs",
+            "diff",
+            "--numstat",
+            "-z",
+            "HEAD",
+            "--",
+            &scope_text,
+        ])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -4944,5 +4974,36 @@ mod tests {
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, "??");
         assert_eq!(changes[0].path, "sub/a -> b.ts");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn git_changes_reject_non_utf8_paths() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let root = std::env::temp_dir().join(format!("lite-git-status-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(OsString::from_vec(vec![b'f', 0xff])), "change").unwrap();
+        assert!(
+            Command::new("git")
+                .arg("init")
+                .arg(&root)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let error = bounded_git_changes(
+            Path::new("git"),
+            &root,
+            &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+        )
+        .err()
+        .unwrap();
+        fs::remove_dir_all(root).unwrap();
+
+        assert_eq!(error, "Git status contains a non-UTF-8 path");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3683,7 +3683,7 @@ async fn git_diff(
     }
     let pathspec = path_text(relative);
     let file = path_text(&file);
-    let untracked = !command_output(
+    let untracked = !bounded_git_output(
         &git,
         &repository,
         &[
@@ -3691,9 +3691,11 @@ async fn git_diff(
             "ls-files",
             "--others",
             "--exclude-standard",
+            "-z",
             "--",
             &pathspec,
         ],
+        &[0],
     )?
     .is_empty();
     if untracked {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3651,11 +3651,12 @@ async fn git_diff(
         );
     }
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
-    let repository = PathBuf::from(command_output(
+    let repository = fs::canonicalize(command_output(
         &git,
         &granted,
         &["rev-parse", "--show-toplevel"],
-    )?);
+    )?)
+    .map_err(|error| error.to_string())?;
     let file = repository.join(relative);
     let mut ancestor = file.as_path();
     while !ancestor.exists() {
@@ -3748,6 +3749,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
             "status",
             "--porcelain=v1",
             "-z",
+            "--no-renames",
             "--untracked-files=all",
             "--",
             &scope_text,
@@ -3757,7 +3759,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
     let base = git_diff_base(&git, &repository)?;
     let mut line_diffs = Command::new(&git)
         .arg("-C")
-        .arg(&repository)
+        .arg(path_text(&repository))
         .args([
             "--literal-pathspecs",
             "diff",
@@ -3805,8 +3807,10 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         })
         .map(|output| {
             let mut diffs = BTreeMap::<String, LineDiff>::new();
-            let mut records = output.split(|byte| *byte == 0);
-            while let Some(header) = records.next().filter(|record| !record.is_empty()) {
+            for header in output
+                .split(|byte| *byte == 0)
+                .filter(|record| !record.is_empty())
+            {
                 let mut fields = header.splitn(3, |byte| *byte == b'\t');
                 let Some(additions) = fields
                     .next()
@@ -3821,14 +3825,9 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     continue;
                 };
                 let Some(path) = fields.next() else { continue };
-                // With -z, a rename leaves the header path empty and follows it with old and new paths.
-                let path = if path.is_empty() {
-                    let _ = records.next();
-                    records.next()
-                } else {
-                    Some(path)
-                };
-                let Some(path) = path else { continue };
+                if path.is_empty() {
+                    continue;
+                }
                 diffs.insert(
                     String::from_utf8_lossy(path).into_owned(),
                     LineDiff {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3616,6 +3616,22 @@ fn bounded_git_output(
     Ok(String::from_utf8_lossy(&output).into_owned())
 }
 
+fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
+    if command_output(git, repository, &["rev-parse", "--verify", "HEAD"]).is_ok() {
+        return Ok("HEAD".into());
+    }
+    command_output(
+        git,
+        repository,
+        &[
+            "hash-object",
+            "-t",
+            "tree",
+            if cfg!(windows) { "NUL" } else { "/dev/null" },
+        ],
+    )
+}
+
 #[tauri::command]
 async fn git_diff(
     roots: State<'_, Roots>,
@@ -3691,7 +3707,7 @@ async fn git_diff(
             &[0, 1],
         );
     }
-    let head = command_output(&git, &repository, &["rev-parse", "--verify", "HEAD"]).is_ok();
+    let base = git_diff_base(&git, &repository)?;
     let mut args = vec![
         "--literal-pathspecs",
         "diff",
@@ -3700,11 +3716,7 @@ async fn git_diff(
         "--no-renames",
         "--no-color",
     ];
-    if head {
-        args.push("HEAD");
-    } else {
-        args.push("--cached");
-    }
+    args.push(&base);
     args.extend(["--", &pathspec]);
     bounded_git_output(&git, &repository, &args, &[0])
 }
@@ -3742,15 +3754,19 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         ],
     )?;
     changes.retain(|change| Path::new(&change.path).starts_with(scope));
+    let base = git_diff_base(&git, &repository)?;
     let mut line_diffs = Command::new(&git)
         .arg("-C")
         .arg(&repository)
         .args([
             "--literal-pathspecs",
             "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
             "--numstat",
             "-z",
-            "HEAD",
+            &base,
             "--",
             &scope_text,
         ])
@@ -4974,6 +4990,39 @@ mod tests {
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, "??");
         assert_eq!(changes[0].path, "sub/a -> b.ts");
+    }
+
+    #[test]
+    fn unborn_diff_includes_staged_and_worktree_content() {
+        let root = std::env::temp_dir().join(format!("lite-git-diff-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let git = Path::new("git");
+        command_output(git, &root, &["init"]).unwrap();
+        fs::write(root.join("file.txt"), "staged").unwrap();
+        command_output(git, &root, &["add", "file.txt"]).unwrap();
+        fs::write(root.join("file.txt"), "stagedworking").unwrap();
+
+        let base = git_diff_base(git, &root).unwrap();
+        let diff = bounded_git_output(
+            git,
+            &root,
+            &[
+                "--literal-pathspecs",
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-renames",
+                "--no-color",
+                &base,
+                "--",
+                "file.txt",
+            ],
+            &[0],
+        )
+        .unwrap();
+        fs::remove_dir_all(root).unwrap();
+
+        assert!(diff.contains("+stagedworking"));
     }
 
     #[cfg(target_os = "linux")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -232,9 +232,15 @@ fn directory_key(name: &str, path: &str, is_directory: bool) -> (u8, String, Str
 struct GitStatus {
     branch: String,
     worktree: String,
-    changes: Vec<String>,
+    changes: Vec<GitChange>,
     line_diffs: BTreeMap<String, LineDiff>,
     changes_truncated: bool,
+}
+
+#[derive(Serialize)]
+struct GitChange {
+    status: String,
+    path: String,
 }
 
 #[derive(Serialize)]
@@ -3513,11 +3519,11 @@ async fn delete_file(roots: State<'_, Roots>, root_id: String, path: String) -> 
     fs::remove_file(path).map_err(|error| error.to_string())
 }
 
-fn bounded_git_lines(
+fn bounded_git_changes(
     git: &Path,
     path: &Path,
     args: &[&str],
-) -> Result<(Vec<String>, bool), String> {
+) -> Result<(Vec<GitChange>, bool), String> {
     let mut child = Command::new(git)
         .arg("-C")
         .arg(path_text(path))
@@ -3527,21 +3533,47 @@ fn bounded_git_lines(
         .spawn()
         .map_err(|error| error.to_string())?;
     let stdout = child.stdout.take().ok_or("Could not read Git status")?;
-    let mut lines = BufReader::new(stdout)
-        .lines()
-        .take(MAX_GIT_CHANGES + 1)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| error.to_string())?;
-    let truncated = lines.len() > MAX_GIT_CHANGES;
+    let mut reader = BufReader::new(stdout);
+    let mut changes = Vec::new();
+    loop {
+        let mut record = Vec::new();
+        if reader
+            .read_until(0, &mut record)
+            .map_err(|error| error.to_string())?
+            == 0
+        {
+            break;
+        }
+        record.pop();
+        if record.len() < 4 || record[2] != b' ' {
+            continue;
+        }
+        let status = String::from_utf8_lossy(&record[..2]).into_owned();
+        // Porcelain v1 -z puts a rename's destination first and its source in the next record.
+        if status.bytes().any(|byte| matches!(byte, b'R' | b'C')) {
+            let mut source = Vec::new();
+            reader
+                .read_until(0, &mut source)
+                .map_err(|error| error.to_string())?;
+        }
+        let Ok(path) = String::from_utf8(record[3..].to_vec()) else {
+            continue;
+        };
+        changes.push(GitChange { status, path });
+        if changes.len() > MAX_GIT_CHANGES {
+            break;
+        }
+    }
+    let truncated = changes.len() > MAX_GIT_CHANGES;
     if truncated {
-        lines.truncate(MAX_GIT_CHANGES);
+        changes.truncate(MAX_GIT_CHANGES);
         let _ = child.kill();
     }
     let status = child.wait().map_err(|error| error.to_string())?;
     if !status.success() && !truncated {
         return Err("Could not read Git status".into());
     }
-    Ok((lines, truncated))
+    Ok((changes, truncated))
 }
 
 fn bounded_git_output(
@@ -3617,7 +3649,7 @@ async fn git_diff(
                 .into(),
         );
     }
-    if is_sensitive_path(&granted, &file) {
+    if is_sensitive_path(&granted, &file) || is_sensitive_path(&granted, &ancestor) {
         return Err("Sensitive files are hidden from Git diffs".into());
     }
     let file = path_text(&file);
@@ -3665,8 +3697,11 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         Err(_) => return Ok(None),
     };
     let branch = command_output(&git, &path, &["branch", "--show-current"])?;
-    let (changes, changes_truncated) =
-        bounded_git_lines(&git, &path, &["status", "--short", "--untracked-files=all"])?;
+    let (changes, changes_truncated) = bounded_git_changes(
+        &git,
+        Path::new(&root),
+        &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    )?;
     let line_diffs = Command::new(&git)
         .arg("-C")
         .arg(&root)
@@ -4233,12 +4268,13 @@ async fn worktree_state(
     }
     let path = PathBuf::from(&recorded.path);
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
-    let (lines, changes_truncated) = match bounded_git_lines(
+    let (entries, changes_truncated) = match bounded_git_changes(
         &git,
         &path,
         &[
             "status",
-            "--porcelain",
+            "--porcelain=v1",
+            "-z",
             "--untracked-files=all",
             "--ignored=matching",
         ],
@@ -4256,8 +4292,8 @@ async fn worktree_state(
             });
         }
     };
-    let changes = lines.iter().filter(|line| !line.starts_with("!!")).count();
-    let ignored = lines.iter().any(|line| line.starts_with("!!"));
+    let changes = entries.iter().filter(|entry| entry.status != "!!").count();
+    let ignored = entries.iter().any(|entry| entry.status == "!!");
     let submodules = !command_output(&git, &path, &["submodule", "status"])
         .unwrap_or_default()
         .is_empty();
@@ -4850,5 +4886,35 @@ mod tests {
         let entry = scoped_entry(&root, link.to_str().unwrap()).unwrap();
         fs::remove_dir_all(base).unwrap();
         assert_eq!(entry, root.join("link.txt"));
+    }
+
+    #[test]
+    fn git_changes_preserve_human_status_markers_in_filenames() {
+        let root = std::env::temp_dir().join(format!("lite-git-status-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("a -> b.ts"), "change").unwrap();
+        assert!(
+            Command::new("git")
+                .arg("init")
+                .arg(&root)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let (changes, truncated) = bounded_git_changes(
+            Path::new("git"),
+            &root,
+            &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+        )
+        .unwrap();
+        fs::remove_dir_all(root).unwrap();
+
+        assert!(!truncated);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].status, "??");
+        assert_eq!(changes[0].path, "a -> b.ts");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3696,16 +3696,33 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         Ok(root) => root,
         Err(_) => return Ok(None),
     };
+    let repository = fs::canonicalize(&root).map_err(|error| error.to_string())?;
+    let scope = path
+        .strip_prefix(&repository)
+        .map_err(|_| "The selected folder is outside the Git repository")?;
+    let scope_text = if scope.as_os_str().is_empty() {
+        ".".into()
+    } else {
+        path_text(scope)
+    };
     let branch = command_output(&git, &path, &["branch", "--show-current"])?;
-    let (changes, changes_truncated) = bounded_git_changes(
+    let (mut changes, changes_truncated) = bounded_git_changes(
         &git,
-        Path::new(&root),
-        &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+        &repository,
+        &[
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--",
+            &scope_text,
+        ],
     )?;
-    let line_diffs = Command::new(&git)
+    changes.retain(|change| Path::new(&change.path).starts_with(scope));
+    let mut line_diffs = Command::new(&git)
         .arg("-C")
-        .arg(&root)
-        .args(["diff", "--numstat", "-z", "HEAD"])
+        .arg(&repository)
+        .args(["diff", "--numstat", "-z", "HEAD", "--", &scope_text])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -3776,6 +3793,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
             diffs
         })
         .unwrap_or_default();
+    line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
     Ok(Some(GitStatus {
         branch: if branch.is_empty() {
             "Detached HEAD".into()
@@ -4888,11 +4906,13 @@ mod tests {
         assert_eq!(entry, root.join("link.txt"));
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn git_changes_preserve_human_status_markers_in_filenames() {
         let root = std::env::temp_dir().join(format!("lite-git-status-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&root).unwrap();
-        fs::write(root.join("a -> b.ts"), "change").unwrap();
+        fs::create_dir_all(root.join("sub")).unwrap();
+        fs::write(root.join("sub/a -> b.ts"), "change").unwrap();
+        fs::write(root.join("outside.txt"), "outside").unwrap();
         assert!(
             Command::new("git")
                 .arg("init")
@@ -4907,7 +4927,14 @@ mod tests {
         let (changes, truncated) = bounded_git_changes(
             Path::new("git"),
             &root,
-            &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            &[
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
+                "--",
+                "sub",
+            ],
         )
         .unwrap();
         fs::remove_dir_all(root).unwrap();
@@ -4915,6 +4942,6 @@ mod tests {
         assert!(!truncated);
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].status, "??");
-        assert_eq!(changes[0].path, "a -> b.ts");
+        assert_eq!(changes[0].path, "sub/a -> b.ts");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3567,14 +3567,14 @@ fn bounded_git_output(
     if output.len() > MAX_GIT_DIFF_BYTES as usize {
         let _ = child.kill();
         let _ = child.wait();
-        return Err("Diff is larger than 1 MB".into());
+        return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
     }
     let status = child.wait().map_err(|error| error.to_string())?;
     if !status
         .code()
         .is_some_and(|code| accepted_codes.contains(&code))
     {
-        return Err("Could not read Git diff".into());
+        return Err("Could not read Git diff; refresh Git and try again".into());
     }
     Ok(String::from_utf8_lossy(&output).into_owned())
 }
@@ -3592,7 +3592,10 @@ async fn git_diff(
             .components()
             .any(|component| !matches!(component, Component::Normal(_)))
     {
-        return Err("Path is outside the selected folder".into());
+        return Err(
+            "This change is outside the selected folder; start a session from the repository root to view it"
+                .into(),
+        );
     }
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
     let repository = PathBuf::from(command_output(
@@ -3605,11 +3608,14 @@ async fn git_diff(
     while !ancestor.exists() {
         ancestor = ancestor
             .parent()
-            .ok_or("Path is outside the selected folder")?;
+            .ok_or("This change is outside the selected folder")?;
     }
     let ancestor = fs::canonicalize(ancestor).map_err(|error| error.to_string())?;
     if !ancestor.starts_with(&granted) {
-        return Err("Path is outside the selected folder".into());
+        return Err(
+            "This change is outside the selected folder; start a session from the repository root to view it"
+                .into(),
+        );
     }
     if is_sensitive_path(&granted, &file) {
         return Err("Sensitive files are hidden from Git diffs".into());
@@ -3659,7 +3665,8 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         Err(_) => return Ok(None),
     };
     let branch = command_output(&git, &path, &["branch", "--show-current"])?;
-    let (changes, changes_truncated) = bounded_git_lines(&git, &path, &["status", "--short"])?;
+    let (changes, changes_truncated) =
+        bounded_git_lines(&git, &path, &["status", "--short", "--untracked-files=all"])?;
     let line_diffs = Command::new(&git)
         .arg("-C")
         .arg(&root)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
     io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     process::{Command, Stdio},
     sync::{
         Arc, Mutex,
@@ -3544,6 +3544,111 @@ fn bounded_git_lines(
     Ok((lines, truncated))
 }
 
+fn bounded_git_output(
+    git: &Path,
+    directory: &Path,
+    args: &[&str],
+    accepted_codes: &[i32],
+) -> Result<String, String> {
+    let mut child = Command::new(git)
+        .arg("-C")
+        .arg(path_text(directory))
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let stdout = child.stdout.take().ok_or("Could not read Git diff")?;
+    let mut output = Vec::new();
+    stdout
+        .take(MAX_GIT_DIFF_BYTES + 1)
+        .read_to_end(&mut output)
+        .map_err(|error| error.to_string())?;
+    if output.len() > MAX_GIT_DIFF_BYTES as usize {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err("Diff is larger than 1 MB".into());
+    }
+    let status = child.wait().map_err(|error| error.to_string())?;
+    if !status
+        .code()
+        .is_some_and(|code| accepted_codes.contains(&code))
+    {
+        return Err("Could not read Git diff".into());
+    }
+    Ok(String::from_utf8_lossy(&output).into_owned())
+}
+
+#[tauri::command]
+async fn git_diff(
+    roots: State<'_, Roots>,
+    root_id: String,
+    path: String,
+) -> Result<String, String> {
+    let granted = root_path(&roots, &root_id)?;
+    let relative = Path::new(&path);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err("Path is outside the selected folder".into());
+    }
+    let git = resolve_executable("git").unwrap_or_else(|| "git".into());
+    let repository = PathBuf::from(command_output(
+        &git,
+        &granted,
+        &["rev-parse", "--show-toplevel"],
+    )?);
+    let file = repository.join(relative);
+    let mut ancestor = file.as_path();
+    while !ancestor.exists() {
+        ancestor = ancestor
+            .parent()
+            .ok_or("Path is outside the selected folder")?;
+    }
+    let ancestor = fs::canonicalize(ancestor).map_err(|error| error.to_string())?;
+    if !ancestor.starts_with(&granted) {
+        return Err("Path is outside the selected folder".into());
+    }
+    if is_sensitive_path(&granted, &file) {
+        return Err("Sensitive files are hidden from Git diffs".into());
+    }
+    let file = path_text(&file);
+    let untracked = !command_output(
+        &git,
+        &repository,
+        &["ls-files", "--others", "--exclude-standard", "--", &file],
+    )?
+    .is_empty();
+    if untracked {
+        let null = if cfg!(windows) { "NUL" } else { "/dev/null" };
+        return bounded_git_output(
+            &git,
+            &repository,
+            &[
+                "diff",
+                "--no-index",
+                "--no-ext-diff",
+                "--no-color",
+                "--",
+                null,
+                &file,
+            ],
+            &[0, 1],
+        );
+    }
+    let head = command_output(&git, &repository, &["rev-parse", "--verify", "HEAD"]).is_ok();
+    let mut args = vec!["diff", "--no-ext-diff", "--no-color"];
+    if head {
+        args.push("HEAD");
+    } else {
+        args.push("--cached");
+    }
+    args.extend(["--", &file]);
+    bounded_git_output(&git, &repository, &args, &[0])
+}
+
 #[tauri::command]
 async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<GitStatus>, String> {
     let path = root_path(&roots, &root_id)?;
@@ -4664,6 +4769,7 @@ pub fn run() {
             write_text_file,
             delete_file,
             git_status,
+            git_diff,
             git_remote,
             git_repo,
             create_worktree,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3668,6 +3668,7 @@ async fn git_diff(
                 "diff",
                 "--no-index",
                 "--no-ext-diff",
+                "--no-textconv",
                 "--no-color",
                 "--",
                 null,
@@ -3677,7 +3678,7 @@ async fn git_diff(
         );
     }
     let head = command_output(&git, &repository, &["rev-parse", "--verify", "HEAD"]).is_ok();
-    let mut args = vec!["diff", "--no-ext-diff", "--no-color"];
+    let mut args = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-color"];
     if head {
         args.push("HEAD");
     } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -554,7 +554,6 @@ function sessionStatus(session: Session, attention: boolean, working: boolean) {
 }
 
 interface SessionGroup {
-  key: string;
   name: string;
   path: string;
   sessions: Session[];
@@ -567,10 +566,9 @@ function groupSessions(sessions: Session[]): SessionGroup[] {
   const groups = new Map<string, SessionGroup>();
   for (const session of sessions) {
     const path = session.repo ?? session.cwd;
-    const key = path;
-    const group = groups.get(key) ?? { key, name: folderName(path) || path, path, sessions: [] };
+    const group = groups.get(path) ?? { name: folderName(path) || path, path, sessions: [] };
     group.sessions.push(session);
-    groups.set(key, group);
+    groups.set(path, group);
   }
   return [...groups.values()];
 }
@@ -754,7 +752,9 @@ function SessionSwitcher({
     const index = matches.findIndex((session) => session.id === activeId);
     const next =
       index < 0 ? (direction > 0 ? 0 : matches.length - 1) : (index + direction + matches.length) % matches.length;
-    setActiveId(matches[next].id);
+    const id = matches[next].id;
+    setActiveId(id);
+    requestAnimationFrame(() => document.getElementById(`switch-session-${id}`)?.scrollIntoView({ block: "nearest" }));
   }
 
   function select(session: Session) {
@@ -778,6 +778,12 @@ function SessionSwitcher({
             value={query}
             placeholder="Switch session…"
             aria-label="Switch session"
+            aria-keyshortcuts={navigator.platform.includes("Mac") ? "Meta+P" : "Control+Shift+P"}
+            role="combobox"
+            aria-expanded="true"
+            aria-controls="session-switcher-list"
+            aria-autocomplete="list"
+            aria-activedescendant={activeId ? `switch-session-${activeId}` : undefined}
             name="session-switcher"
             autoComplete="off"
             spellCheck={false}
@@ -796,16 +802,17 @@ function SessionSwitcher({
             }}
           />
         </InputGroup>
-        <ScrollArea className="max-h-[min(28rem,60dvh)]">
-          <div className="space-y-0.5">
+        <DialogBody className="max-h-[min(28rem,60dvh)] overscroll-contain">
+          <div id="session-switcher-list" role="listbox" className="space-y-0.5">
             {matches.map((session) => {
               const needsAttention = attention.includes(session.id);
               return (
                 <Item
                   key={session.id}
+                  id={`switch-session-${session.id}`}
                   size="xs"
                   className={`flex-nowrap text-left ${session.id === activeId ? "bg-accent text-accent-foreground" : "hover:bg-accent/60"}`}
-                  render={<button type="button" />}
+                  render={<button type="button" role="option" aria-selected={session.id === activeId} />}
                   onPointerMove={() => setActiveId(session.id)}
                   onClick={() => select(session)}
                 >
@@ -832,7 +839,7 @@ function SessionSwitcher({
               <p className="px-2 py-4 text-center text-xs text-muted-foreground">No sessions found</p>
             ) : null}
           </div>
-        </ScrollArea>
+        </DialogBody>
       </DialogContent>
     </Dialog>
   );
@@ -1327,7 +1334,7 @@ function App() {
   }, [sessions, query]);
   const visibleGroups = useMemo(() => groupSessions(visible), [visible]);
   const displayed = visibleGroups.flatMap((group) =>
-    query.trim() || !collapsedGroups.has(group.key) ? group.sessions : [],
+    query.trim() || !collapsedGroups.has(group.path) ? group.sessions : [],
   );
   const sessionsById = new Map(sessions.map((session) => [session.id, session]));
   const switcherSessions = recentSessions.current.flatMap((id) => sessionsById.get(id) ?? []);
@@ -1342,6 +1349,15 @@ function App() {
   closeRef.current = closeSession;
   openRef.current = (session) => {
     recentSessions.current = [session.id, ...recentSessions.current.filter((id) => id !== session.id)];
+    const group = session.repo ?? session.cwd;
+    if (collapsedGroups.has(group)) {
+      setCollapsedGroups((current) => {
+        if (!current.has(group)) return current;
+        const next = new Set(current);
+        next.delete(group);
+        return next;
+      });
+    }
     clearAttention(session.id);
     setSelectedId(session.id);
     if (session.running) {
@@ -2372,6 +2388,7 @@ function App() {
                           type="button"
                           className="min-w-0 truncate rounded-sm text-xs font-medium hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
                           aria-label="Switch session"
+                          aria-keyshortcuts={navigator.platform.includes("Mac") ? "Meta+P" : "Control+Shift+P"}
                           onClick={() => setSessionSwitcherOpen(true)}
                         />
                       }
@@ -2563,19 +2580,20 @@ function App() {
                           <p className="px-2 py-1.5 text-xs text-muted-foreground">No session matches “{query}”.</p>
                         ) : null}
                         {visibleGroups.map((group) => {
-                          const open = Boolean(query.trim()) || !collapsedGroups.has(group.key);
+                          const open = Boolean(query.trim()) || !collapsedGroups.has(group.path);
                           return (
-                            <section key={group.key}>
+                            <section key={group.path}>
                               <button
                                 type="button"
                                 className="flex h-7 w-full items-center gap-1.5 rounded-md px-1.5 text-left text-[10px] font-medium text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:outline-none"
                                 title={group.path}
+                                aria-label={`${group.name}, ${group.sessions.length} session${group.sessions.length === 1 ? "" : "s"}`}
                                 aria-expanded={open}
                                 onClick={() =>
                                   setCollapsedGroups((current) => {
                                     const next = new Set(current);
-                                    if (next.has(group.key)) next.delete(group.key);
-                                    else next.add(group.key);
+                                    if (next.has(group.path)) next.delete(group.path);
+                                    else next.add(group.path);
                                     return next;
                                   })
                                 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   ClipboardPaste,
   Copy,
   ExternalLink,
+  Folder,
   GitBranch,
   Link,
   Moon,
@@ -69,7 +70,7 @@ import {
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
-import { Item, ItemActions, ItemMedia } from "@/components/ui/item";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
 import {
   type PanelImperativeHandle,
@@ -94,7 +95,7 @@ import {
 } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
 import { applyTheme, initialTheme, type Theme } from "@/theme";
-import { type Agent, defaultSessionName, repoName, type Session, sessionLabel } from "@/types";
+import { type Agent, defaultSessionName, folderName, repoName, type Session, sessionLabel } from "@/types";
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
@@ -548,6 +549,32 @@ const SESSION_STATUS = {
   },
 } as const;
 
+function sessionStatus(session: Session, attention: boolean, working: boolean) {
+  return SESSION_STATUS[!session.running ? "disconnected" : attention ? "attention" : working ? "working" : "idle"];
+}
+
+interface SessionGroup {
+  key: string;
+  name: string;
+  path: string;
+  sessions: Session[];
+}
+
+// Worktrees sit beside their main checkout, so the repository recorded when the session was created
+// is the stable group. Plain folders group by their own path, and first appearance preserves the
+// session order the user chose.
+function groupSessions(sessions: Session[]): SessionGroup[] {
+  const groups = new Map<string, SessionGroup>();
+  for (const session of sessions) {
+    const path = session.repo ?? session.cwd;
+    const key = path;
+    const group = groups.get(key) ?? { key, name: folderName(path) || path, path, sessions: [] };
+    group.sessions.push(session);
+    groups.set(key, group);
+  }
+  return [...groups.values()];
+}
+
 // A local build names its commit and is red, so it is never mistaken for the installed copy.
 // A release names its version and says at a glance whether it is the current one. The top bar and the
 // update dialog render this one badge, so the version, the release date and the link to it are stated
@@ -662,8 +689,7 @@ function SessionBadge({
   starting: boolean;
   working: boolean;
 }) {
-  const status =
-    SESSION_STATUS[!session.running ? "disconnected" : attention ? "attention" : working ? "working" : "idle"];
+  const status = sessionStatus(session, attention, working);
   const ring = active ? "ring-sidebar-accent" : "ring-sidebar";
   return (
     <span className="relative flex size-7 shrink-0 items-center justify-center rounded-md border bg-background">
@@ -680,6 +706,135 @@ function SessionBadge({
         />
       )}
     </span>
+  );
+}
+
+function SessionSwitcher({
+  open,
+  sessions,
+  selectedId,
+  attention,
+  working,
+  startingIds,
+  shellAgents,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean;
+  sessions: Session[];
+  selectedId: string;
+  attention: string[];
+  working: Set<string>;
+  startingIds: Set<string>;
+  shellAgents: Map<string, Agent>;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (session: Session) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [activeId, setActiveId] = useState(selectedId);
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return sessions;
+    return sessions.filter((session) => {
+      const status = sessionStatus(session, attention.includes(session.id), working.has(session.id)).label;
+      return [session.name, session.cwd, session.repo, sessionLabel(session), status].some((value) =>
+        value?.toLowerCase().includes(needle),
+      );
+    });
+  }, [attention, query, sessions, working]);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setActiveId(selectedId);
+  }, [open, selectedId]);
+
+  function move(direction: -1 | 1) {
+    if (!matches.length) return;
+    const index = matches.findIndex((session) => session.id === activeId);
+    const next =
+      index < 0 ? (direction > 0 ? 0 : matches.length - 1) : (index + direction + matches.length) % matches.length;
+    setActiveId(matches[next].id);
+  }
+
+  function select(session: Session) {
+    onOpenChange(false);
+    onSelect(session);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-2 p-2 sm:max-w-xl" showCloseButton={false}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>Switch session</DialogTitle>
+          <DialogDescription>Search open sessions by name, folder, agent, repository, or status.</DialogDescription>
+        </DialogHeader>
+        <InputGroup>
+          <InputGroupAddon>
+            <Search aria-hidden="true" />
+          </InputGroupAddon>
+          <InputGroupInput
+            autoFocus
+            value={query}
+            placeholder="Switch session…"
+            aria-label="Switch session"
+            name="session-switcher"
+            autoComplete="off"
+            spellCheck={false}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveId("");
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                event.preventDefault();
+                move(event.key === "ArrowDown" ? 1 : -1);
+              } else if (event.key === "Enter") {
+                const session = matches.find((item) => item.id === activeId) ?? matches[0];
+                if (session) select(session);
+              }
+            }}
+          />
+        </InputGroup>
+        <ScrollArea className="max-h-[min(28rem,60dvh)]">
+          <div className="space-y-0.5">
+            {matches.map((session) => {
+              const needsAttention = attention.includes(session.id);
+              return (
+                <Item
+                  key={session.id}
+                  size="xs"
+                  className={`flex-nowrap text-left ${session.id === activeId ? "bg-accent text-accent-foreground" : "hover:bg-accent/60"}`}
+                  render={<button type="button" />}
+                  onPointerMove={() => setActiveId(session.id)}
+                  onClick={() => select(session)}
+                >
+                  <ItemMedia>
+                    <SessionBadge
+                      session={session}
+                      agent={shellAgents.get(session.id)}
+                      active={session.id === selectedId}
+                      attention={needsAttention}
+                      starting={startingIds.has(session.id)}
+                      working={working.has(session.id)}
+                    />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle className="w-full text-xs">{session.name}</ItemTitle>
+                    <ItemDescription className="truncate font-mono text-[10px]">
+                      {shortPath(session.cwd)} · {sessionLabel(session)}
+                    </ItemDescription>
+                  </ItemContent>
+                </Item>
+              );
+            })}
+            {!matches.length ? (
+              <p className="px-2 py-4 text-center text-xs text-muted-foreground">No sessions found</p>
+            ) : null}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -1088,6 +1243,8 @@ function App() {
   const [working, setWorking] = useState<Set<string>>(new Set());
   const [shellAgents, setShellAgents] = useState<Map<string, Agent>>(new Map());
   const [query, setQuery] = useState("");
+  const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [renamingId, setRenamingId] = useState("");
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
@@ -1122,6 +1279,7 @@ function App() {
   const forceWorktree = useRef(new Map<string, boolean>());
   // Sessions whose worktree the user chose to keep; cleanup forgets Lite's record instead of removing.
   const keptWorktrees = useRef(new Set<string>());
+  const recentSessions = useRef(sessions.map((session) => session.id));
   // Sessions with a close flow in flight: the dialog is singular, so from probe to answer only
   // one worktree session may be closing at all.
   const closingIds = useRef(new Set<string>());
@@ -1158,6 +1316,7 @@ function App() {
   }, []);
   const selected = useMemo(() => sessions.find((session) => session.id === selectedId), [sessions, selectedId]);
   const selectedStarting = selected ? startingIds.has(selected.id) : false;
+  const sessionShortcut = navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+Shift+P";
   // A session is found by what names it: the subject it was given and the folder it works in.
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -1166,13 +1325,23 @@ function App() {
       (session) => session.name.toLowerCase().includes(needle) || session.cwd.toLowerCase().includes(needle),
     );
   }, [sessions, query]);
-  visibleRef.current = visible;
+  const visibleGroups = useMemo(() => groupSessions(visible), [visible]);
+  const displayed = visibleGroups.flatMap((group) =>
+    query.trim() || !collapsedGroups.has(group.key) ? group.sessions : [],
+  );
+  const sessionsById = new Map(sessions.map((session) => [session.id, session]));
+  const switcherSessions = recentSessions.current.flatMap((id) => sessionsById.get(id) ?? []);
+  for (const session of sessions) {
+    if (!recentSessions.current.includes(session.id)) switcherSessions.push(session);
+  }
+  visibleRef.current = shut.sidebar ? sessions : displayed;
   sessionsRef.current = sessions;
   themeRef.current = theme;
   selectedRef.current = selected;
   notificationsRef.current = notifications;
   closeRef.current = closeSession;
   openRef.current = (session) => {
+    recentSessions.current = [session.id, ...recentSessions.current.filter((id) => id !== session.id)];
     clearAttention(session.id);
     setSelectedId(session.id);
     if (session.running) {
@@ -1277,7 +1446,9 @@ function App() {
     function onKeyDown(event: KeyboardEvent) {
       if (event.defaultPrevented || (!event.metaKey && !event.ctrlKey)) return;
       if (event.target instanceof Element && event.target.closest('[role="dialog"]')) return;
-      if (event.key === "n") setNewSessionOpen(true);
+      const switchSession = event.key.toLowerCase() === "p" && (event.metaKey || (event.ctrlKey && event.shiftKey));
+      if (switchSession) setSessionSwitcherOpen(true);
+      else if (event.key === "n") setNewSessionOpen(true);
       else if (event.key === ",") setSettingsOpen(true);
       else if (event.key === "w" && selectedRef.current) closeRef.current(selectedRef.current);
       else if (event.shiftKey && event.key.toLowerCase() === "u") {
@@ -1650,6 +1821,7 @@ function App() {
 
   function createSession(session: Session) {
     resumed.current = session.id;
+    recentSessions.current = [session.id, ...recentSessions.current];
     setSessions((current) => [session, ...current]);
     setSelectedId(session.id);
     void launch(session, false);
@@ -2193,7 +2365,21 @@ function App() {
                     provider={selected.provider}
                     className="size-4 shrink-0"
                   />
-                  <span className="min-w-0 truncate text-xs font-medium">{selected.name}</span>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          className="min-w-0 truncate rounded-sm text-xs font-medium hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                          aria-label="Switch session"
+                          onClick={() => setSessionSwitcherOpen(true)}
+                        />
+                      }
+                    >
+                      {selected.name}
+                    </TooltipTrigger>
+                    <TooltipContent>Switch session · {sessionShortcut}</TooltipContent>
+                  </Tooltip>
                   <button
                     type="button"
                     className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground hover:text-foreground"
@@ -2376,36 +2562,69 @@ function App() {
                         {query && !visible.length ? (
                           <p className="px-2 py-1.5 text-xs text-muted-foreground">No session matches “{query}”.</p>
                         ) : null}
-                        {visible.map((session) => (
-                          <SessionRow
-                            key={session.id}
-                            session={session}
-                            agent={shellAgents.get(session.id)}
-                            active={session.id === selectedId}
-                            attention={attention.includes(session.id)}
-                            starting={startingIds.has(session.id)}
-                            working={working.has(session.id)}
-                            renaming={renamingId === session.id}
-                            reorderable={!query.trim()}
-                            onSelect={() => openRef.current(session)}
-                            onRename={(name) =>
-                              setSessions((current) =>
-                                current.map((item) =>
-                                  item.id === session.id ? { ...item, name, renamed: true } : item,
-                                ),
-                              )
-                            }
-                            onRenamingChange={(renaming) => setRenamingId(renaming ? session.id : "")}
-                            onReorder={(targetId, after) => reorderSession(session.id, targetId, after)}
-                            onMove={(direction) => {
-                              const index = sessionsRef.current.findIndex((item) => item.id === session.id);
-                              const target = sessionsRef.current[index + direction];
-                              if (target) reorderSession(session.id, target.id, direction > 0);
-                            }}
-                            onRestart={() => void restartSession(session)}
-                            onClose={() => closeSession(session)}
-                          />
-                        ))}
+                        {visibleGroups.map((group) => {
+                          const open = Boolean(query.trim()) || !collapsedGroups.has(group.key);
+                          return (
+                            <section key={group.key}>
+                              <button
+                                type="button"
+                                className="flex h-7 w-full items-center gap-1.5 rounded-md px-1.5 text-left text-[10px] font-medium text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:outline-none"
+                                title={group.path}
+                                aria-expanded={open}
+                                onClick={() =>
+                                  setCollapsedGroups((current) => {
+                                    const next = new Set(current);
+                                    if (next.has(group.key)) next.delete(group.key);
+                                    else next.add(group.key);
+                                    return next;
+                                  })
+                                }
+                              >
+                                <ChevronRight
+                                  aria-hidden="true"
+                                  className={`size-3 transition-transform motion-reduce:transition-none ${open ? "rotate-90" : ""}`}
+                                />
+                                <Folder aria-hidden="true" className="size-3" />
+                                <span className="min-w-0 flex-1 truncate">{group.name}</span>
+                                <span className="tabular-nums">{group.sessions.length}</span>
+                              </button>
+                              {open ? (
+                                <div className="space-y-0.5">
+                                  {group.sessions.map((session) => (
+                                    <SessionRow
+                                      key={session.id}
+                                      session={session}
+                                      agent={shellAgents.get(session.id)}
+                                      active={session.id === selectedId}
+                                      attention={attention.includes(session.id)}
+                                      starting={startingIds.has(session.id)}
+                                      working={working.has(session.id)}
+                                      renaming={renamingId === session.id}
+                                      reorderable={!query.trim()}
+                                      onSelect={() => openRef.current(session)}
+                                      onRename={(name) =>
+                                        setSessions((current) =>
+                                          current.map((item) =>
+                                            item.id === session.id ? { ...item, name, renamed: true } : item,
+                                          ),
+                                        )
+                                      }
+                                      onRenamingChange={(renaming) => setRenamingId(renaming ? session.id : "")}
+                                      onReorder={(targetId, after) => reorderSession(session.id, targetId, after)}
+                                      onMove={(direction) => {
+                                        const index = group.sessions.findIndex((item) => item.id === session.id);
+                                        const target = group.sessions[index + direction];
+                                        if (target) reorderSession(session.id, target.id, direction > 0);
+                                      }}
+                                      onRestart={() => void restartSession(session)}
+                                      onClose={() => closeSession(session)}
+                                    />
+                                  ))}
+                                </div>
+                              ) : null}
+                            </section>
+                          );
+                        })}
                       </div>
                     </ScrollArea>
                   </>
@@ -2847,6 +3066,17 @@ function App() {
             onOpenChange={setNewSessionOpen}
             onCreate={createSession}
             sessions={sessions}
+          />
+          <SessionSwitcher
+            open={sessionSwitcherOpen}
+            sessions={switcherSessions}
+            selectedId={selectedId}
+            attention={attention}
+            working={working}
+            startingIds={startingIds}
+            shellAgents={shellAgents}
+            onOpenChange={setSessionSwitcherOpen}
+            onSelect={(session) => openRef.current(session)}
           />
           <SettingsDialog
             open={settingsOpen}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1001,11 +1001,10 @@ function SessionRow({
           });
         }
         event.preventDefault();
-        const parent = pointer.row.parentElement;
-        const rows = [...(parent?.querySelectorAll<HTMLElement>("[data-context-session]") ?? [])];
-        const parentTop = parent?.getBoundingClientRect().top ?? 0;
+        const list = pointer.row.closest("[data-session-list]");
+        const rows = [...(list?.querySelectorAll<HTMLElement>("[data-context-session]") ?? [])];
         const before = rows.find(
-          (row) => row !== pointer.row && event.clientY < parentTop + row.offsetTop + row.offsetHeight / 2,
+          (row) => row !== pointer.row && event.clientY < row.getBoundingClientRect().top + row.offsetHeight / 2,
         );
         const last = rows[rows.length - 1];
         const row = before ?? (last === pointer.row ? rows[rows.length - 2] : last);
@@ -1018,10 +1017,14 @@ function SessionRow({
         const start = sourceIndex < targetIndex ? sourceIndex + 1 : targetIndex + Number(after);
         const end = sourceIndex < targetIndex ? targetIndex + Number(after) : sourceIndex;
         const shifts: [HTMLElement, number][] = [];
-        for (let index = start; index < end; index++) {
-          const shiftedRow = rows[index];
-          const neighbor = rows[index + (sourceIndex < targetIndex ? -1 : 1)];
-          shifts.push([shiftedRow, neighbor.offsetTop - shiftedRow.offsetTop]);
+        // Group headers do not move during a drag, so cross-group drops use the insertion marker
+        // without pretending the rows can close a gap that includes a header.
+        if (pointer.row.parentElement === row.parentElement) {
+          for (let index = start; index < end; index++) {
+            const shiftedRow = rows[index];
+            const neighbor = rows[index + (sourceIndex < targetIndex ? -1 : 1)];
+            shifts.push([shiftedRow, neighbor.getBoundingClientRect().top - shiftedRow.getBoundingClientRect().top]);
+          }
         }
         clearDrop();
         row.dataset.drop = after ? "after" : "before";
@@ -1845,13 +1848,28 @@ function App() {
 
   function reorderSession(draggedId: string, targetId: string, after: boolean) {
     setSessions((current) => {
-      const draggedIndex = current.findIndex((session) => session.id === draggedId);
-      const targetIndex = current.findIndex((session) => session.id === targetId);
+      const ordered = groupSessions(current).flatMap((group) => group.sessions);
+      const draggedIndex = ordered.findIndex((session) => session.id === draggedId);
+      const targetIndex = ordered.findIndex((session) => session.id === targetId);
       if (draggedIndex < 0 || targetIndex < 0 || draggedIndex === targetIndex) return current;
-      const next = [...current];
-      const [dragged] = next.splice(draggedIndex, 1);
+      const dragged = ordered[draggedIndex];
+      const target = ordered[targetIndex];
+      const draggedGroup = dragged.repo ?? dragged.cwd;
+      const targetGroup = target.repo ?? target.cwd;
+      if (draggedGroup !== targetGroup) {
+        const moved = ordered.filter((session) => (session.repo ?? session.cwd) === draggedGroup);
+        const next = ordered.filter((session) => (session.repo ?? session.cwd) !== draggedGroup);
+        const targets = next.flatMap((session, index) =>
+          (session.repo ?? session.cwd) === targetGroup ? [index] : [],
+        );
+        const destination = after ? targets[targets.length - 1] + 1 : targets[0];
+        next.splice(destination, 0, ...moved);
+        return next;
+      }
+      const next = [...ordered];
+      const [moved] = next.splice(draggedIndex, 1);
       const destination = next.findIndex((session) => session.id === targetId) + Number(after);
-      next.splice(destination, 0, dragged);
+      next.splice(destination, 0, moved);
       return next;
     });
   }
@@ -1899,6 +1917,10 @@ function App() {
 
   // Restarting keeps the tab and its folder but asks the provider for a conversation of its own, so the
   // session it resumed by id is retained only until the shared Undo window expires.
+  function replaceRecentSession(from: string, to: string) {
+    recentSessions.current = recentSessions.current.map((id) => (id === from ? to : id));
+  }
+
   function restartSession(session: Session, select = true, recovered = false) {
     // A close in flight owns this session's fate: restarting now would inherit a worktree the
     // close dialog is about to take away.
@@ -1922,6 +1944,7 @@ function App() {
       restarted,
       () => {
         const restored = { ...session, running: false };
+        replaceRecentSession(fresh.id, session.id);
         setStartingIds((current) => swapped(current, fresh.id, session.id));
         setSessions((current) => current.map((item) => (item.id === fresh.id ? restored : item)));
         setSelectedId((current) => (current === fresh.id ? session.id : current));
@@ -1932,6 +1955,7 @@ function App() {
           try {
             await invoke("stop_session", { sessionId: fresh.id });
           } catch (reason) {
+            replaceRecentSession(session.id, fresh.id);
             setStartingIds((current) => swapped(current, session.id, fresh.id));
             const relaunched = { ...fresh, running: false };
             setSessions((current) => current.map((item) => (item.id === session.id ? relaunched : item)));
@@ -1963,6 +1987,7 @@ function App() {
 
   async function restartSessionNow(session: Session, fresh: Session, select: boolean): Promise<boolean> {
     runs.current.delete(session.id);
+    replaceRecentSession(session.id, fresh.id);
     setStartingIds((current) => new Set(current).add(fresh.id));
     setSessions((current) => current.map((item) => (item.id === session.id ? fresh : item)));
     if (select) {
@@ -1972,6 +1997,7 @@ function App() {
     try {
       await invoke("stop_session", { sessionId: session.id });
     } catch (reason) {
+      replaceRecentSession(fresh.id, session.id);
       const restored = { ...session, running: false };
       setStartingIds((current) => swapped(current, fresh.id, session.id));
       setSessions((current) => current.map((item) => (item.id === fresh.id ? restored : item)));
@@ -1983,6 +2009,7 @@ function App() {
       return false;
     }
     if (!(await launch(fresh, false))) {
+      replaceRecentSession(fresh.id, session.id);
       await invoke("delete_session_data", { sessionId: fresh.id }).catch(() => {});
       clearOutput(fresh.id);
       clearInspectorCache(fresh.id);
@@ -2575,7 +2602,7 @@ function App() {
                       </ActionIconButton>
                     </div>
                     <ScrollArea className="min-h-0 flex-1">
-                      <div className="space-y-0.5 px-2 pb-2">
+                      <div className="space-y-0.5 px-2 pb-2" data-session-list>
                         {query && !visible.length ? (
                           <p className="px-2 py-1.5 text-xs text-muted-foreground">No session matches “{query}”.</p>
                         ) : null}
@@ -2630,8 +2657,8 @@ function App() {
                                       onRenamingChange={(renaming) => setRenamingId(renaming ? session.id : "")}
                                       onReorder={(targetId, after) => reorderSession(session.id, targetId, after)}
                                       onMove={(direction) => {
-                                        const index = group.sessions.findIndex((item) => item.id === session.id);
-                                        const target = group.sessions[index + direction];
+                                        const index = displayed.findIndex((item) => item.id === session.id);
+                                        const target = displayed[index + direction];
                                         if (target) reorderSession(session.id, target.id, direction > 0);
                                       }}
                                       onRestart={() => void restartSession(session)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -747,6 +747,10 @@ function SessionSwitcher({
     setActiveId(selectedId);
   }, [open, selectedId]);
 
+  useEffect(() => {
+    if (open && !matches.some((session) => session.id === activeId)) setActiveId(matches[0]?.id ?? "");
+  }, [activeId, matches, open]);
+
   function move(direction: -1 | 1) {
     if (!matches.length) return;
     const index = matches.findIndex((session) => session.id === activeId);
@@ -787,10 +791,7 @@ function SessionSwitcher({
             name="session-switcher"
             autoComplete="off"
             spellCheck={false}
-            onChange={(event) => {
-              setQuery(event.target.value);
-              setActiveId("");
-            }}
+            onChange={(event) => setQuery(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "ArrowDown" || event.key === "ArrowUp") {
                 event.preventDefault();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1341,9 +1341,10 @@ function App() {
   );
   const sessionsById = new Map(sessions.map((session) => [session.id, session]));
   recentSessions.current = recentSessions.current.filter((id) => sessionsById.has(id));
+  const recentIds = new Set(recentSessions.current);
   const switcherSessions = recentSessions.current.flatMap((id) => sessionsById.get(id) ?? []);
   for (const session of sessions) {
-    if (!recentSessions.current.includes(session.id)) switcherSessions.push(session);
+    if (!recentIds.has(session.id)) switcherSessions.push(session);
   }
   visibleRef.current = shut.sidebar ? sessions : displayed;
   sessionsRef.current = sessions;
@@ -2208,6 +2209,7 @@ function App() {
     if (startingIds.has(session.id)) return;
     clearAttention(session.id);
     const index = sessions.findIndex((item) => item.id === session.id);
+    const recentIndex = recentSessions.current.indexOf(session.id);
     const wasSelected = selectedId === session.id;
     const nextSelectedId = sessions.find((item) => item.id !== session.id)?.id ?? "";
     runs.current.delete(session.id);
@@ -2222,6 +2224,9 @@ function App() {
     function restore(running: boolean) {
       keptWorktrees.current.delete(session.id);
       forceWorktree.current.delete(session.id);
+      if (!recentSessions.current.includes(session.id)) {
+        recentSessions.current.splice(Math.min(Math.max(recentIndex, 0), recentSessions.current.length), 0, session.id);
+      }
       setSessions((current) => {
         if (current.some((item) => item.id === session.id)) {
           return current.map((item) => (item.id === session.id ? { ...item, running } : item));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1340,6 +1340,7 @@ function App() {
     query.trim() || !collapsedGroups.has(group.path) ? group.sessions : [],
   );
   const sessionsById = new Map(sessions.map((session) => [session.id, session]));
+  recentSessions.current = recentSessions.current.filter((id) => sessionsById.has(id));
   const switcherSessions = recentSessions.current.flatMap((id) => sessionsById.get(id) ?? []);
   for (const session of sessions) {
     if (!recentSessions.current.includes(session.id)) switcherSessions.push(session);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1008,10 +1008,16 @@ function SessionRow({
           (row) => row !== pointer.row && event.clientY < row.getBoundingClientRect().top + row.offsetHeight / 2,
         );
         const last = rows[rows.length - 1];
-        const row = before ?? (last === pointer.row ? rows[rows.length - 2] : last);
-        const after = !before;
+        let row = before ?? (last === pointer.row ? rows[rows.length - 2] : last);
+        let after = !before;
         pointer.row.style.transform = `translate3d(0, ${event.clientY - pointer.y}px, 0)`;
         if (!row) return clearDrop();
+        if (row.parentElement !== pointer.row.parentElement) {
+          const targetRows = [...(row.parentElement?.querySelectorAll<HTMLElement>("[data-context-session]") ?? [])];
+          const targetRect = row.parentElement?.getBoundingClientRect();
+          after = Boolean(targetRect && event.clientY >= targetRect.top + targetRect.height / 2);
+          row = targetRows[after ? targetRows.length - 1 : 0];
+        }
         if (drop.current?.row === row && drop.current?.after === after) return;
         const sourceIndex = rows.indexOf(pointer.row);
         const targetIndex = rows.indexOf(row);
@@ -1024,7 +1030,7 @@ function SessionRow({
           for (let index = start; index < end; index++) {
             const shiftedRow = rows[index];
             const neighbor = rows[index + (sourceIndex < targetIndex ? -1 : 1)];
-            shifts.push([shiftedRow, neighbor.getBoundingClientRect().top - shiftedRow.getBoundingClientRect().top]);
+            shifts.push([shiftedRow, neighbor.offsetTop - shiftedRow.offsetTop]);
           }
         }
         clearDrop();
@@ -1353,17 +1359,19 @@ function App() {
   selectedRef.current = selected;
   notificationsRef.current = notifications;
   closeRef.current = closeSession;
+  function expandSessionGroup(session: Session) {
+    const group = session.repo ?? session.cwd;
+    if (!collapsedGroups.has(group)) return;
+    setCollapsedGroups((current) => {
+      if (!current.has(group)) return current;
+      const next = new Set(current);
+      next.delete(group);
+      return next;
+    });
+  }
   openRef.current = (session) => {
     recentSessions.current = [session.id, ...recentSessions.current.filter((id) => id !== session.id)];
-    const group = session.repo ?? session.cwd;
-    if (collapsedGroups.has(group)) {
-      setCollapsedGroups((current) => {
-        if (!current.has(group)) return current;
-        const next = new Set(current);
-        next.delete(group);
-        return next;
-      });
-    }
+    expandSessionGroup(session);
     clearAttention(session.id);
     setSelectedId(session.id);
     if (session.running) {
@@ -1844,6 +1852,7 @@ function App() {
   function createSession(session: Session) {
     resumed.current = session.id;
     recentSessions.current = [session.id, ...recentSessions.current];
+    expandSessionGroup(session);
     setSessions((current) => [session, ...current]);
     setSelectedId(session.id);
     void launch(session, false);
@@ -2225,6 +2234,7 @@ function App() {
     function restore(running: boolean) {
       keptWorktrees.current.delete(session.id);
       forceWorktree.current.delete(session.id);
+      expandSessionGroup(session);
       if (!recentSessions.current.includes(session.id)) {
         recentSessions.current.splice(Math.min(Math.max(recentIndex, 0), recentSessions.current.length), 0, session.id);
       }

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1168,6 +1168,24 @@ function DiffViewer({
 
   useEffect(() => viewer.current?.focus(), []);
 
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!viewer.current || viewer.current.offsetParent === null) return;
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest("input, textarea, [contenteditable=true], [role=dialog], [role=menu], [data-context-session]")
+      )
+        return;
+      event.preventDefault();
+      onBack();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onBack]);
+
   function zoom(step: -1 | 0 | 1) {
     setFontSize(zoomedFontSize(PREVIEW_FONT_KEY, fontSize, step));
   }
@@ -1195,13 +1213,13 @@ function DiffViewer({
           }
           return;
         }
-        if (event.key === "Escape" || event.key === "ArrowLeft") {
-          event.preventDefault();
-          onBack();
-        }
       }}
     >
-      <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]">
+      <div
+        className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]"
+        data-context-value={path}
+        data-context-label="Copy path"
+      >
         <ActionIconButton size="icon-sm" tooltip="Back to Git" aria-label="Back to Git" onClick={onBack}>
           <ArrowLeft />
         </ActionIconButton>
@@ -1432,10 +1450,10 @@ function GitPanel({
     }
   }
 
-  function closeDiff() {
+  const closeDiff = useCallback(() => {
     diffRequest.current++;
     setDiffPath("");
-  }
+  }, []);
 
   useEffect(() => {
     void refresh();

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -176,7 +176,7 @@ const GITHUB_STATE_ICON = {
 
 interface RepositoryGroup {
   branch: string | null;
-  changes: string[];
+  changes: GitStatus["changes"];
   changesTruncated: boolean;
   lineDiffs: GitStatus["lineDiffs"];
   items: (GitHubItem & GitHubReference)[];
@@ -1145,11 +1145,6 @@ function FilesPanel({ root, rootId, sessionId }: { root: string; rootId: string;
   );
 }
 
-function changedPath(change: string) {
-  const path = change.slice(3);
-  return path.split(" -> ").pop() ?? path;
-}
-
 function DiffViewer({
   path,
   source,
@@ -1309,23 +1304,22 @@ function RepositoryCard({
         <div className="border-t px-2.5 py-2">
           <p className="mb-1 px-0.5 text-xs font-medium">Changes</p>
           {repository.changes.map((change) => {
-            const path = changedPath(change);
-            const diff = repository.lineDiffs[path];
+            const diff = repository.lineDiffs[change.path];
             return (
               <button
-                key={change}
+                key={`${change.status}:${change.path}`}
                 type="button"
                 className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-                aria-label={`View diff for ${path}`}
-                onClick={() => onOpenDiff(path)}
+                aria-label={`View diff for ${change.path}`}
+                onClick={() => onOpenDiff(change.path)}
               >
                 <span
-                  className={`${change.startsWith("??") ? "w-16" : "w-5"} shrink-0 font-mono text-xs text-muted-foreground`}
+                  className={`${change.status === "??" ? "w-16" : "w-5"} shrink-0 font-mono text-xs text-muted-foreground`}
                 >
-                  {change.startsWith("??") ? "Untracked" : change.slice(0, 2).trim()}
+                  {change.status === "??" ? "Untracked" : change.status.trim()}
                 </span>
-                <span className="min-w-0 flex-1 truncate font-mono text-xs" title={path}>
-                  {path}
+                <span className="min-w-0 flex-1 truncate font-mono text-xs" title={change.path}>
+                  {change.path}
                 </span>
                 {diff?.additions ? (
                   <span className="shrink-0 font-mono text-xs text-green-600 dark:text-green-400">
@@ -1467,7 +1461,7 @@ function GitPanel({
     ? repositories
         .map((repository) => ({
           ...repository,
-          changes: repository.changes.filter((change) => change.slice(3).toLowerCase().includes(lowered)),
+          changes: repository.changes.filter((change) => change.path.toLowerCase().includes(lowered)),
           items: repository.items.filter(
             (item) => `#${item.number}`.includes(lowered) || item.title?.toLowerCase().includes(lowered),
           ),

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1119,7 +1119,103 @@ function FilesPanel({ root, rootId, sessionId }: { root: string; rootId: string;
   );
 }
 
-function RepositoryCard({ repository }: { repository: RepositoryGroup }) {
+function changedPath(change: string) {
+  const path = change.slice(3);
+  return path.split(" -> ").pop() ?? path;
+}
+
+function DiffViewer({
+  path,
+  source,
+  error,
+  loading,
+  onBack,
+}: {
+  path: string;
+  source: string;
+  error: string;
+  loading: boolean;
+  onBack: () => void;
+}) {
+  const viewer = useRef<HTMLElement>(null);
+  const [fontSize, setFontSize] = useState(() => storedFontSize(PREVIEW_FONT_KEY));
+
+  useEffect(() => viewer.current?.focus(), []);
+
+  function zoom(step: -1 | 0 | 1) {
+    setFontSize(zoomedFontSize(PREVIEW_FONT_KEY, fontSize, step));
+  }
+
+  return (
+    <section
+      ref={viewer}
+      aria-label={`Diff for ${path}`}
+      tabIndex={-1}
+      data-context-zoom
+      className="flex h-full min-h-0 flex-col outline-none"
+      style={{ fontSize, lineHeight: 1.6 }}
+      onKeyDown={(event) => {
+        const command = event.metaKey || (!navigator.platform.includes("Mac") && event.ctrlKey);
+        if (command && event.key.toLowerCase() === "w") {
+          event.preventDefault();
+          onBack();
+          return;
+        }
+        if (command) {
+          const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
+          if (step || event.key === "0") {
+            event.preventDefault();
+            zoom(step);
+          }
+          return;
+        }
+        if (event.key === "Escape" || event.key === "ArrowLeft") {
+          event.preventDefault();
+          onBack();
+        }
+      }}
+    >
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]">
+        <ActionIconButton size="icon-sm" tooltip="Back to Git" aria-label="Back to Git" onClick={onBack}>
+          <ArrowLeft />
+        </ActionIconButton>
+        <FileDiff aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate font-mono font-medium" title={path}>
+          {path}
+        </span>
+        <ActionIconButton size="icon-sm" tooltip="Close diff" aria-label="Close diff" onClick={onBack}>
+          <X />
+        </ActionIconButton>
+      </div>
+      <button type="button" hidden data-context-zoom-in onClick={() => zoom(1)} />
+      <button type="button" hidden data-context-zoom-out onClick={() => zoom(-1)} />
+      <button type="button" hidden data-context-zoom-reset onClick={() => zoom(0)} />
+      <ScrollArea className="min-h-0 flex-1">
+        {loading ? (
+          <Loading label="Reading diff…" />
+        ) : error ? (
+          <p role="alert" className="p-3 text-xs text-destructive">
+            {error}
+          </p>
+        ) : source ? (
+          <Suspense fallback={<Loading label="Opening diff…" />}>
+            <CodePreview path={`${path}.diff`} source={source} />
+          </Suspense>
+        ) : (
+          <p className="p-3 text-xs text-muted-foreground">This file has no text diff.</p>
+        )}
+      </ScrollArea>
+    </section>
+  );
+}
+
+function RepositoryCard({
+  repository,
+  onOpenDiff,
+}: {
+  repository: RepositoryGroup;
+  onOpenDiff: (path: string) => void;
+}) {
   const pullRequests = repository.items.filter((item) => item.kind === "pull request");
   const issues = repository.items.filter((item) => item.kind === "issue");
   const header = (
@@ -1169,10 +1265,16 @@ function RepositoryCard({ repository }: { repository: RepositoryGroup }) {
         <div className="border-t px-2.5 py-2">
           <p className="mb-1 px-0.5 text-xs font-medium">Changes</p>
           {repository.changes.map((change) => {
-            const path = change.slice(3);
-            const diff = repository.lineDiffs[path.split(" -> ").pop() ?? path];
+            const path = changedPath(change);
+            const diff = repository.lineDiffs[path];
             return (
-              <div key={change} className="flex items-center gap-2 rounded-md px-1.5 py-1 hover:bg-muted">
+              <button
+                key={change}
+                type="button"
+                className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                aria-label={`View diff for ${path}`}
+                onClick={() => onOpenDiff(path)}
+              >
                 <span
                   className={`${change.startsWith("??") ? "w-16" : "w-5"} shrink-0 font-mono text-xs text-muted-foreground`}
                 >
@@ -1189,7 +1291,7 @@ function RepositoryCard({ repository }: { repository: RepositoryGroup }) {
                 {diff?.deletions ? (
                   <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{diff.deletions}</span>
                 ) : null}
-              </div>
+              </button>
             );
           })}
         </div>
@@ -1224,6 +1326,11 @@ function GitPanel({
   const [items, setItems] = useState<GitHubItem[]>();
   const [error, setError] = useState("");
   const [query, setQuery] = useState("");
+  const [diffPath, setDiffPath] = useState("");
+  const [diffSource, setDiffSource] = useState("");
+  const [diffError, setDiffError] = useState("");
+  const [diffLoading, setDiffLoading] = useState(false);
+  const diffRequest = useRef(0);
 
   // While Git is visible, follow the output stream it summarizes. Subscribing replays the existing
   // chunks synchronously, so one initial scan replaces rescanning the whole bounded buffer per chunk.
@@ -1283,6 +1390,27 @@ function GitPanel({
     }
   }, [rootId]);
 
+  async function openDiff(path: string) {
+    const request = ++diffRequest.current;
+    setDiffPath(path);
+    setDiffSource("");
+    setDiffError("");
+    setDiffLoading(true);
+    try {
+      const source = await invoke<string>("git_diff", { rootId, path });
+      if (diffRequest.current === request) setDiffSource(source);
+    } catch (reason) {
+      if (diffRequest.current === request) setDiffError(String(reason));
+    } finally {
+      if (diffRequest.current === request) setDiffLoading(false);
+    }
+  }
+
+  function closeDiff() {
+    diffRequest.current++;
+    setDiffPath("");
+  }
+
   useEffect(() => {
     void refresh();
   }, [refresh]);
@@ -1308,29 +1436,38 @@ function GitPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <SearchInput value={query} placeholder="Search items" onChange={setQuery} />
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-3 p-3">
-          {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          {!error && status === undefined ? <Loading label="Reading Git status…" /> : null}
-          {shown.map((repository) => (
-            <RepositoryCard key={(repository.url ?? repository.path)?.toLowerCase()} repository={repository} />
-          ))}
-          {lowered && status !== undefined && items && repositories.length && !shown.length ? (
-            <p className="text-sm text-muted-foreground">No matches</p>
-          ) : null}
-          {items === undefined && urls.length ? <Loading label="Checking GitHub links…" /> : null}
-          {status === null && items && !repositories.length ? (
-            <Empty>
-              <EmptyHeader>
-                <EmptyDescription>
-                  This folder is not a Git repository, and this session has not named a GitHub pull request or issue.
-                </EmptyDescription>
-              </EmptyHeader>
-            </Empty>
-          ) : null}
-        </div>
-      </ScrollArea>
+      {diffPath ? (
+        <DiffViewer path={diffPath} source={diffSource} error={diffError} loading={diffLoading} onBack={closeDiff} />
+      ) : null}
+      <div className={`min-h-0 flex-1 flex-col ${diffPath ? "hidden" : "flex"}`}>
+        <SearchInput value={query} placeholder="Search items" onChange={setQuery} />
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="flex flex-col gap-3 p-3">
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            {!error && status === undefined ? <Loading label="Reading Git status…" /> : null}
+            {shown.map((repository) => (
+              <RepositoryCard
+                key={(repository.url ?? repository.path)?.toLowerCase()}
+                repository={repository}
+                onOpenDiff={(path) => void openDiff(path)}
+              />
+            ))}
+            {lowered && status !== undefined && items && repositories.length && !shown.length ? (
+              <p className="text-sm text-muted-foreground">No matches</p>
+            ) : null}
+            {items === undefined && urls.length ? <Loading label="Checking GitHub links…" /> : null}
+            {status === null && items && !repositories.length ? (
+              <Empty>
+                <EmptyHeader>
+                  <EmptyDescription>
+                    This folder is not a Git repository, and this session has not named a GitHub pull request or issue.
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : null}
+          </div>
+        </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1763,7 +1763,7 @@ export function Inspector({
           {visited.has("git") ? (
             <TabsContent value="git" keepMounted className="min-h-0 overflow-hidden">
               <GitPanel
-                key={reload.git}
+                key={`${session.rootId}:${reload.git}`}
                 rootId={session.rootId}
                 sessionId={session.id}
                 remote={remote}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -44,7 +44,17 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { GitHubLogomark, ProviderIcon } from "@/brand-icons";
 import { Badge } from "@/components/ui/badge";
@@ -774,6 +784,117 @@ function FileTree({
 const PREVIEW_FONT_KEY = "lite.preview.fontSize";
 const RENDERED_FILE = /\.(?:html?|mdx?|svg)$/i;
 
+function usePreviewViewer<T extends HTMLElement>(onBack: () => void) {
+  const viewer = useRef<T>(null);
+  const [fontSize, setFontSize] = useState(() => storedFontSize(PREVIEW_FONT_KEY));
+  const zoom = useCallback((step: -1 | 0 | 1) => {
+    setFontSize((current) => zoomedFontSize(PREVIEW_FONT_KEY, current, step));
+  }, []);
+
+  useEffect(() => viewer.current?.focus(), []);
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!viewer.current || viewer.current.offsetParent === null) return;
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest("input, textarea, [contenteditable=true], [role=dialog], [role=menu], [data-context-session]")
+      )
+        return;
+      event.preventDefault();
+      onBack();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onBack]);
+
+  return { viewer, fontSize, zoom };
+}
+
+function previewKeyDown(
+  event: ReactKeyboardEvent<HTMLElement>,
+  onClose: () => void,
+  zoom: (step: -1 | 0 | 1) => void,
+  onSave?: () => void,
+) {
+  const command = event.metaKey || (!navigator.platform.includes("Mac") && event.ctrlKey);
+  if (!command) return;
+  if (onSave && event.key.toLowerCase() === "s") {
+    event.preventDefault();
+    onSave();
+    return;
+  }
+  if (event.key.toLowerCase() === "w") {
+    event.preventDefault();
+    onClose();
+    return;
+  }
+  const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
+  if (!step && event.key !== "0") return;
+  event.preventDefault();
+  zoom(step);
+}
+
+function PreviewHeader({
+  path,
+  backLabel,
+  closeLabel,
+  icon,
+  title,
+  disabled,
+  showClose = true,
+  onClose,
+  children,
+}: {
+  path: string;
+  backLabel: string;
+  closeLabel: string;
+  icon: ReactNode;
+  title: ReactNode;
+  disabled?: boolean;
+  showClose?: boolean;
+  onClose: () => void;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]"
+      data-context-value={path}
+      data-context-label="Copy path"
+    >
+      <ActionIconButton size="icon-sm" tooltip={backLabel} aria-label={backLabel} disabled={disabled} onClick={onClose}>
+        <ArrowLeft />
+      </ActionIconButton>
+      {icon}
+      {title}
+      {children}
+      {showClose ? (
+        <ActionIconButton
+          size="icon-sm"
+          tooltip={closeLabel}
+          aria-label={closeLabel}
+          disabled={disabled}
+          onClick={onClose}
+        >
+          <X />
+        </ActionIconButton>
+      ) : null}
+    </div>
+  );
+}
+
+function PreviewZoomControls({ zoom }: { zoom: (step: -1 | 0 | 1) => void }) {
+  return (
+    <>
+      <button type="button" hidden data-context-zoom-in onClick={() => zoom(1)} />
+      <button type="button" hidden data-context-zoom-out onClick={() => zoom(-1)} />
+      <button type="button" hidden data-context-zoom-reset onClick={() => zoom(0)} />
+    </>
+  );
+}
+
 // The preview inherits its type from here, so one zoom scales code, prose, and the line-number gutter
 // together while the header chrome keeps its own size. Zooming lives in this component so a step
 // re-renders the view alone, never the tree hidden behind it.
@@ -796,50 +917,23 @@ function FileViewer({
   onDraftChange: (contents: string) => void;
   onSave: (contents: string) => Promise<void>;
 }) {
-  const [fontSize, setFontSize] = useState(() => storedFontSize(PREVIEW_FONT_KEY));
   const [view, setView] = useState<"source" | "preview" | "edit">("source");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [discardOpen, setDiscardOpen] = useState(false);
-  const viewer = useRef<HTMLDivElement>(null);
   const editor = useRef<HTMLTextAreaElement>(null);
   const dirty = draft !== source;
   const editing = view === "edit";
   const renderable = RENDERED_FILE.test(entry.path);
   const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
-
-  // Reading is keyboard work, so the viewer takes focus as it opens and the zoom keys land here
-  // rather than wherever the pointer last was.
-  useEffect(() => {
-    viewer.current?.focus();
-  }, []);
+  const { viewer, fontSize, zoom } = usePreviewViewer<HTMLDivElement>(() => {
+    if (dirty) setDiscardOpen(true);
+    else onBack();
+  });
 
   useEffect(() => {
     if (editing) editor.current?.focus();
   }, [editing]);
-
-  // Escape and ArrowLeft step back to the tree from anywhere focus has wandered — after a menu closes,
-  // after a click on nothing — but never out from under typing: a terminal, a field, or an open layer
-  // reads its own keys, and a key one of them has already answered is not answered again. The panel
-  // stays mounted behind other tabs and the collapsed rail, so a viewer nobody can see answers nothing.
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (!viewer.current || viewer.current.offsetParent === null) return;
-      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
-      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
-      const target = event.target;
-      if (
-        target instanceof Element &&
-        target.closest("input, textarea, [contenteditable=true], [role=dialog], [role=menu], [data-context-session]")
-      )
-        return;
-      event.preventDefault();
-      if (dirty) setDiscardOpen(true);
-      else onBack();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [dirty, onBack]);
 
   async function save() {
     setSaving(true);
@@ -859,10 +953,6 @@ function FileViewer({
     else onBack();
   }
 
-  function zoom(step: -1 | 0 | 1) {
-    setFontSize(zoomedFontSize(PREVIEW_FONT_KEY, fontSize, step));
-  }
-
   return (
     <Tabs
       ref={viewer}
@@ -873,24 +963,7 @@ function FileViewer({
       data-context-zoom
       className="flex min-h-0 flex-1 flex-col gap-0 outline-none"
       style={{ fontSize, lineHeight: 1.6 }}
-      onKeyDown={(event) => {
-        const command = event.metaKey || (!navigator.platform.includes("Mac") && event.ctrlKey);
-        if (!command) return;
-        if (event.key.toLowerCase() === "s") {
-          event.preventDefault();
-          if (!saving && dirty) void save();
-          return;
-        }
-        if (event.key.toLowerCase() === "w") {
-          event.preventDefault();
-          closeFile();
-          return;
-        }
-        const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
-        if (!step && event.key !== "0") return;
-        event.preventDefault();
-        zoom(step);
-      }}
+      onKeyDown={(event) => previewKeyDown(event, closeFile, zoom, () => !saving && dirty && void save())}
     >
       <Dialog open={discardOpen} onOpenChange={setDiscardOpen}>
         <DialogContent>
@@ -915,25 +988,21 @@ function FileViewer({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div
-        className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]"
-        data-context-value={entry.path}
-        data-context-label="Copy path"
+      <PreviewHeader
+        path={entry.path}
+        backLabel="Back to files"
+        closeLabel="Close file"
+        icon={<FileIcon name={entry.name} />}
+        title={
+          <span className="min-w-0 flex-1 truncate font-medium">
+            {entry.name}
+            {dirty ? " •" : ""}
+          </span>
+        }
+        disabled={saving}
+        showClose={!editing}
+        onClose={closeFile}
       >
-        <ActionIconButton
-          size="icon-sm"
-          tooltip="Back to files"
-          aria-label="Back to files"
-          disabled={saving}
-          onClick={closeFile}
-        >
-          <ArrowLeft />
-        </ActionIconButton>
-        <FileIcon name={entry.name} />
-        <span className="min-w-0 flex-1 truncate font-medium">
-          {entry.name}
-          {dirty ? " •" : ""}
-        </span>
         {renderable && !editing && !error ? (
           <TabsList aria-label="File view" className="h-7 shrink-0">
             <TabsTrigger value="source" className="text-xs">
@@ -960,36 +1029,21 @@ function FileViewer({
               {saving ? "Saving…" : "Save"}
             </Button>
           </>
-        ) : (
-          <>
-            {!error ? (
-              <ActionIconButton
-                size="icon-sm"
-                tooltip="Edit file"
-                aria-label="Edit file"
-                onClick={() => {
-                  setSaveError("");
-                  setView("edit");
-                }}
-              >
-                <SquarePen />
-              </ActionIconButton>
-            ) : null}
-            <ActionIconButton
-              size="icon-sm"
-              tooltip="Close file"
-              aria-label="Close file"
-              disabled={saving}
-              onClick={closeFile}
-            >
-              <X />
-            </ActionIconButton>
-          </>
-        )}
-      </div>
-      <button type="button" hidden data-context-zoom-in onClick={() => zoom(1)} />
-      <button type="button" hidden data-context-zoom-out onClick={() => zoom(-1)} />
-      <button type="button" hidden data-context-zoom-reset onClick={() => zoom(0)} />
+        ) : !error ? (
+          <ActionIconButton
+            size="icon-sm"
+            tooltip="Edit file"
+            aria-label="Edit file"
+            onClick={() => {
+              setSaveError("");
+              setView("edit");
+            }}
+          >
+            <SquarePen />
+          </ActionIconButton>
+        ) : null}
+      </PreviewHeader>
+      <PreviewZoomControls zoom={zoom} />
       <ScrollArea className="min-h-0 flex-1">
         {loading ? (
           <Loading label="Opening file…" />
@@ -1158,32 +1212,7 @@ function DiffViewer({
   loading: boolean;
   onBack: () => void;
 }) {
-  const viewer = useRef<HTMLElement>(null);
-  const [fontSize, setFontSize] = useState(() => storedFontSize(PREVIEW_FONT_KEY));
-
-  useEffect(() => viewer.current?.focus(), []);
-
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (!viewer.current || viewer.current.offsetParent === null) return;
-      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
-      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
-      const target = event.target;
-      if (
-        target instanceof Element &&
-        target.closest("input, textarea, [contenteditable=true], [role=dialog], [role=menu], [data-context-session]")
-      )
-        return;
-      event.preventDefault();
-      onBack();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onBack]);
-
-  function zoom(step: -1 | 0 | 1) {
-    setFontSize(zoomedFontSize(PREVIEW_FONT_KEY, fontSize, step));
-  }
+  const { viewer, fontSize, zoom } = usePreviewViewer<HTMLElement>(onBack);
 
   return (
     <section
@@ -1193,42 +1222,21 @@ function DiffViewer({
       data-context-zoom
       className="flex h-full min-h-0 flex-col outline-none"
       style={{ fontSize, lineHeight: 1.6 }}
-      onKeyDown={(event) => {
-        const command = event.metaKey || (!navigator.platform.includes("Mac") && event.ctrlKey);
-        if (command && event.key.toLowerCase() === "w") {
-          event.preventDefault();
-          onBack();
-          return;
-        }
-        if (command) {
-          const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
-          if (step || event.key === "0") {
-            event.preventDefault();
-            zoom(step);
-          }
-          return;
-        }
-      }}
+      onKeyDown={(event) => previewKeyDown(event, onBack, zoom)}
     >
-      <div
-        className="flex h-9 shrink-0 items-center gap-2 border-b px-2 text-[13px]"
-        data-context-value={path}
-        data-context-label="Copy path"
-      >
-        <ActionIconButton size="icon-sm" tooltip="Back to Git" aria-label="Back to Git" onClick={onBack}>
-          <ArrowLeft />
-        </ActionIconButton>
-        <FileDiff aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 flex-1 truncate font-mono font-medium" title={path}>
-          {path}
-        </span>
-        <ActionIconButton size="icon-sm" tooltip="Close diff" aria-label="Close diff" onClick={onBack}>
-          <X />
-        </ActionIconButton>
-      </div>
-      <button type="button" hidden data-context-zoom-in onClick={() => zoom(1)} />
-      <button type="button" hidden data-context-zoom-out onClick={() => zoom(-1)} />
-      <button type="button" hidden data-context-zoom-reset onClick={() => zoom(0)} />
+      <PreviewHeader
+        path={path}
+        backLabel="Back to Git"
+        closeLabel="Close diff"
+        icon={<FileDiff aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />}
+        title={
+          <span className="min-w-0 flex-1 truncate font-mono font-medium" title={path}>
+            {path}
+          </span>
+        }
+        onClose={onBack}
+      />
+      <PreviewZoomControls zoom={zoom} />
       <ScrollArea className="min-h-0 flex-1">
         {loading ? (
           <Loading label="Reading diff…" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export interface DirectoryListing {
 export interface GitStatus {
   branch: string;
   worktree: string;
-  changes: string[];
+  changes: { status: string; path: string }[];
   lineDiffs: Record<string, { additions: number; deletions: number }>;
   changesTruncated: boolean;
 }


### PR DESCRIPTION
## Summary

- group sessions by repository and add an MRU keyboard switcher
- open bounded, read-only diffs from Git changed-file rows
- bump Lite from 0.0.23 to 0.0.24

Built on current `main`, including #87 file-preview improvements.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite now groups sessions with collapsible repository sections, adds MRU keyboard switching, and supports bounded read-only Git diff viewing from changed files.

### 📊 Key Changes

- Added session grouping by repository or working directory, with collapsible headers, cross-group drag-and-drop, and MRU ordering.
- Added a searchable session switcher opened with `⌘P` on macOS or `Ctrl+Shift+P` elsewhere, including keyboard navigation and session status details.
- Changed Git status data to structured `{ status, path }` entries and scoped repository status and line-diff queries to the selected folder.
- Added the `git_diff` Tauri command and a read-only diff viewer for tracked, staged, and untracked files, with path validation, sensitive-file blocking, and a 1 MB output limit.
- Bumped Lite from `0.0.23` to `0.0.24`, added Git parsing/diff tests, and changed CI Bun setup to use the retry action.

### 🎯 Purpose & Impact

- Users can organize larger session lists by repository, quickly find recent sessions, and move between sessions without leaving the current workspace.
- Git changed-file rows now open an in-app diff view; diffs support the existing preview navigation and zoom controls but cannot be edited or saved.
- Diff requests reject paths outside the selected folder, sensitive files, oversized output, and non-UTF-8 Git paths; Git status handling also preserves filenames containing status-like text.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
