### PR TITLE
Polish setup and About interactions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.25"
+version = "0.0.26"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,11 @@ const SUPPORTED_KEYS: [&str; 6] = [
 #[tauri::command]
 fn notifications_supported() -> bool {
     cfg!(target_os = "macos")
+        && std::env::current_exe().is_ok_and(|executable| {
+            executable
+                .ancestors()
+                .any(|path| path.extension().is_some_and(|extension| extension == "app"))
+        })
 }
 
 #[cfg(target_os = "macos")]
@@ -78,6 +83,9 @@ fn send_notification(title: String) {
         UNMutableNotificationContent, UNNotificationRequest, UNUserNotificationCenter,
     };
 
+    if !notifications_supported() {
+        return;
+    }
     let content = UNMutableNotificationContent::new();
     content.setTitle(&NSString::from_str(&title));
     content.setBody(&NSString::from_str("This session needs your attention."));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1899,7 +1899,9 @@ function App() {
   useEffect(() => {
     if (localStorage.getItem(NOTIFICATIONS_KEY) !== null) return;
     void invoke<boolean>("notifications_supported")
-      .then((supported) => (supported ? changeNotifications(true) : undefined))
+      .then((supported) =>
+        supported && localStorage.getItem(NOTIFICATIONS_KEY) === null ? changeNotifications(true) : undefined,
+      )
       .catch(() => {
         localStorage.setItem(NOTIFICATIONS_KEY, "false");
         notificationsRef.current = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1413,7 +1413,7 @@ function App() {
   const [attention, setAttention] = useState<string[]>([]);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [notifications, setNotifications] = useState(() => localStorage.getItem(NOTIFICATIONS_KEY) === "true");
+  const [notifications, setNotifications] = useState(() => localStorage.getItem(NOTIFICATIONS_KEY) !== "false");
   const [keepAwake, setKeepAwake] = useState(() => localStorage.getItem(KEEP_AWAKE_KEY) === "true");
   const [closingAll, setClosingAll] = useState(false);
   // Bulk close is running: the dialog stays up and sessions stay untouched until every stop and
@@ -1893,6 +1893,15 @@ function App() {
     notificationsRef.current = enabled;
     setNotifications(enabled);
   }, []);
+
+  useEffect(() => {
+    if (localStorage.getItem(NOTIFICATIONS_KEY) !== null) return;
+    void changeNotifications(true).catch(() => {
+      localStorage.setItem(NOTIFICATIONS_KEY, "false");
+      notificationsRef.current = false;
+      setNotifications(false);
+    });
+  }, [changeNotifications]);
 
   const changeKeepAwake = useCallback((enabled: boolean) => {
     localStorage.setItem(KEEP_AWAKE_KEY, String(enabled));
@@ -3398,7 +3407,18 @@ function App() {
             onKeepAwakeChange={changeKeepAwake}
             theme={theme}
             onThemeChange={setTheme}
-            version={version}
+            versionBadge={
+              <VersionBadge
+                version={version}
+                commit={commit}
+                built={built}
+                release={release}
+                onCheck={() => {
+                  setSettingsOpen(false);
+                  void checkForUpdates();
+                }}
+              />
+            }
             commit={commit}
             built={built}
             repo={repo}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1895,13 +1895,15 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (localStorage.getItem(NOTIFICATIONS_KEY) !== null) return;
+    // A local build has no application bundle for macOS to authorize, while an installed release
+    // does. Both default on; only the release asks the OS for its first permission.
+    if (commit === undefined || commit || localStorage.getItem(NOTIFICATIONS_KEY) !== null) return;
     void changeNotifications(true).catch(() => {
       localStorage.setItem(NOTIFICATIONS_KEY, "false");
       notificationsRef.current = false;
       setNotifications(false);
     });
-  }, [changeNotifications]);
+  }, [changeNotifications, commit]);
 
   const changeKeepAwake = useCallback((enabled: boolean) => {
     localStorage.setItem(KEEP_AWAKE_KEY, String(enabled));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1895,15 +1895,15 @@ function App() {
   }, []);
 
   useEffect(() => {
-    // A local build has no application bundle for macOS to authorize, while an installed release
-    // does. Both default on; only the release asks the OS for its first permission.
-    if (commit === undefined || commit || localStorage.getItem(NOTIFICATIONS_KEY) !== null) return;
-    void changeNotifications(true).catch(() => {
-      localStorage.setItem(NOTIFICATIONS_KEY, "false");
-      notificationsRef.current = false;
-      setNotifications(false);
-    });
-  }, [changeNotifications, commit]);
+    if (localStorage.getItem(NOTIFICATIONS_KEY) !== null) return;
+    void invoke<boolean>("notifications_supported")
+      .then((supported) => (supported ? changeNotifications(true) : undefined))
+      .catch(() => {
+        localStorage.setItem(NOTIFICATIONS_KEY, "false");
+        notificationsRef.current = false;
+        setNotifications(false);
+      });
+  }, [changeNotifications]);
 
   const changeKeepAwake = useCallback((enabled: boolean) => {
     localStorage.setItem(KEEP_AWAKE_KEY, String(enabled));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1887,8 +1887,10 @@ function App() {
   }, [forgetShellAgent, markAttention, markDirectory, markWorking, markTitle]);
 
   const changeNotifications = useCallback(async (enabled: boolean) => {
+    const stored = localStorage.getItem(NOTIFICATIONS_KEY);
     if (enabled && !(await invoke<boolean>("request_notification_permission")))
       throw new Error("Allow notifications for Lite in macOS System Settings.");
+    if (localStorage.getItem(NOTIFICATIONS_KEY) !== stored) return;
     localStorage.setItem(NOTIFICATIONS_KEY, String(enabled));
     notificationsRef.current = enabled;
     setNotifications(enabled);

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -403,9 +403,9 @@ export function NewSessionDialog({
                   // A registry that could not answer knows of no update, so only one it reported is
                   // offered — by the button and by the mark beside the version alike.
                   const updatable = managed && update === true;
-                  // What the button offers, if it is there at all, and the room the tile keeps for it:
-                  // a tile only ever offers the one action, so each reserves the width of its own
-                  // widest label rather than both settling for the wider.
+                  // What the button offers, if it is there at all, and the room the title keeps for it.
+                  // The status line keeps the same width it has on main instead of shrinking when the
+                  // adjacent action appears.
                   const action = state?.installable
                     ? ({ label: "Install", working: "Installing…", room: "pr-28" } as const)
                     : updatable
@@ -420,7 +420,7 @@ export function NewSessionDialog({
                         type="button"
                         size="lg"
                         variant={active ? "secondary" : "outline"}
-                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action?.room ?? "pr-3"}`}
+                        className="h-14 w-full min-w-0 justify-start overflow-hidden pr-3 pl-3"
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}
@@ -430,7 +430,7 @@ export function NewSessionDialog({
                         <div
                           className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : updatable ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
                         >
-                          <span className="block truncate">{sessionLabel(option)}</span>
+                          <span className={`block truncate ${action?.room ?? ""}`}>{sessionLabel(option)}</span>
                           {state && !state.available ? (
                             <span className="block truncate text-xs font-normal text-muted-foreground">
                               {state.installable ? "Not installed" : "Setup required"}
@@ -449,7 +449,7 @@ export function NewSessionDialog({
                           type="button"
                           size="sm"
                           variant="ghost"
-                          className="absolute top-1/2 right-1.5 -mt-3.5 hover:bg-primary hover:text-primary-foreground"
+                          className="absolute top-1 right-1.5 hover:bg-primary hover:text-primary-foreground"
                           disabled={Boolean(installing)}
                           onClick={() => void install(option)}
                         >

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -448,8 +448,8 @@ export function NewSessionDialog({
                         <Button
                           type="button"
                           size="sm"
-                          variant="ghost"
-                          className="absolute top-1/2 right-1.5 -translate-y-1/2"
+                          variant="outline"
+                          className="absolute top-1/2 right-1.5 -mt-3.5"
                           disabled={Boolean(installing)}
                           onClick={() => void install(option)}
                         >

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -448,8 +448,8 @@ export function NewSessionDialog({
                         <Button
                           type="button"
                           size="sm"
-                          variant="outline"
-                          className="absolute top-1/2 right-1.5 -mt-3.5"
+                          variant="ghost"
+                          className="absolute top-1/2 right-1.5 -mt-3.5 hover:bg-primary hover:text-primary-foreground"
                           disabled={Boolean(installing)}
                           onClick={() => void install(option)}
                         >

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -446,7 +446,7 @@ export function NewSessionDialog({
                         <ActionIconButton
                           type="button"
                           size="icon-sm"
-                          variant="default"
+                          className="absolute top-1/2 right-2 -mt-3.5 bg-background shadow-sm hover:bg-background hover:shadow-md"
                           tooltip={
                             busy
                               ? `${action.working} ${sessionLabel(option)}…`
@@ -459,7 +459,6 @@ export function NewSessionDialog({
                               ? `Install ${sessionLabel(option)}`
                               : `Update ${sessionLabel(option)} to the latest version`
                           }
-                          className="absolute top-1/2 right-2 -mt-3.5"
                           disabled={Boolean(installing)}
                           onClick={() => void install(option)}
                         >

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -446,6 +446,7 @@ export function NewSessionDialog({
                         <ActionIconButton
                           type="button"
                           size="icon-sm"
+                          variant="default"
                           tooltip={
                             busy
                               ? `${action.working} ${sessionLabel(option)}…`

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -445,8 +445,9 @@ export function NewSessionDialog({
                       {action ? (
                         <ActionIconButton
                           type="button"
-                          size="icon-sm"
-                          className="absolute top-1/2 right-2 -mt-3.5 bg-background hover:bg-muted"
+                          size="icon"
+                          variant="outline"
+                          className="absolute top-1/2 right-2 -mt-4"
                           tooltip={
                             busy
                               ? `${action.working} ${sessionLabel(option)}…`

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -446,7 +446,7 @@ export function NewSessionDialog({
                         <ActionIconButton
                           type="button"
                           size="icon-sm"
-                          className="absolute top-1/2 right-2 -mt-3.5 bg-background shadow-sm hover:bg-background hover:shadow-md"
+                          className="absolute top-1/2 right-2 -mt-3.5 bg-background hover:bg-muted"
                           tooltip={
                             busy
                               ? `${action.working} ${sessionLabel(option)}…`

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -1,7 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { FolderOpen } from "lucide-react";
+import { Download, FolderOpen, RefreshCw } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 
 import { ProviderIcon } from "@/brand-icons";
@@ -403,13 +403,11 @@ export function NewSessionDialog({
                   // A registry that could not answer knows of no update, so only one it reported is
                   // offered — by the button and by the mark beside the version alike.
                   const updatable = managed && update === true;
-                  // What the button offers, if it is there at all, and the room the title keeps for it.
-                  // The status line keeps the same width it has on main instead of shrinking when the
-                  // adjacent action appears.
+                  // What the icon offers, if it is there at all.
                   const action = state?.installable
-                    ? ({ label: "Install", working: "Installing…", room: "pr-28" } as const)
+                    ? ({ label: "Install", working: "Installing" } as const)
                     : updatable
-                      ? ({ label: "Update", working: "Updating…", room: "pr-24" } as const)
+                      ? ({ label: "Update", working: "Updating" } as const)
                       : undefined;
                   const busy = installing === option.id;
                   const authProvider = "configured" in option ? option : undefined;
@@ -420,7 +418,7 @@ export function NewSessionDialog({
                         type="button"
                         size="lg"
                         variant={active ? "secondary" : "outline"}
-                        className="h-14 w-full min-w-0 justify-start overflow-hidden pr-3 pl-3"
+                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-11" : "pr-3"}`}
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}
@@ -430,7 +428,7 @@ export function NewSessionDialog({
                         <div
                           className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : updatable ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
                         >
-                          <span className={`block truncate ${action?.room ?? ""}`}>{sessionLabel(option)}</span>
+                          <span className="block truncate">{sessionLabel(option)}</span>
                           {state && !state.available ? (
                             <span className="block truncate text-xs font-normal text-muted-foreground">
                               {state.installable ? "Not installed" : "Setup required"}
@@ -445,17 +443,27 @@ export function NewSessionDialog({
                         </div>
                       </Button>
                       {action ? (
-                        <Button
+                        <ActionIconButton
                           type="button"
-                          size="sm"
-                          variant="ghost"
-                          className="absolute top-1 right-1.5 hover:bg-primary hover:text-primary-foreground"
+                          size="icon-sm"
+                          tooltip={
+                            busy
+                              ? `${action.working} ${sessionLabel(option)}…`
+                              : action.label === "Install"
+                                ? `Install ${sessionLabel(option)}`
+                                : `Update ${sessionLabel(option)} to the latest version`
+                          }
+                          aria-label={
+                            action.label === "Install"
+                              ? `Install ${sessionLabel(option)}`
+                              : `Update ${sessionLabel(option)} to the latest version`
+                          }
+                          className="absolute top-1/2 right-2 -mt-3.5"
                           disabled={Boolean(installing)}
                           onClick={() => void install(option)}
                         >
-                          {busy ? <Spinner /> : null}
-                          {busy ? action.working : action.label}
-                        </Button>
+                          {busy ? <Spinner /> : action.label === "Install" ? <Download /> : <RefreshCw />}
+                        </ActionIconButton>
                       ) : null}
                     </div>
                   );

--- a/src/provider-auth.tsx
+++ b/src/provider-auth.tsx
@@ -103,10 +103,10 @@ export function ProviderAuthDescription({
   return (
     <ItemDescription className="truncate text-xs leading-4">
       {status && (hint || status.cliAuthMethod) ? (
-        <span className="flex min-w-0 items-center gap-1.5">
+        <span className="flex items-center gap-1.5">
           <Check className="size-3.5 shrink-0" />
-          <span className="min-w-0 truncate">{configured}</span>
-          {hint ? <span className="shrink-0 font-mono">••••{hint}</span> : null}
+          {configured}
+          {hint ? <span className="font-mono">••••{hint}</span> : null}
         </span>
       ) : status ? (
         "Not set up"

--- a/src/provider-auth.tsx
+++ b/src/provider-auth.tsx
@@ -103,10 +103,10 @@ export function ProviderAuthDescription({
   return (
     <ItemDescription className="truncate text-xs leading-4">
       {status && (hint || status.cliAuthMethod) ? (
-        <span className="flex items-center gap-1.5">
+        <span className="flex min-w-0 items-center gap-1.5">
           <Check className="size-3.5 shrink-0" />
-          {configured}
-          {hint ? <span className="font-mono">••••{hint}</span> : null}
+          <span className="min-w-0 truncate">{configured}</span>
+          {hint ? <span className="shrink-0 font-mono">••••{hint}</span> : null}
         </span>
       ) : status ? (
         "Not set up"

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -251,8 +251,8 @@ export function SettingsDialog({
                         <ProviderIcon agent={option.agent} provider={option.provider} className="size-5" />
                       </ItemMedia>
                       <ItemContent>
-                        <ItemTitle>
-                          {option.label}
+                        <ItemTitle className="max-w-full">
+                          <span className="min-w-0 truncate">{option.label}</span>
                           <Badge variant="outline" className="font-mono font-normal">
                             {option.variable}
                           </Badge>

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -251,8 +251,8 @@ export function SettingsDialog({
                         <ProviderIcon agent={option.agent} provider={option.provider} className="size-5" />
                       </ItemMedia>
                       <ItemContent>
-                        <ItemTitle className="max-w-full">
-                          <span className="min-w-0 truncate">{option.label}</span>
+                        <ItemTitle>
+                          {option.label}
                           <Badge variant="outline" className="font-mono font-normal">
                             {option.variable}
                           </Badge>

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -1,10 +1,22 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { Bell, Eye, EyeOff, Info, KeyRound, Moon, RefreshCw, SlidersHorizontal, Sun, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import {
+  Bell,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Info,
+  KeyRound,
+  Moon,
+  RefreshCw,
+  SlidersHorizontal,
+  Sun,
+  Trash2,
+} from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 
-import { ProviderIcon } from "@/brand-icons";
+import { GitHubLogomark, ProviderIcon, UltralyticsLogomark } from "@/brand-icons";
 import { Badge } from "@/components/ui/badge";
 import { ActionIconButton, Button } from "@/components/ui/button";
 import {
@@ -48,7 +60,7 @@ export function SettingsDialog({
   onKeepAwakeChange,
   theme,
   onThemeChange,
-  version,
+  versionBadge,
   commit,
   built,
   repo,
@@ -63,7 +75,7 @@ export function SettingsDialog({
   onKeepAwakeChange: (enabled: boolean) => void;
   theme: Theme;
   onThemeChange: (theme: Theme) => void;
-  version: string;
+  versionBadge: ReactNode;
   commit?: string;
   built: string;
   repo: string;
@@ -319,58 +331,72 @@ export function SettingsDialog({
               </ItemGroup>
             </TabsContent>
             <TabsContent value="about" className="min-w-0">
-              <h2 className="text-base font-semibold">About</h2>
-              <p className="mt-1 mb-4 text-sm text-muted-foreground">Version, build, and update information.</p>
-              <Item variant="outline">
-                <ItemMedia variant="icon">
-                  <Info />
-                </ItemMedia>
-                <ItemContent>
-                  <ItemTitle>{version ? `Lite ${version}` : "Lite"}</ItemTitle>
-                  <ItemDescription>A fast, local workspace for AI coding agents.</ItemDescription>
-                </ItemContent>
-                <ItemActions>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      onOpenChange(false);
-                      onCheckForUpdates();
-                    }}
-                  >
-                    <RefreshCw />
-                    Check for Updates
-                  </Button>
-                </ItemActions>
-              </Item>
-              <dl className="mt-4 grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-xs">
-                {version ? (
-                  <>
-                    <dt className="text-muted-foreground">Version</dt>
-                    <dd className="truncate font-mono">{version}</dd>
-                  </>
-                ) : null}
-                {commit ? (
-                  <>
-                    <dt className="text-muted-foreground">Revision</dt>
-                    <dd className="truncate font-mono">{commit}</dd>
-                  </>
-                ) : null}
-                {built ? (
-                  <>
-                    <dt className="text-muted-foreground">Built</dt>
-                    <dd className="truncate">{built}</dd>
-                  </>
-                ) : null}
-                {repo ? (
-                  <>
-                    <dt className="text-muted-foreground">Source</dt>
-                    <dd className="truncate font-mono" title={repo}>
-                      {repo}
-                    </dd>
-                  </>
-                ) : null}
-              </dl>
+              <div className="flex flex-col items-center pt-3 text-center">
+                <UltralyticsLogomark className="size-14" />
+                <div className="mt-3 flex items-center gap-2">
+                  <h2 className="text-xl font-semibold">Lite</h2>
+                  {versionBadge}
+                </div>
+                <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                  A fast, local workspace for AI coding agents, with no indexing, telemetry, or cloud service.
+                </p>
+              </div>
+              <ItemGroup className="mt-6 gap-2.5">
+                <Item variant="outline">
+                  <ItemMedia variant="icon">
+                    <GitHubLogomark />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>Open source</ItemTitle>
+                    <ItemDescription>AGPL-3.0 · github.com/ultralytics/lite</ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void invoke("open_url", { url: "https://github.com/ultralytics/lite" })}
+                    >
+                      View repository
+                      <ExternalLink />
+                    </Button>
+                  </ItemActions>
+                </Item>
+              </ItemGroup>
+              <div className="mt-4 flex items-start justify-between gap-4">
+                <dl className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-xs">
+                  {commit ? (
+                    <>
+                      <dt className="text-muted-foreground">Revision</dt>
+                      <dd className="truncate font-mono">{commit}</dd>
+                    </>
+                  ) : null}
+                  {built ? (
+                    <>
+                      <dt className="text-muted-foreground">Built</dt>
+                      <dd className="truncate">{built}</dd>
+                    </>
+                  ) : null}
+                  {repo ? (
+                    <>
+                      <dt className="text-muted-foreground">Working tree</dt>
+                      <dd className="truncate font-mono" title={repo}>
+                        {repo}
+                      </dd>
+                    </>
+                  ) : null}
+                </dl>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    onOpenChange(false);
+                    onCheckForUpdates();
+                  }}
+                >
+                  <RefreshCw />
+                  Check for Updates
+                </Button>
+              </div>
             </TabsContent>
           </Tabs>
         </DialogBody>

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -251,8 +251,8 @@ export function SettingsDialog({
                         <ProviderIcon agent={option.agent} provider={option.provider} className="size-5" />
                       </ItemMedia>
                       <ItemContent>
-                        <ItemTitle className="w-full min-w-0">
-                          <span className="min-w-0 truncate">{option.label}</span>
+                        <ItemTitle>
+                          {option.label}
                           <Badge variant="outline" className="font-mono font-normal">
                             {option.variable}
                           </Badge>

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -251,8 +251,8 @@ export function SettingsDialog({
                         <ProviderIcon agent={option.agent} provider={option.provider} className="size-5" />
                       </ItemMedia>
                       <ItemContent>
-                        <ItemTitle>
-                          {option.label}
+                        <ItemTitle className="w-full min-w-0">
+                          <span className="min-w-0 truncate">{option.label}</span>
                           <Badge variant="outline" className="font-mono font-normal">
                             {option.variable}
                           </Badge>


### PR DESCRIPTION
## Summary

- keep install and update actions visible over selected agents and prevent their pressed state from jumping
- enable macOS notifications by default on first install while preserving saved choices
- refresh About with the Lite mark, the existing live version badge, open-source repository details, and build metadata
- bump Lite to 0.0.26

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite 0.0.26 updates agent install/update controls, enables supported macOS notifications by default for new installations, and refreshes the About view with branding, repository access, and build information.

### 📊 Key Changes

- Replaced text-based agent Install and Update buttons with fixed-position icon buttons that remain visible over selected agents and show contextual tooltips.
- Changed notification initialization to default to enabled when no saved preference exists, while preserving existing choices and limiting automatic macOS setup to packaged `.app` builds.
- Redesigned the About tab with the Ultralytics mark, the live version badge, an open-source repository link, license information, revision, build, and working-tree metadata.
- Moved the update check action into the About metadata area and connected the version badge to the existing update-check workflow.
- Bumped the Tauri package version from `0.0.25` to `0.0.26`.

### 🎯 Purpose & Impact

- Agent selection buttons no longer resize or shift when an Install or Update action is available; those actions remain accessible as fixed icon controls.
- On first install, supported macOS app builds request notification permission automatically; saved notification settings remain unchanged, and unsupported or failed setups are disabled.
- The About view provides clearer product identity, direct access to the Lite GitHub repository, and visible build details while retaining update checking.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
