### PR TITLE
Resume interrupted sessions after relaunch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -934,6 +934,24 @@ fn default_directory_path(app: &AppHandle) -> Option<PathBuf> {
     path.is_dir().then_some(path)
 }
 
+fn typed_path(app: &AppHandle, path: &str) -> Result<PathBuf, String> {
+    let path = match path.trim().strip_prefix('~') {
+        Some(rest) => app
+            .path()
+            .home_dir()
+            .map_err(|error| error.to_string())?
+            .join(rest.trim_start_matches(['/', '\\'])),
+        None => PathBuf::from(path.trim()),
+    };
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(path))
+            .map_err(|error| error.to_string())
+    }
+}
+
 #[cfg(unix)]
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
@@ -1243,15 +1261,7 @@ async fn use_directory(
     roots: State<'_, Roots>,
     path: String,
 ) -> Result<DirectoryGrant, String> {
-    let path = path.trim();
-    let path = match path.strip_prefix('~') {
-        Some(rest) => app
-            .path()
-            .home_dir()
-            .map_err(|error| error.to_string())?
-            .join(rest.trim_start_matches(['/', '\\'])),
-        None => PathBuf::from(path),
-    };
+    let path = typed_path(&app, &path)?;
     if !path.exists() {
         // Resolve the closest existing ancestor before creating through it: a symlink into a sensitive
         // configuration folder must not let the final canonical-path check happen after the mutation.
@@ -4213,15 +4223,7 @@ struct DirectoryProbe {
 // takes the bare path — the same folder the grant would name — and only reads from it.
 #[tauri::command]
 async fn directory_probe(app: AppHandle, path: String) -> Result<DirectoryProbe, String> {
-    let path = path.trim();
-    let path = match path.strip_prefix('~') {
-        Some(rest) => app
-            .path()
-            .home_dir()
-            .map_err(|error| error.to_string())?
-            .join(rest.trim_start_matches(['/', '\\'])),
-        None => PathBuf::from(path),
-    };
+    let path = typed_path(&app, &path)?;
     if !path.is_dir() {
         return Ok(DirectoryProbe {
             exists: path.exists(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1235,7 +1235,8 @@ async fn choose_directory(
     grant_directory(&app, &roots, path, None).map(Some)
 }
 
-// A typed path is a folder like any other: it has to exist and it goes through the same grant.
+// A typed path is a folder like any other and goes through the same grant. The field tells the user
+// before submit when a missing folder will be created; an existing non-folder remains invalid.
 #[tauri::command]
 async fn use_directory(
     app: AppHandle,
@@ -1251,8 +1252,21 @@ async fn use_directory(
             .join(rest.trim_start_matches(['/', '\\'])),
         None => PathBuf::from(path),
     };
+    if !path.exists() {
+        // Resolve the closest existing ancestor before creating through it: a symlink into a sensitive
+        // configuration folder must not let the final canonical-path check happen after the mutation.
+        let mut ancestor = path.as_path();
+        while !ancestor.exists() {
+            ancestor = ancestor.parent().ok_or("That folder cannot be created")?;
+        }
+        let ancestor = fs::canonicalize(ancestor).map_err(|error| error.to_string())?;
+        if is_sensitive_root(&ancestor) || is_sensitive_root(&path) {
+            return Err("Credential and configuration folders cannot be opened".into());
+        }
+        fs::create_dir_all(&path).map_err(|error| error.to_string())?;
+    }
     if !path.is_dir() {
-        return Err("That folder does not exist".into());
+        return Err("That path is not a folder".into());
     }
     let path = fs::canonicalize(path).map_err(|error| error.to_string())?;
     write_atomic(&last_directory_path(&app)?, path_text(&path).as_bytes())?;
@@ -4186,11 +4200,19 @@ struct Repository {
     worktree: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DirectoryProbe {
+    exists: bool,
+    is_directory: bool,
+    repository: Option<Repository>,
+}
+
 // Whether a folder sits inside a repository, where its main checkout is, and the next sibling path
 // available for a Lite worktree. The new-session dialog asks before it has granted anything, so this
 // takes the bare path — the same folder the grant would name — and only reads from it.
 #[tauri::command]
-async fn git_repo(app: AppHandle, path: String) -> Result<Option<Repository>, String> {
+async fn directory_probe(app: AppHandle, path: String) -> Result<DirectoryProbe, String> {
     let path = path.trim();
     let path = match path.strip_prefix('~') {
         Some(rest) => app
@@ -4201,23 +4223,35 @@ async fn git_repo(app: AppHandle, path: String) -> Result<Option<Repository>, St
         None => PathBuf::from(path),
     };
     if !path.is_dir() {
-        return Ok(None);
+        return Ok(DirectoryProbe {
+            exists: path.exists(),
+            is_directory: false,
+            repository: None,
+        });
     }
     // Canonicalized like the grant's path would be, so the root can be compared with session cwds.
     let path = fs::canonicalize(path).map_err(|error| error.to_string())?;
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
     let Ok(root) = main_checkout(&git, &path) else {
-        return Ok(None);
+        return Ok(DirectoryProbe {
+            exists: true,
+            is_directory: true,
+            repository: None,
+        });
     };
     let checkout = command_output(&git, &path, &["rev-parse", "--show-toplevel"])
         .map(PathBuf::from)
         .unwrap_or_else(|_| root.clone());
     let candidate = next_worktree(&git, &root, &checkout)?;
-    Ok(Some(Repository {
-        worktree: path_text(&candidate.path),
-        branch: candidate.branch,
-        root: path_text(&root),
-    }))
+    Ok(DirectoryProbe {
+        exists: true,
+        is_directory: true,
+        repository: Some(Repository {
+            worktree: path_text(&candidate.path),
+            branch: candidate.branch,
+            root: path_text(&root),
+        }),
+    })
 }
 
 // A session that shares its project with another gets the next numbered sibling folder. A missing
@@ -5085,7 +5119,7 @@ pub fn run() {
             git_status,
             git_diff,
             git_remote,
-            git_repo,
+            directory_probe,
             create_worktree,
             restore_worktree,
             worktree_state,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1868,6 +1868,10 @@ function App() {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
         runs.current.delete(payload.sessionId);
         forgetShellAgent(payload.sessionId);
+        const timer = workTimers.current.get(payload.sessionId);
+        if (timer) window.clearTimeout(timer);
+        workTimers.current.delete(payload.sessionId);
+        setWorking((current) => without(current, payload.sessionId));
         setSessions((current) =>
           current.map((session) => (session.id === payload.sessionId ? { ...session, running: false } : session)),
         );
@@ -1990,11 +1994,13 @@ function App() {
 
   const resumeSession = useCallback(
     async (session: Session) => {
-      const shouldContinue = session.agent !== "shell" && interrupted.current.has(session.id);
+      // Taking the marker before launch makes this caller the sole owner of the continuation even
+      // when another mount effect or click reaches the same in-flight process.
+      const shouldContinue = session.agent !== "shell" && interrupted.current.delete(session.id);
       const launched = await launch(session, true);
-      if (launched && shouldContinue) {
-        interrupted.current.delete(session.id);
-        runOnStart(session.id, "continue");
+      if (shouldContinue) {
+        if (launched) runOnStart(session.id, "continue");
+        else interrupted.current.add(session.id);
       }
       return launched;
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,7 @@ import { type Agent, defaultSessionName, folderName, repoName, type Session, ses
 import "./App.css";
 
 const STORAGE_KEY = "lite.sessions.v1";
+const WORKING_KEY = "lite.working.v1";
 const SESSION_VIEW_KEY = "lite.sessionView.v1";
 type SessionGrouping = "none" | "repository" | "directory" | "state";
 type SessionSort = "newest" | "oldest" | "name-asc" | "name-desc" | "manual";
@@ -824,6 +825,15 @@ function loadSessions(): Session[] {
   }
 }
 
+function loadWorking(): Set<string> {
+  try {
+    const stored = JSON.parse(localStorage.getItem(WORKING_KEY) ?? "[]");
+    return new Set(Array.isArray(stored) ? stored.filter((id): id is string => typeof id === "string") : []);
+  } catch {
+    return new Set();
+  }
+}
+
 // Keeps a failing panel from taking the whole window down with it.
 class PanelBoundary extends Component<{ children: ReactNode }, { message: string }> {
   state = { message: "" };
@@ -1438,7 +1448,9 @@ function App() {
   const [startingIds, setStartingIds] = useState<Set<string>>(new Set());
   // Sessions whose terminal has written something recently, which is what separates a connected
   // session that is working from one that is merely connected.
-  const [working, setWorking] = useState<Set<string>>(new Set());
+  const [working, setWorking] = useState(loadWorking);
+  // Work that was live when the previous process disappeared is resumed once in this process.
+  const interrupted = useRef(new Set(working));
   const [shellAgents, setShellAgents] = useState<Map<string, Agent>>(new Map());
   const [query, setQuery] = useState("");
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
@@ -1566,7 +1578,7 @@ function App() {
     if (session.running) {
       recoveryFailures.current.delete(session.id);
       void recoverRef.current(session).catch(() => {});
-    } else if (!startingIds.has(session.id)) void launch(session, true);
+    } else if (!startingIds.has(session.id)) void resumeSession(session);
   };
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
@@ -1696,6 +1708,12 @@ function App() {
       JSON.stringify(sessions.filter((session) => !session.mode).map((session) => ({ ...session, running: false }))),
     );
   }, [sessions]);
+
+  // This is written while work changes rather than at shutdown, so a power loss still leaves the
+  // next Lite process an exact list. An install freezes the last state before it stops the PTYs.
+  useEffect(() => {
+    if (updateStatus !== "installing") localStorage.setItem(WORKING_KEY, JSON.stringify([...working]));
+  }, [updateStatus, working]);
 
   const hasActiveSessions = sessions.some((session) => session.running);
   useEffect(() => {
@@ -1970,6 +1988,30 @@ function App() {
     }
   }, []);
 
+  const resumeSession = useCallback(
+    async (session: Session) => {
+      const shouldContinue = session.agent !== "shell" && interrupted.current.has(session.id);
+      const launched = await launch(session, true);
+      if (launched && shouldContinue) {
+        interrupted.current.delete(session.id);
+        runOnStart(session.id, "continue");
+      }
+      return launched;
+    },
+    [launch],
+  );
+
+  // Busy sessions belong back where they were without waiting for each tab to be visited. Idle tabs
+  // keep their existing lazy resume behavior, and a shell never receives an agent prompt as a command.
+  useEffect(() => {
+    const pending = sessionsRef.current.filter(
+      (session) => !session.mode && session.agent !== "shell" && interrupted.current.has(session.id),
+    );
+    if (pending.some((session) => session.id === selectedRef.current?.id))
+      resumed.current = selectedRef.current?.id ?? "";
+    for (const session of pending) void resumeSession(session);
+  }, [resumeSession]);
+
   function recoverSession(session: Session): Promise<void> {
     const pending = recoveries.current.get(session.id);
     if (pending) return pending;
@@ -2027,12 +2069,12 @@ function App() {
   }
   recoverRef.current = recoverSession;
 
-  // Opening the app, or coming back to a session, brings its provider process back on its own.
+  // Opening the app, or coming back to an idle session, brings its provider process back on its own.
   useEffect(() => {
     if (!selected || selected.mode || selected.running || selectedStarting || resumed.current === selected.id) return;
     resumed.current = selected.id;
-    void launch(selected, true);
-  }, [selected, selectedStarting, launch]);
+    void resumeSession(selected);
+  }, [selected, selectedStarting, resumeSession]);
 
   // Which repository a folder was cloned from is a fact about the folder, so it is asked for once when
   // the selection changes and never watched.

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -1,7 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
-import { Download, FolderOpen, RefreshCw } from "lucide-react";
+import { Check, CircleAlert, Download, FolderOpen, RefreshCw, TriangleAlert } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 
 import { ProviderIcon } from "@/brand-icons";
@@ -47,6 +47,12 @@ interface Repository {
   worktree: string;
 }
 
+interface DirectoryProbe {
+  exists: boolean;
+  isDirectory: boolean;
+  repository: Repository | null;
+}
+
 interface Availability {
   available: boolean;
   installable: boolean;
@@ -78,6 +84,7 @@ export function NewSessionDialog({
   const [error, setError] = useState("");
   // Undefined while checking, null outside a repository, otherwise the repository's main checkout.
   const [repo, setRepo] = useState<string | null>();
+  const [folder, setFolder] = useState<"checking" | "missing" | "directory" | "other">("checking");
   const [worktree, setWorktree] = useState("");
   const [worktreeOn, setWorktreeOn] = useState(false);
   const [branch, setBranch] = useState("");
@@ -112,6 +119,7 @@ export function NewSessionDialog({
   useEffect(() => {
     if (!isOpen || !path.trim()) {
       setRepo(null);
+      setFolder("checking");
       setWorktree("");
       setWorktreeOn(false);
       return;
@@ -119,9 +127,10 @@ export function NewSessionDialog({
     setRepo(undefined);
     let disposed = false;
     const probe = window.setTimeout(() => {
-      void invoke<Repository | null>("git_repo", { path: path.trim() })
-        .then((repository) => {
+      void invoke<DirectoryProbe>("directory_probe", { path: path.trim() })
+        .then(({ exists, isDirectory, repository }) => {
           if (disposed) return;
+          setFolder(isDirectory ? "directory" : exists ? "other" : "missing");
           const root = repository?.root ?? null;
           setRepo(root);
           setWorktree(repository?.worktree ?? "");
@@ -131,6 +140,7 @@ export function NewSessionDialog({
         .catch(() => {
           if (!disposed) {
             setRepo(null);
+            setFolder("other");
             setWorktree("");
           }
         });
@@ -186,6 +196,7 @@ export function NewSessionDialog({
         if (directory) void invoke("revoke_directory", { rootId: directory.id });
         setDirectory(selected);
         setPath(selected.path);
+        setFolder("directory");
         setRepo(undefined);
         setWorktree("");
       }
@@ -228,7 +239,7 @@ export function NewSessionDialog({
       // the worktree and the recorded repository always describe where the session will run.
       let root: string | null;
       try {
-        root = (await invoke<Repository | null>("git_repo", { path: folder.path }))?.root ?? null;
+        root = (await invoke<DirectoryProbe>("directory_probe", { path: folder.path })).repository?.root ?? null;
       } catch (reason) {
         setError(String(reason));
         return;
@@ -302,7 +313,10 @@ export function NewSessionDialog({
   const ready =
     !installing &&
     !creating &&
-    Boolean(missing || (path.trim() && status && repo !== undefined && (!repo || !worktreeOn || branch.trim())));
+    Boolean(
+      missing ||
+        (path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim())),
+    );
   function start() {
     if (missing?.installable) void install();
     else if (missing)
@@ -331,21 +345,42 @@ export function NewSessionDialog({
                 Project folder
               </Label>
               <div className="flex gap-2">
-                <Input
-                  id="project-folder"
-                  value={path}
-                  className="min-w-0 flex-1 font-mono"
-                  placeholder="Type or choose a project folder…"
-                  name="project-folder"
-                  autoComplete="off"
-                  onChange={(event) => {
-                    setPath(event.target.value);
-                    // The worktree section describes the probed folder; while a new one is being
-                    // typed there is nothing true to show, so it hides until the probe answers.
-                    setRepo(undefined);
-                    setWorktree("");
-                  }}
-                />
+                <div className="relative min-w-0 flex-1">
+                  <Input
+                    id="project-folder"
+                    value={path}
+                    className={`pr-8 font-mono ${folder === "directory" ? "border-success focus-visible:border-success focus-visible:ring-success/20" : folder === "missing" ? "border-amber-500 focus-visible:border-amber-500 focus-visible:ring-amber-500/20" : ""}`}
+                    placeholder="Type or choose a project folder…"
+                    name="project-folder"
+                    autoComplete="off"
+                    aria-invalid={folder === "other" || undefined}
+                    aria-describedby={folder === "missing" || folder === "other" ? "project-folder-status" : undefined}
+                    onChange={(event) => {
+                      setPath(event.target.value);
+                      // The worktree section describes the probed folder; while a new one is being
+                      // typed there is nothing true to show, so it hides until the probe answers.
+                      setFolder("checking");
+                      setRepo(undefined);
+                      setWorktree("");
+                    }}
+                  />
+                  {folder === "directory" ? (
+                    <Check
+                      className="absolute top-1/2 right-2 size-4 -translate-y-1/2 text-success"
+                      aria-hidden="true"
+                    />
+                  ) : folder === "missing" ? (
+                    <TriangleAlert
+                      className="absolute top-1/2 right-2 size-4 -translate-y-1/2 text-amber-500"
+                      aria-hidden="true"
+                    />
+                  ) : folder === "other" ? (
+                    <CircleAlert
+                      className="absolute top-1/2 right-2 size-4 -translate-y-1/2 text-destructive"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </div>
                 <ActionIconButton
                   variant="outline"
                   size="icon"
@@ -356,6 +391,15 @@ export function NewSessionDialog({
                   <FolderOpen />
                 </ActionIconButton>
               </div>
+              {folder === "missing" ? (
+                <p id="project-folder-status" className="text-xs text-amber-600 dark:text-amber-400">
+                  This folder does not exist and will be created.
+                </p>
+              ) : folder === "other" ? (
+                <p id="project-folder-status" className="text-xs text-destructive">
+                  This path is not a folder.
+                </p>
+              ) : null}
             </div>
             {repo ? (
               <div className="space-y-2">

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -310,13 +310,9 @@ export function NewSessionDialog({
   // Everything the dialog can be asked for arrives here: the submit button, Enter from the folder field,
   // and a second click on the agent already chosen. An agent that is not installed reads them all as a
   // request to install it, which is the only one of the two it can answer.
-  const ready =
-    !installing &&
-    !creating &&
-    Boolean(
-      missing ||
-      (path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim())),
-    );
+  const folderReady =
+    path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim());
+  const ready = !installing && !creating && Boolean(missing || folderReady);
   function start() {
     if (missing?.installable) void install();
     else if (missing)

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -315,7 +315,7 @@ export function NewSessionDialog({
     !creating &&
     Boolean(
       missing ||
-        (path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim())),
+      (path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim())),
     );
   function start() {
     if (missing?.installable) void install();


### PR DESCRIPTION
## Summary
- persist actively working agent sessions so relaunches and power recovery resume them automatically with a continue prompt
- show green, amber, and red project-folder validation states
- create missing project directories safely when starting a session

## Validation
- bun run check
- bun run build
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Implemented persistent interrupted-session recovery and clearer project-folder validation, allowing active agent sessions to resume after relaunch while safely creating missing directories.

### 📊 Key Changes

- Stores working session IDs in `localStorage` and resumes interrupted non-shell agent sessions automatically, issuing a `continue` prompt after relaunch.
- Replaced the `git_repo` command with `directory_probe`, which reports whether a path is missing, a directory, or another existing path while retaining repository and worktree detection.
- Updated the new-session dialog with green, amber, and red folder states, status icons, and messages for valid, missing, and invalid paths.
- `use_directory` now resolves typed paths, creates missing directory trees, rejects non-folder paths, and blocks sensitive credential or configuration locations before creation.
- Clears persisted working state when a session exits and avoids sending agent continuation prompts to shell sessions.

### 🎯 Purpose & Impact

- Interrupted agent sessions are restored without requiring users to reopen each session manually; idle sessions retain lazy resume behavior.
- Users can start sessions in missing project folders, which are created automatically, while invalid paths are identified before submission.
- Existing repository/worktree setup continues through the new directory probe, and sensitive directories remain blocked.