### PR TITLE
Add sidebar keyboard zoom

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.26"
+version = "0.0.27"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,7 @@ import {
   writeSession,
 } from "@/output-store";
 import { SettingsDialog } from "@/settings-dialog";
-import { applyTheme, initialTheme, type Theme } from "@/theme";
+import { applyTheme, initialTheme, storedFontSize, type Theme, zoomedFontSize, zoomStep } from "@/theme";
 import { type Agent, defaultSessionName, folderName, repoName, type Session, sessionLabel } from "@/types";
 import "./App.css";
 
@@ -295,8 +295,20 @@ const RELEASE_NOTE = {
 
 const NOTIFICATIONS_KEY = "lite.notifications";
 const KEEP_AWAKE_KEY = "lite.keep-awake";
+const SIDEBAR_FONT_KEY = "lite.sidebar.fontSize";
+const INSPECTOR_FONT_KEY = "lite.inspector.fontSize";
 
 type UpdateStatus = "checking" | "available" | "rebuild" | "current" | "installing" | "error";
+
+function zoomPanelStyle(fontSize: number) {
+  const scale = fontSize / 13;
+  return {
+    width: `${100 / scale}%`,
+    height: `${100 / scale}%`,
+    transform: `scale(${scale})`,
+    transformOrigin: "top left",
+  };
+}
 
 type Editable = HTMLInputElement | HTMLTextAreaElement | HTMLElement;
 type AppMenuContext = {
@@ -1459,6 +1471,8 @@ function App() {
   // Each side collapses to a rail of icons rather than to nothing, so the panel is still there to click
   // or drag back open. Dragging past the minimum is what collapses it; the handle never goes away.
   const [shut, setShut] = useState({ sidebar: false, inspector: false });
+  const [sidebarFontSize, setSidebarFontSize] = useState(() => storedFontSize(SIDEBAR_FONT_KEY));
+  const [inspectorFontSize, setInspectorFontSize] = useState(() => storedFontSize(INSPECTOR_FONT_KEY));
   const layout = useRef<HTMLDivElement>(null);
   const sidebarPanel = useRef<PanelImperativeHandle>(null);
   const inspectorPanel = useRef<PanelImperativeHandle>(null);
@@ -1677,6 +1691,16 @@ function App() {
     function onKeyDown(event: KeyboardEvent) {
       if (event.defaultPrevented || (!event.metaKey && !event.ctrlKey)) return;
       if (event.target instanceof Element && event.target.closest('[role="dialog"]')) return;
+      const panel = event.target instanceof Element ? event.target.closest<HTMLElement>("[data-zoom-panel]") : null;
+      const step = zoomStep(event.key);
+      if (panel && step !== undefined) {
+        const sidebar = panel.dataset.zoomPanel === "sidebar";
+        const key = sidebar ? SIDEBAR_FONT_KEY : INSPECTOR_FONT_KEY;
+        const setFontSize = sidebar ? setSidebarFontSize : setInspectorFontSize;
+        setFontSize((current) => zoomedFontSize(key, current, step));
+        event.preventDefault();
+        return;
+      }
       const switchSession = event.key.toLowerCase() === "p" && (event.metaKey || (event.ctrlKey && event.shiftKey));
       if (switchSession) setSessionSwitcherOpen(true);
       else if (event.key === "n") setNewSessionOpen(true);
@@ -2814,7 +2838,12 @@ function App() {
               maxSize={SIDES.sidebar.max}
               onResize={(size) => rail("sidebar", size)}
             >
-              <aside data-context-surface className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
+              <aside
+                data-context-surface
+                data-zoom-panel="sidebar"
+                className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground"
+                style={zoomPanelStyle(sidebarFontSize)}
+              >
                 {shut.sidebar ? (
                   <ScrollArea className="min-h-0 flex-1">
                     <div className="flex animate-in flex-col items-center gap-0.5 py-1.5 fade-in duration-200">
@@ -3146,7 +3175,11 @@ function App() {
                   maxSize={SIDES.inspector.max}
                   onResize={(size) => rail("inspector", size)}
                 >
-                  <aside className="h-full border-l">
+                  <aside
+                    data-zoom-panel="inspector"
+                    className="h-full w-full border-l"
+                    style={zoomPanelStyle(inspectorFontSize)}
+                  >
                     <PanelBoundary key={selected.id}>
                       <Inspector
                         session={selected}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -76,7 +76,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { without } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput, subscribeOutput } from "@/output-store";
-import { storedFontSize, zoomedFontSize } from "@/theme";
+import { storedFontSize, zoomedFontSize, zoomStep } from "@/theme";
 import {
   type DirectoryCursor,
   type DirectoryListing,
@@ -829,8 +829,8 @@ function previewKeyDown(
     onClose();
     return;
   }
-  const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
-  if (!step && event.key !== "0") return;
+  const step = zoomStep(event.key);
+  if (step === undefined) return;
   event.preventDefault();
   zoom(step);
 }

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 
 import { subscribeOutput, writeSession } from "@/output-store";
-import { storedFontSize, type Theme, zoomedFontSize } from "@/theme";
+import { storedFontSize, type Theme, zoomedFontSize, zoomStep } from "@/theme";
 import type { Agent } from "@/types";
 
 // Surface colors follow the app tokens; ANSI colors follow GitHub light and dark, matching the code preview.
@@ -236,8 +236,8 @@ export function TerminalView({
         return false;
       }
       if (!(event.metaKey || event.ctrlKey)) return true;
-      const step = event.key === "+" || event.key === "=" ? 1 : event.key === "-" ? -1 : 0;
-      if (!step && event.key !== "0") return true;
+      const step = zoomStep(event.key);
+      if (step === undefined) return true;
       zoomRef.current(step);
       return false;
     });

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -36,3 +36,9 @@ export function zoomedFontSize(key: string, from: number, step: -1 | 0 | 1): num
   if (size !== from) localStorage.setItem(key, String(size));
   return size;
 }
+
+export function zoomStep(key: string): -1 | 0 | 1 | undefined {
+  if (key === "+" || key === "=") return 1;
+  if (key === "-") return -1;
+  if (key === "0") return 0;
+}


### PR DESCRIPTION
## Summary
- extend Command/Control +, -, and 0 zoom shortcuts to the focused sessions and inspector sidebars
- remember left and right sidebar zoom independently
- reuse one zoom-key parser across terminal, preview, and sidebar surfaces

## Validation
- `bun run check`
- `bun run build`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added independent Command/Control keyboard zoom for the sessions and inspector sidebars, while centralizing zoom-key handling across the app.

### 📊 Key Changes
- Added `+`/`=`, `-`, and `0` zoom shortcuts to the focused sidebar and inspector panels.
- Persisted sidebar and inspector font sizes independently using separate local-storage keys.
- Added panel scaling through `zoomPanelStyle`, applying zoom without changing panel layout dimensions.
- Reused the new `zoomStep` parser in the terminal and preview alongside the sidebar handlers.
- Bumped the Tauri application version from `0.0.26` to `0.0.27`.

### 🎯 Purpose & Impact
- Users can adjust or reset zoom separately in the sessions sidebar and inspector, with each panel restoring its last stored size.
- Terminal and preview zoom shortcut interpretation is now handled consistently through the shared parser.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
