### PR TITLE
Isolate release Rust build cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Cache Rust build
         uses: swatinem/rust-cache@v2
         with:
+          shared-key: release
           workspaces: src-tauri
       - name: Install Linux packages
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

- give publish builds a dedicated Rust cache namespace
- prevent debug CI artifacts from occupying the release build cache key
- allow subsequent releases to reuse optimized dependency artifacts across macOS, Linux, and Windows

## Validation

- `actionlint .github/workflows/publish.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The publish workflow now assigns Rust build caches a dedicated `release` namespace so release builds can reuse their own cached artifacts separately from other CI builds.

### 📊 Key Changes

- Added `shared-key: release` to the `swatinem/rust-cache@v2` step in `.github/workflows/publish.yml`.
- Kept caching scoped to the `src-tauri` workspace.
- Release builds now use a stable, dedicated cache key across the publish workflow.

### 🎯 Purpose & Impact

- Debug CI artifacts no longer populate the release cache namespace, allowing subsequent release builds to reuse release-specific Rust dependency artifacts.
- This changes publish-workflow caching only; no application behavior is modified.