### PR TITLE
Open sessions from desktop notifications

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.27"
+version = "0.0.28"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"
@@ -44,7 +44,7 @@ objc2 = "0.6.4"
 objc2-core-foundation = { version = "0.3.2", features = ["CFString"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
 objc2-io-kit = { version = "0.3.2", features = ["pwr_mgt"] }
-objc2-user-notifications = { version = "0.3.2", default-features = false, features = ["block2", "UNNotificationContent", "UNNotificationRequest", "UNNotificationTrigger", "UNUserNotificationCenter"] }
+objc2-user-notifications = { version = "0.3.2", default-features = false, features = ["block2", "UNNotification", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotificationTrigger", "UNUserNotificationCenter"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.12"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,13 @@ use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_updater::UpdaterExt;
 use tungstenite::Message;
 
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSObject, NSObjectProtocol};
+#[cfg(target_os = "macos")]
+use objc2_user_notifications::{
+    UNNotificationResponse, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
+};
+
 const MAX_FILE_BYTES: u64 = 500_000;
 const DIRECTORY_PAGE_SIZE: usize = 250;
 const MAX_GIT_CHANGES: usize = 500;
@@ -39,6 +46,49 @@ const SUPPORTED_KEYS: [&str; 6] = [
     "gemini",
     "kimi",
 ];
+
+#[cfg(target_os = "macos")]
+static NOTIFICATION_APP: std::sync::OnceLock<AppHandle> = std::sync::OnceLock::new();
+
+#[cfg(target_os = "macos")]
+objc2::define_class!(
+    #[unsafe(super(NSObject))]
+    struct NotificationDelegate;
+
+    unsafe impl NSObjectProtocol for NotificationDelegate {}
+
+    unsafe impl UNUserNotificationCenterDelegate for NotificationDelegate {
+        #[unsafe(method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:))]
+        #[allow(non_snake_case)]
+        fn userNotificationCenter_didReceiveNotificationResponse_withCompletionHandler(
+            &self,
+            _center: &UNUserNotificationCenter,
+            response: &UNNotificationResponse,
+            completion_handler: &block2::DynBlock<dyn Fn()>,
+        ) {
+            if let Some(app) = NOTIFICATION_APP.get() {
+                let session_id = response.notification().request().identifier().to_string();
+                let _ = app.emit("notification-clicked", session_id);
+            }
+            completion_handler.call(());
+        }
+    }
+);
+
+#[cfg(target_os = "macos")]
+static NOTIFICATION_DELEGATE: std::sync::OnceLock<objc2::rc::Retained<NotificationDelegate>> =
+    std::sync::OnceLock::new();
+
+#[cfg(target_os = "macos")]
+fn install_notification_delegate(app: &AppHandle) {
+    use objc2::{AnyThread, runtime::ProtocolObject};
+
+    let _ = NOTIFICATION_APP.set(app.clone());
+    let delegate = NOTIFICATION_DELEGATE
+        .get_or_init(|| unsafe { objc2::msg_send![NotificationDelegate::alloc(), init] });
+    UNUserNotificationCenter::currentNotificationCenter()
+        .setDelegate(Some(ProtocolObject::from_ref(&**delegate)));
+}
 
 #[tauri::command]
 fn notifications_supported() -> bool {
@@ -77,7 +127,7 @@ fn request_notification_permission() -> bool {
 
 #[cfg(target_os = "macos")]
 #[tauri::command]
-fn send_notification(title: String) {
+fn send_notification(title: String, session_id: String) {
     use objc2_foundation::NSString;
     use objc2_user_notifications::{
         UNMutableNotificationContent, UNNotificationRequest, UNUserNotificationCenter,
@@ -88,9 +138,9 @@ fn send_notification(title: String) {
     }
     let content = UNMutableNotificationContent::new();
     content.setTitle(&NSString::from_str(&title));
-    content.setBody(&NSString::from_str("This session needs your attention."));
+    content.setBody(&NSString::from_str("Ready"));
     let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
-        &NSString::from_str(&uuid::Uuid::new_v4().to_string()),
+        &NSString::from_str(&session_id),
         &content,
         None,
     );
@@ -100,7 +150,7 @@ fn send_notification(title: String) {
 
 #[cfg(not(target_os = "macos"))]
 #[tauri::command]
-fn send_notification() {}
+fn send_notification(_title: String, _session_id: String) {}
 
 #[derive(Clone, Copy)]
 struct CodexProvider {
@@ -5097,7 +5147,10 @@ pub fn run() {
             app.manage(load_provider_sessions(app.handle()));
             app.manage(load_codex_server(app.handle())?);
             #[cfg(target_os = "macos")]
-            describe_app(app.handle())?;
+            {
+                describe_app(app.handle())?;
+                install_notification_delegate(app.handle());
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,7 +26,8 @@ use tungstenite::Message;
 use objc2_foundation::{NSObject, NSObjectProtocol};
 #[cfg(target_os = "macos")]
 use objc2_user_notifications::{
-    UNNotificationResponse, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
+    UNNotificationDefaultActionIdentifier, UNNotificationResponse, UNUserNotificationCenter,
+    UNUserNotificationCenterDelegate,
 };
 
 const MAX_FILE_BYTES: u64 = 500_000;
@@ -47,12 +48,13 @@ const SUPPORTED_KEYS: [&str; 6] = [
     "kimi",
 ];
 
-#[cfg(target_os = "macos")]
-static NOTIFICATION_APP: std::sync::OnceLock<AppHandle> = std::sync::OnceLock::new();
+#[derive(Default)]
+struct PendingNotification(Mutex<Option<String>>);
 
 #[cfg(target_os = "macos")]
 objc2::define_class!(
     #[unsafe(super(NSObject))]
+    #[ivars = AppHandle]
     struct NotificationDelegate;
 
     unsafe impl NSObjectProtocol for NotificationDelegate {}
@@ -66,9 +68,19 @@ objc2::define_class!(
             response: &UNNotificationResponse,
             completion_handler: &block2::DynBlock<dyn Fn()>,
         ) {
-            if let Some(app) = NOTIFICATION_APP.get() {
+            use objc2::DefinedClass;
+
+            let action = response.actionIdentifier();
+            // SAFETY: UserNotifications provides this immutable framework identifier.
+            if &*action == unsafe { UNNotificationDefaultActionIdentifier } {
                 let session_id = response.notification().request().identifier().to_string();
-                let _ = app.emit("notification-clicked", session_id);
+                *self
+                    .ivars()
+                    .state::<PendingNotification>()
+                    .0
+                    .lock()
+                    .unwrap() = Some(session_id);
+                let _ = self.ivars().emit("notification-clicked", ());
             }
             completion_handler.call(());
         }
@@ -76,16 +88,24 @@ objc2::define_class!(
 );
 
 #[cfg(target_os = "macos")]
+impl NotificationDelegate {
+    fn new(app: AppHandle) -> objc2::rc::Retained<Self> {
+        use objc2::AnyThread;
+
+        let this = Self::alloc().set_ivars(app);
+        unsafe { objc2::msg_send![super(this), init] }
+    }
+}
+
+#[cfg(target_os = "macos")]
 static NOTIFICATION_DELEGATE: std::sync::OnceLock<objc2::rc::Retained<NotificationDelegate>> =
     std::sync::OnceLock::new();
 
 #[cfg(target_os = "macos")]
 fn install_notification_delegate(app: &AppHandle) {
-    use objc2::{AnyThread, runtime::ProtocolObject};
+    use objc2::runtime::ProtocolObject;
 
-    let _ = NOTIFICATION_APP.set(app.clone());
-    let delegate = NOTIFICATION_DELEGATE
-        .get_or_init(|| unsafe { objc2::msg_send![NotificationDelegate::alloc(), init] });
+    let delegate = NOTIFICATION_DELEGATE.get_or_init(|| NotificationDelegate::new(app.clone()));
     UNUserNotificationCenter::currentNotificationCenter()
         .setDelegate(Some(ProtocolObject::from_ref(&**delegate)));
 }
@@ -98,6 +118,11 @@ fn notifications_supported() -> bool {
                 .ancestors()
                 .any(|path| path.extension().is_some_and(|extension| extension == "app"))
         })
+}
+
+#[tauri::command]
+fn notification_session(pending: State<'_, PendingNotification>) -> Option<String> {
+    pending.0.lock().unwrap().take()
 }
 
 #[cfg(target_os = "macos")]
@@ -5141,6 +5166,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(Sessions::default())
         .manage(WakeLock::default())
+        .manage(PendingNotification::default())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             app.manage(load_roots(app.handle()));
@@ -5191,6 +5217,7 @@ pub fn run() {
             save_api_key,
             delete_api_key,
             notifications_supported,
+            notification_session,
             request_notification_permission,
             send_notification,
             check_update,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1669,14 +1669,6 @@ function App() {
     return () => void closing.then((unlisten) => unlisten());
   }, []);
 
-  useEffect(() => {
-    const clicked = listen<string>("notification-clicked", ({ payload }) => {
-      const session = sessionsRef.current.find((item) => item.id === payload);
-      if (session) openRef.current(session);
-    });
-    return () => void clicked.then((unlisten) => unlisten());
-  }, []);
-
   // Opening a session reads its current notifications. A later notification remains highlighted until
   // the user returns to that session.
   useEffect(() => {
@@ -1879,6 +1871,12 @@ function App() {
     let unlistenOutput: (() => void) | undefined;
     let unlistenExit: (() => void) | undefined;
     let unlistenAgent: (() => void) | undefined;
+    let unlistenNotification: (() => void) | undefined;
+    const openNotification = () =>
+      invoke<string | null>("notification_session").then((sessionId) => {
+        const session = sessionsRef.current.find((item) => item.id === sessionId);
+        if (session) openRef.current(session);
+      });
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
@@ -1918,16 +1916,20 @@ function App() {
           return next;
         });
       }),
-    ]).then(([output, exit, agent]) => {
+      listen("notification-clicked", () => void openNotification()),
+    ]).then(([output, exit, agent, notification]) => {
       if (disposed) {
         output();
         exit();
         agent();
+        notification();
         return;
       }
       unlistenOutput = output;
       unlistenExit = exit;
       unlistenAgent = agent;
+      unlistenNotification = notification;
+      void openNotification();
     });
     const timers = workTimers.current;
     return () => {
@@ -1935,6 +1937,7 @@ function App() {
       unlistenOutput?.();
       unlistenExit?.();
       unlistenAgent?.();
+      unlistenNotification?.();
       for (const timer of timers.values()) window.clearTimeout(timer);
       timers.clear();
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -683,11 +683,11 @@ const SESSION_STATUS = {
   working: { dot: "bg-sky-500 animate-pulse motion-reduce:animate-none", label: "Connected, working" },
   attention: {
     dot: "bg-amber-500 animate-attention motion-reduce:animate-none",
-    label: "Connected, needs attention",
+    label: "Connected, ready",
   },
 } as const;
 const SESSION_STATE_LABELS = {
-  attention: "Needs attention",
+  attention: "Ready",
   working: "Working",
   idle: "Idle",
   disconnected: "Disconnected",
@@ -1669,6 +1669,14 @@ function App() {
     return () => void closing.then((unlisten) => unlisten());
   }, []);
 
+  useEffect(() => {
+    const clicked = listen<string>("notification-clicked", ({ payload }) => {
+      const session = sessionsRef.current.find((item) => item.id === payload);
+      if (session) openRef.current(session);
+    });
+    return () => void clicked.then((unlisten) => unlisten());
+  }, []);
+
   // Opening a session reads its current notifications. A later notification remains highlighted until
   // the user returns to that session.
   useEffect(() => {
@@ -1884,7 +1892,7 @@ function App() {
         ) {
           const session = sessionsRef.current.find((item) => item.id === payload.sessionId);
           if (notificationsRef.current && session)
-            void invoke("send_notification", { title: session.name }).catch(() => {});
+            void invoke("send_notification", { title: session.name, sessionId: session.id }).catch(() => {});
         }
         if (activity !== false) markWorking(payload.sessionId);
       }),
@@ -2875,9 +2883,7 @@ function App() {
                                 variant="ghost"
                                 size="icon-sm"
                                 aria-pressed={session.id === selectedId}
-                                aria-label={
-                                  attention.includes(session.id) ? `${session.name}; needs attention` : session.name
-                                }
+                                aria-label={attention.includes(session.id) ? `${session.name}; ready` : session.name}
                                 data-context-session={session.id}
                                 className={
                                   session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -220,7 +220,7 @@ export function SettingsDialog({
                     </ItemMedia>
                     <ItemContent>
                       <ItemTitle>macOS Notifications</ItemTitle>
-                      <ItemDescription>Notify you when a background session needs attention.</ItemDescription>
+                      <ItemDescription>Notify you when a background session is ready.</ItemDescription>
                     </ItemContent>
                     <ItemActions>
                       <Switch


### PR DESCRIPTION
## Summary
- open the exact session when its macOS notification is clicked
- simplify notification and session status copy to Ready
- bump Lite to v0.0.28

## Validation
- bun run check
- bun run build
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

macOS notifications now open their associated session when clicked, use “Ready” status copy, and update Lite to version 0.0.28.

### 📊 Key Changes

- Added a macOS `UNUserNotificationCenter` delegate that captures the clicked notification’s session ID and emits a `notification-clicked` event.
- Changed notification requests to use the session ID as their identifier and added the `notification_session` command for retrieving pending session IDs.
- Updated the frontend to listen for notification clicks, find the matching session, and open it, including notifications received before the listener is registered.
- Changed notification text, session labels, accessibility text, and settings copy from “needs attention” to “Ready”.
- Bumped the Rust package version from `0.0.27` to `0.0.28` and enabled the required UserNotifications response features.

### 🎯 Purpose & Impact

- Clicking a macOS desktop notification opens the corresponding session instead of only displaying the notification.
- Notification and session-status workflows now describe attention-required sessions as “Ready”.
- Non-macOS notification handling remains a no-op while accepting the updated notification arguments.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
