### PR TITLE
Name sessions at creation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1941,7 +1941,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.29"
+version = "0.0.30"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4290,7 +4290,6 @@ fn owned_worktree(git: &Path, repo: &Path, root_id: &str, branch: &str) -> Optio
 struct Repository {
     branch: String,
     root: String,
-    worktree: String,
 }
 
 #[derive(Serialize)]
@@ -4332,7 +4331,6 @@ async fn directory_probe(app: AppHandle, path: String) -> Result<DirectoryProbe,
         exists: true,
         is_directory: true,
         repository: Some(Repository {
-            worktree: path_text(&candidate.path),
             branch: candidate.branch,
             root: path_text(&root),
         }),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4290,6 +4290,7 @@ fn owned_worktree(git: &Path, repo: &Path, root_id: &str, branch: &str) -> Optio
 struct Repository {
     branch: String,
     root: String,
+    worktree: String,
 }
 
 #[derive(Serialize)]
@@ -4331,6 +4332,7 @@ async fn directory_probe(app: AppHandle, path: String) -> Result<DirectoryProbe,
         exists: true,
         is_directory: true,
         repository: Some(Repository {
+            worktree: path_text(&candidate.path),
             branch: candidate.branch,
             root: path_text(&root),
         }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3536,12 +3536,7 @@ function App() {
               </DialogFooter>
             </DialogContent>
           </Dialog>
-          <NewSessionDialog
-            open={newSessionOpen}
-            onOpenChange={setNewSessionOpen}
-            onCreate={createSession}
-            sessions={sessions}
-          />
+          <NewSessionDialog open={newSessionOpen} onOpenChange={setNewSessionOpen} onCreate={createSession} />
           <SessionSwitcher
             open={sessionSwitcherOpen}
             sessions={switcherSessions}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -261,18 +261,16 @@ export function NewSessionDialog({
           return;
         }
       }
-      // A name the user gave at creation is theirs, so it is marked renamed and no window title
-      // or first prompt replaces it, the same as a rename from the sidebar would.
-      const project = title.trim() || defaultSessionName(folder.path);
+      const name = title.trim();
       onCreate({
         id: crypto.randomUUID(),
         agent: choice.agent,
         provider: choice.provider,
         cwd: folder.path,
         rootId: folder.id,
-        name: project,
+        name: name || defaultSessionName(folder.path),
         running: false,
-        renamed: Boolean(title.trim()),
+        renamed: Boolean(name),
         worktree,
         repo: root || undefined,
       });
@@ -406,12 +404,12 @@ export function NewSessionDialog({
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="session-title" className={SECTION}>
-                Session name
+                Session name (optional)
               </Label>
               <Input
                 id="session-title"
                 value={title}
-                placeholder="Name the session, or leave it to name itself…"
+                placeholder="Name this session…"
                 name="session-title"
                 autoComplete="off"
                 onChange={(event) => setTitle(event.target.value)}
@@ -422,7 +420,7 @@ export function NewSessionDialog({
                 <div className="flex items-center justify-between gap-3">
                   <div className="min-w-0">
                     <Label htmlFor="new-worktree" className={SECTION}>
-                      Worktree
+                      Worktree (optional)
                     </Label>
                     <p className="text-xs text-muted-foreground">
                       {sharing

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -404,7 +404,10 @@ export function NewSessionDialog({
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="session-title" className={SECTION}>
-                Session name (optional)
+                Session name{" "}
+                <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
+                  Optional
+                </span>
               </Label>
               <Input
                 id="session-title"
@@ -420,7 +423,10 @@ export function NewSessionDialog({
                 <div className="flex items-center justify-between gap-3">
                   <div className="min-w-0">
                     <Label htmlFor="new-worktree" className={SECTION}>
-                      Worktree (optional)
+                      Worktree{" "}
+                      <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
+                        Optional
+                      </span>
                     </Label>
                     <p className="text-xs text-muted-foreground">
                       {sharing

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -227,6 +227,8 @@ export function NewSessionDialog({
       void invoke("revoke_directory", { rootId: directory.id });
       setDirectory(undefined);
     }
+    // A cancelled dialog stays mounted, so a name typed into it must not wait for the next session.
+    if (!open) setTitle("");
     onOpenChange(open);
   }
 

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -88,6 +88,7 @@ export function NewSessionDialog({
   const [worktree, setWorktree] = useState("");
   const [worktreeOn, setWorktreeOn] = useState(false);
   const [branch, setBranch] = useState("");
+  const [title, setTitle] = useState("");
   const choice = choices.find((option) => option.id === choiceId) ?? choices[0];
   const status = availability[choice.id];
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
@@ -258,7 +259,9 @@ export function NewSessionDialog({
           return;
         }
       }
-      const project = defaultSessionName(folder.path);
+      // A name the user gave at creation is theirs, so it is marked renamed and no window title
+      // or first prompt replaces it, the same as a rename from the sidebar would.
+      const project = title.trim() || defaultSessionName(folder.path);
       onCreate({
         id: crypto.randomUUID(),
         agent: choice.agent,
@@ -267,10 +270,12 @@ export function NewSessionDialog({
         rootId: folder.id,
         name: project,
         running: false,
+        renamed: Boolean(title.trim()),
         worktree,
         repo: root || undefined,
       });
       setDirectory(undefined);
+      setTitle("");
       onOpenChange(false);
     } finally {
       setCreating(false);
@@ -396,6 +401,19 @@ export function NewSessionDialog({
                   This path is not a folder.
                 </p>
               ) : null}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="session-title" className={SECTION}>
+                Session name
+              </Label>
+              <Input
+                id="session-title"
+                value={title}
+                placeholder="Name the session, or leave it to name itself…"
+                name="session-title"
+                autoComplete="off"
+                onChange={(event) => setTitle(event.target.value)}
+              />
             </div>
             {repo ? (
               <div className="space-y-2">

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -24,6 +24,9 @@ import { defaultSessionName, type Session, sessionLabel } from "@/types";
 
 const choices = [...Object.values(AUTH_PROVIDERS), { id: "shell", agent: "shell" as const, provider: undefined }];
 const harnesses = [...new Set(choices.map((option) => option.agent).filter((agent) => agent !== "shell"))];
+const CHOICE_KEY = "lite.newSession.choice.v1";
+const NAME_KEY = "lite.newSession.name.v1";
+const WORKTREE_KEY = "lite.newSession.worktree.v1";
 
 // The quiet heading that separates the two questions the dialog asks, in the sidebar's own label style.
 const SECTION = "text-[11px] font-medium tracking-wide text-muted-foreground uppercase";
@@ -60,7 +63,10 @@ export function NewSessionDialog({
   onOpenChange: (open: boolean) => void;
   onCreate: (session: Session) => void;
 }) {
-  const [choiceId, setChoiceId] = useState(choices[0].id);
+  const [choiceId, setChoiceId] = useState(() => {
+    const stored = localStorage.getItem(CHOICE_KEY);
+    return choices.find((option) => option.id === stored)?.id ?? choices[0].id;
+  });
   const [directory, setDirectory] = useState<DirectoryGrant>();
   const [path, setPath] = useState("");
   const [availability, setAvailability] = useState<Record<string, Availability>>({});
@@ -76,9 +82,11 @@ export function NewSessionDialog({
   const [repo, setRepo] = useState<string | null>();
   const [folder, setFolder] = useState<"checking" | "missing" | "directory" | "other">("checking");
   const [worktree, setWorktree] = useState("");
-  const [worktreeOn, setWorktreeOn] = useState(false);
+  const [worktreeOn, setWorktreeOn] = useState(() => localStorage.getItem(WORKTREE_KEY) === "true");
   const [branch, setBranch] = useState("");
-  const [title, setTitle] = useState<string>();
+  const [title, setTitle] = useState<string | undefined>(() =>
+    localStorage.getItem(NAME_KEY) === "true" ? "" : undefined,
+  );
   const choice = choices.find((option) => option.id === choiceId) ?? choices[0];
   const status = availability[choice.id];
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
@@ -110,7 +118,6 @@ export function NewSessionDialog({
       setRepo(null);
       setFolder("checking");
       setWorktree("");
-      setWorktreeOn(false);
       return;
     }
     setRepo(undefined);
@@ -123,7 +130,6 @@ export function NewSessionDialog({
           const root = repository?.root ?? null;
           setRepo(root);
           setWorktree(repository?.worktree ?? "");
-          setWorktreeOn(false);
           setBranch(repository?.branch ?? "");
         })
         .catch(() => {
@@ -216,7 +222,7 @@ export function NewSessionDialog({
       setDirectory(undefined);
     }
     // A cancelled dialog stays mounted, so a name typed into it must not wait for the next session.
-    if (!open) setTitle(undefined);
+    if (!open) setTitle((current) => (current === undefined ? undefined : ""));
     onOpenChange(open);
   }
 
@@ -263,7 +269,7 @@ export function NewSessionDialog({
         repo: root || undefined,
       });
       setDirectory(undefined);
-      setTitle(undefined);
+      setTitle((current) => (current === undefined ? undefined : ""));
       onOpenChange(false);
     } finally {
       setCreating(false);
@@ -391,7 +397,7 @@ export function NewSessionDialog({
               ) : null}
             </div>
             <div className="space-y-2">
-              <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
                 <Label htmlFor="custom-session-name" className={SECTION}>
                   Name{" "}
                   <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
@@ -401,7 +407,10 @@ export function NewSessionDialog({
                 <Switch
                   id="custom-session-name"
                   checked={title !== undefined}
-                  onCheckedChange={(checked) => setTitle(checked ? "" : undefined)}
+                  onCheckedChange={(checked) => {
+                    localStorage.setItem(NAME_KEY, String(checked));
+                    setTitle(checked ? "" : undefined);
+                  }}
                 />
               </div>
               {title !== undefined ? (
@@ -418,14 +427,21 @@ export function NewSessionDialog({
             </div>
             {repo ? (
               <div className="space-y-2">
-                <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
                   <Label htmlFor="new-worktree" className={SECTION}>
                     Worktree{" "}
                     <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
                       Optional
                     </span>
                   </Label>
-                  <Switch id="new-worktree" checked={worktreeOn} onCheckedChange={setWorktreeOn} />
+                  <Switch
+                    id="new-worktree"
+                    checked={worktreeOn}
+                    onCheckedChange={(checked) => {
+                      localStorage.setItem(WORKTREE_KEY, String(checked));
+                      setWorktreeOn(checked);
+                    }}
+                  />
                 </div>
                 {worktreeOn ? (
                   <div className="min-w-0 space-y-1.5">
@@ -477,7 +493,13 @@ export function NewSessionDialog({
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}
-                        onClick={() => (active && ready ? start() : setChoiceId(option.id))}
+                        onClick={() => {
+                          if (active && ready) start();
+                          else {
+                            localStorage.setItem(CHOICE_KEY, option.id);
+                            setChoiceId(option.id);
+                          }
+                        }}
                       >
                         <ProviderIcon agent={option.agent} provider={option.provider} className="size-5" />
                         <div

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -78,7 +78,7 @@ export function NewSessionDialog({
   const [worktree, setWorktree] = useState("");
   const [worktreeOn, setWorktreeOn] = useState(false);
   const [branch, setBranch] = useState("");
-  const [title, setTitle] = useState("");
+  const [title, setTitle] = useState<string>();
   const choice = choices.find((option) => option.id === choiceId) ?? choices[0];
   const status = availability[choice.id];
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
@@ -216,7 +216,7 @@ export function NewSessionDialog({
       setDirectory(undefined);
     }
     // A cancelled dialog stays mounted, so a name typed into it must not wait for the next session.
-    if (!open) setTitle("");
+    if (!open) setTitle(undefined);
     onOpenChange(open);
   }
 
@@ -249,7 +249,7 @@ export function NewSessionDialog({
           return;
         }
       }
-      const name = title.trim();
+      const name = title?.trim() ?? "";
       onCreate({
         id: crypto.randomUUID(),
         agent: choice.agent,
@@ -263,7 +263,7 @@ export function NewSessionDialog({
         repo: root || undefined,
       });
       setDirectory(undefined);
-      setTitle("");
+      setTitle(undefined);
       onOpenChange(false);
     } finally {
       setCreating(false);
@@ -390,21 +390,28 @@ export function NewSessionDialog({
                 </p>
               ) : null}
             </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="session-title" className={SECTION}>
-                Session name{" "}
-                <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
-                  Optional
-                </span>
-              </Label>
-              <Input
-                id="session-title"
-                value={title}
-                placeholder="Name this session…"
-                name="session-title"
-                autoComplete="off"
-                onChange={(event) => setTitle(event.target.value)}
-              />
+            <div className="space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <Label htmlFor="custom-session-name" className={SECTION}>
+                  Custom session name
+                </Label>
+                <Switch
+                  id="custom-session-name"
+                  checked={title !== undefined}
+                  onCheckedChange={(checked) => setTitle(checked ? "" : undefined)}
+                />
+              </div>
+              {title !== undefined ? (
+                <Input
+                  id="session-title"
+                  value={title}
+                  placeholder="Name this session…"
+                  name="session-title"
+                  autoComplete="off"
+                  aria-label="Session name"
+                  onChange={(event) => setTitle(event.target.value)}
+                />
+              ) : null}
             </div>
             {repo ? (
               <div className="space-y-2">

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -36,7 +36,6 @@ interface DirectoryGrant {
 interface Repository {
   branch: string;
   root: string;
-  worktree: string;
 }
 
 interface DirectoryProbe {
@@ -75,7 +74,6 @@ export function NewSessionDialog({
   // Undefined while checking, null outside a repository, otherwise the repository's main checkout.
   const [repo, setRepo] = useState<string | null>();
   const [folder, setFolder] = useState<"checking" | "missing" | "directory" | "other">("checking");
-  const [worktree, setWorktree] = useState("");
   const [worktreeOn, setWorktreeOn] = useState(false);
   const [branch, setBranch] = useState("");
   const [title, setTitle] = useState("");
@@ -109,7 +107,6 @@ export function NewSessionDialog({
     if (!isOpen || !path.trim()) {
       setRepo(null);
       setFolder("checking");
-      setWorktree("");
       setWorktreeOn(false);
       return;
     }
@@ -122,7 +119,6 @@ export function NewSessionDialog({
           setFolder(isDirectory ? "directory" : exists ? "other" : "missing");
           const root = repository?.root ?? null;
           setRepo(root);
-          setWorktree(repository?.worktree ?? "");
           setWorktreeOn(false);
           setBranch(repository?.branch ?? "");
         })
@@ -130,7 +126,6 @@ export function NewSessionDialog({
           if (!disposed) {
             setRepo(null);
             setFolder("other");
-            setWorktree("");
           }
         });
     }, 250);
@@ -187,7 +182,6 @@ export function NewSessionDialog({
         setPath(selected.path);
         setFolder("directory");
         setRepo(undefined);
-        setWorktree("");
       }
     } catch (reason) {
       setError(String(reason));
@@ -350,7 +344,6 @@ export function NewSessionDialog({
                       // typed there is nothing true to show, so it hides until the probe answers.
                       setFolder("checking");
                       setRepo(undefined);
-                      setWorktree("");
                     }}
                   />
                   {folder === "directory" ? (
@@ -415,22 +408,17 @@ export function NewSessionDialog({
                   <Switch id="new-worktree" checked={worktreeOn} onCheckedChange={setWorktreeOn} />
                 </div>
                 {worktreeOn ? (
-                  <div className="min-w-0 space-y-1.5">
-                    <Label htmlFor="worktree-branch">New branch</Label>
-                    <Input
-                      id="worktree-branch"
-                      value={branch}
-                      className="font-mono"
-                      placeholder="Branch for the worktree…"
-                      name="worktree-branch"
-                      autoComplete="off"
-                      spellCheck={false}
-                      onChange={(event) => setBranch(event.target.value)}
-                    />
-                    <p className="max-w-full truncate font-mono text-xs text-muted-foreground" title={worktree}>
-                      {worktree}
-                    </p>
-                  </div>
+                  <Input
+                    id="worktree-branch"
+                    value={branch}
+                    className="font-mono"
+                    placeholder="New branch name…"
+                    name="worktree-branch"
+                    autoComplete="off"
+                    spellCheck={false}
+                    aria-label="New branch"
+                    onChange={(event) => setBranch(event.target.value)}
+                  />
                 ) : null}
               </div>
             ) : null}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -393,7 +393,10 @@ export function NewSessionDialog({
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-3">
                 <Label htmlFor="custom-session-name" className={SECTION}>
-                  Custom session name
+                  Name{" "}
+                  <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
+                    Optional
+                  </span>
                 </Label>
                 <Switch
                   id="custom-session-name"
@@ -417,7 +420,10 @@ export function NewSessionDialog({
               <div className="space-y-2">
                 <div className="flex items-center justify-between gap-3">
                   <Label htmlFor="new-worktree" className={SECTION}>
-                    Create isolated worktree
+                    Worktree{" "}
+                    <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
+                      Optional
+                    </span>
                   </Label>
                   <Switch id="new-worktree" checked={worktreeOn} onCheckedChange={setWorktreeOn} />
                 </div>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -36,6 +36,7 @@ interface DirectoryGrant {
 interface Repository {
   branch: string;
   root: string;
+  worktree: string;
 }
 
 interface DirectoryProbe {
@@ -74,6 +75,7 @@ export function NewSessionDialog({
   // Undefined while checking, null outside a repository, otherwise the repository's main checkout.
   const [repo, setRepo] = useState<string | null>();
   const [folder, setFolder] = useState<"checking" | "missing" | "directory" | "other">("checking");
+  const [worktree, setWorktree] = useState("");
   const [worktreeOn, setWorktreeOn] = useState(false);
   const [branch, setBranch] = useState("");
   const [title, setTitle] = useState("");
@@ -107,6 +109,7 @@ export function NewSessionDialog({
     if (!isOpen || !path.trim()) {
       setRepo(null);
       setFolder("checking");
+      setWorktree("");
       setWorktreeOn(false);
       return;
     }
@@ -119,6 +122,7 @@ export function NewSessionDialog({
           setFolder(isDirectory ? "directory" : exists ? "other" : "missing");
           const root = repository?.root ?? null;
           setRepo(root);
+          setWorktree(repository?.worktree ?? "");
           setWorktreeOn(false);
           setBranch(repository?.branch ?? "");
         })
@@ -126,6 +130,7 @@ export function NewSessionDialog({
           if (!disposed) {
             setRepo(null);
             setFolder("other");
+            setWorktree("");
           }
         });
     }, 250);
@@ -182,6 +187,7 @@ export function NewSessionDialog({
         setPath(selected.path);
         setFolder("directory");
         setRepo(undefined);
+        setWorktree("");
       }
     } catch (reason) {
       setError(String(reason));
@@ -344,6 +350,7 @@ export function NewSessionDialog({
                       // typed there is nothing true to show, so it hides until the probe answers.
                       setFolder("checking");
                       setRepo(undefined);
+                      setWorktree("");
                     }}
                   />
                   {folder === "directory" ? (
@@ -408,17 +415,22 @@ export function NewSessionDialog({
                   <Switch id="new-worktree" checked={worktreeOn} onCheckedChange={setWorktreeOn} />
                 </div>
                 {worktreeOn ? (
-                  <Input
-                    id="worktree-branch"
-                    value={branch}
-                    className="font-mono"
-                    placeholder="New branch name…"
-                    name="worktree-branch"
-                    autoComplete="off"
-                    spellCheck={false}
-                    aria-label="New branch"
-                    onChange={(event) => setBranch(event.target.value)}
-                  />
+                  <div className="min-w-0 space-y-1.5">
+                    <Label htmlFor="worktree-branch">New branch</Label>
+                    <Input
+                      id="worktree-branch"
+                      value={branch}
+                      className="font-mono"
+                      placeholder="Branch for the worktree…"
+                      name="worktree-branch"
+                      autoComplete="off"
+                      spellCheck={false}
+                      onChange={(event) => setBranch(event.target.value)}
+                    />
+                    <p className="max-w-full truncate font-mono text-xs text-muted-foreground" title={worktree}>
+                      {worktree}
+                    </p>
+                  </div>
                 ) : null}
               </div>
             ) : null}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -28,14 +28,6 @@ const harnesses = [...new Set(choices.map((option) => option.agent).filter((agen
 // The quiet heading that separates the two questions the dialog asks, in the sidebar's own label style.
 const SECTION = "text-[11px] font-medium tracking-wide text-muted-foreground uppercase";
 
-// Two sessions share a project when they sit in the same repository — which a worktree's path
-// cannot say, since Lite worktrees live beside the checkout rather than under it, so the repo
-// recorded at creation answers. Sessions older than that record fall back to their path.
-function sharesRepo(session: Session, repo: string) {
-  if (session.repo) return session.repo === repo;
-  return session.cwd === repo || session.cwd.startsWith(`${repo}/`) || session.cwd.startsWith(`${repo}\\`);
-}
-
 interface DirectoryGrant {
   id: string;
   path: string;
@@ -63,12 +55,10 @@ export function NewSessionDialog({
   open: isOpen,
   onOpenChange,
   onCreate,
-  sessions,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreate: (session: Session) => void;
-  sessions: Session[];
 }) {
   const [choiceId, setChoiceId] = useState(choices[0].id);
   const [directory, setDirectory] = useState<DirectoryGrant>();
@@ -93,8 +83,6 @@ export function NewSessionDialog({
   const status = availability[choice.id];
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
   const missing = status && !status.available ? status : undefined;
-  // Sessions already working in this repository, which is the case a worktree exists for.
-  const sharing = repo ? sessions.filter((session) => sharesRepo(session, repo)).length : 0;
   // Dialog checks are independent, so one slow registry request never holds up another harness.
   useEffect(() => {
     if (!isOpen) return;
@@ -421,24 +409,14 @@ export function NewSessionDialog({
             {repo ? (
               <div className="space-y-2">
                 <div className="flex items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <Label htmlFor="new-worktree" className={SECTION}>
-                      Worktree{" "}
-                      <span className="text-[10px] font-normal tracking-normal text-muted-foreground/70 normal-case">
-                        Optional
-                      </span>
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      {sharing
-                        ? `${sharing} session${sharing === 1 ? "" : "s"} already work${sharing === 1 ? "s" : ""} in this project`
-                        : "Isolate this session from the main checkout"}
-                    </p>
-                  </div>
+                  <Label htmlFor="new-worktree" className={SECTION}>
+                    Create isolated worktree
+                  </Label>
                   <Switch id="new-worktree" checked={worktreeOn} onCheckedChange={setWorktreeOn} />
                 </div>
                 {worktreeOn ? (
                   <div className="min-w-0 space-y-1.5">
-                    <Label htmlFor="worktree-branch">Branch</Label>
+                    <Label htmlFor="worktree-branch">New branch</Label>
                     <Input
                       id="worktree-branch"
                       value={branch}


### PR DESCRIPTION
- Adds an optional **Session name** field to the New session dialog, between the project folder and the agent choice.
- A name given at creation sets `renamed: true`, so the window title and first prompt never overwrite it — the same protection a sidebar rename already gets.
- Leaving the field empty keeps the existing auto-naming behavior unchanged.
- Saves the rename trip through the sidebar when juggling many sessions with different purposes.

![Session name field in the New session dialog](https://gist.githubusercontent.com/Laughing-q/bcadc7dea160f4e5709a72592c3a3e87/raw/session-name.png)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds an optional session name field to the new-session dialog, allowing users to name sessions at creation.

### 📊 Key Changes
- Adds a controlled “Session name” input with a descriptive placeholder.
- Uses the trimmed custom title when creating a session, falling back to the default folder-based name when left blank.
- Marks manually named sessions as renamed and resets the title field after creation.

### 🎯 Purpose & Impact
- Gives users immediate control over session names without requiring a later sidebar rename.
- Preserves existing automatic naming behavior for sessions without a custom title.
- Prevents manually chosen names from being replaced by window titles or initial prompts.