### PR TITLE
Finish agent performance follow-ups

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1955,6 +1955,7 @@ dependencies = [
  "objc2-user-notifications",
  "portable-pty",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sysinfo",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -980,6 +980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1953,6 +1954,7 @@ dependencies = [
  "objc2-io-kit",
  "objc2-user-notifications",
  "portable-pty",
+ "reqwest",
  "serde",
  "serde_json",
  "sysinfo",
@@ -2820,6 +2822,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ toml_edit = "0.25"
 atomicwrites = "0.4.4"
 portable-pty = "0.9.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "rustls-no-provider"] }
+rustls = { version = "0.23.43", default-features = false, features = ["ring", "std"] }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 tauri-plugin-dialog = "2.7.2"
 tungstenite = "0.30"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.30"
+version = "0.0.31"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 toml_edit = "0.25"
 atomicwrites = "0.4.4"
 portable-pty = "0.9.0"
+reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "rustls-no-provider"] }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 tauri-plugin-dialog = "2.7.2"
 tungstenite = "0.30"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1150,6 +1150,9 @@ fn claude_settings(app: &AppHandle, session_id: &str, run_id: &str) -> Result<Pa
             "preferredNotifChannel": "iterm2",
             "statusLine": { "type": "command", "command": status, "refreshInterval": 1 },
             "hooks": {
+                "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }],
+                "PostToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }],
+                "PostToolUseFailure": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }]
             }
@@ -1160,9 +1163,9 @@ fn claude_settings(app: &AppHandle, session_id: &str, run_id: &str) -> Result<Pa
     Ok(settings_path)
 }
 
-fn activity_key(input: &serde_json::Value) -> Option<&str> {
+fn activity_key<'a>(input: &'a serde_json::Value, field: &str) -> Option<&'a str> {
     input
-        .get("agent_id")
+        .get(field)
         .and_then(serde_json::Value::as_str)
         .filter(|value| {
             value.chars().all(|character| {
@@ -1183,13 +1186,23 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
     match event {
-        "SubagentStart" => {
-            if let Some(key) = activity_key(&input) {
+        "PreToolUse" | "SubagentStart" => {
+            let field = if event == "PreToolUse" {
+                "tool_use_id"
+            } else {
+                "agent_id"
+            };
+            if let Some(key) = activity_key(&input, field) {
                 fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
             }
         }
-        "SubagentStop" => {
-            if let Some(key) = activity_key(&input)
+        "PostToolUse" | "PostToolUseFailure" | "SubagentStop" => {
+            let field = if event == "SubagentStop" {
+                "agent_id"
+            } else {
+                "tool_use_id"
+            };
+            if let Some(key) = activity_key(&input, field)
                 && let Err(error) = fs::remove_file(directory.join(key))
                 && error.kind() != std::io::ErrorKind::NotFound
             {
@@ -1199,51 +1212,6 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
         _ => {}
     }
     Ok(())
-}
-
-fn claude_shell_running() -> bool {
-    let mut system = System::new();
-    system.refresh_processes_specifics(
-        ProcessesToUpdate::All,
-        true,
-        ProcessRefreshKind::nothing().without_tasks(),
-    );
-    let Ok(current) = sysinfo::get_current_pid() else {
-        return false;
-    };
-    let mut ancestors = HashSet::from([current]);
-    let mut parent = system.process(current).and_then(|process| process.parent());
-    let claude = loop {
-        let Some(pid) = parent else { return false };
-        ancestors.insert(pid);
-        let Some(process) = system.process(pid) else {
-            return false;
-        };
-        let name = process.name().to_string_lossy().to_ascii_lowercase();
-        if name.strip_suffix(".exe").unwrap_or(&name) == "claude" {
-            break pid;
-        }
-        parent = process.parent();
-    };
-    system.processes().iter().any(|(pid, process)| {
-        let name = process.name().to_string_lossy().to_ascii_lowercase();
-        if ancestors.contains(pid)
-            || !matches!(
-                name.strip_suffix(".exe").unwrap_or(&name),
-                "bash" | "cmd" | "dash" | "fish" | "nu" | "powershell" | "pwsh" | "sh" | "zsh"
-            )
-        {
-            return false;
-        }
-        let mut parent = process.parent();
-        while let Some(pid) = parent {
-            if pid == claude {
-                return true;
-            }
-            parent = system.process(pid).and_then(|process| process.parent());
-        }
-        false
-    })
 }
 
 pub fn capture_claude_status(path: &str, activity_path: &str) -> Result<(), String> {
@@ -1297,8 +1265,7 @@ pub fn capture_claude_status(path: &str, activity_path: &str) -> Result<(), Stri
     if !fs::read(path).is_ok_and(|current| current == usage) {
         write_atomic(Path::new(path), &usage)?;
     }
-    let working = fs::read_dir(activity_path).is_ok_and(|mut entries| entries.next().is_some())
-        || claude_shell_running();
+    let working = fs::read_dir(activity_path).is_ok_and(|mut entries| entries.next().is_some());
     let activity = if working { "working" } else { "idle" };
     if let Some(percent) = snapshot.context_used_percent {
         println!("\x1b]6973;lite-{activity}\x07Lite · {percent:.0}% context");
@@ -3064,27 +3031,22 @@ async fn agent_update_available(agent: String) -> Result<bool, String> {
         let Some(executable) = resolve_executable(executable) else {
             return Ok(false);
         };
-        let package = match agent.as_str() {
-            "claude" => "@anthropic-ai/claude-code",
-            "codex" => "@openai/codex",
-            "gemini" => "@google/gemini-cli",
-            "kimi" => "@moonshot-ai/kimi-code",
-            "qwen" => "@qwen-code/qwen-code",
+        let (latest_url, version_field) = match agent.as_str() {
+            "claude" => (
+                "https://downloads.claude.ai/claude-code-releases/latest",
+                false,
+            ),
+            "codex" => ("https://registry.npmjs.org/@openai%2Fcodex/latest", true),
+            "gemini" => (
+                "https://registry.npmjs.org/@google%2Fgemini-cli/latest",
+                true,
+            ),
+            "kimi" => ("https://code.kimi.com/kimi-code/latest", false),
+            "qwen" => (
+                "https://registry.npmjs.org/@qwen-code%2Fqwen-code/latest",
+                true,
+            ),
             _ => return Err("Unknown session type".into()),
-        };
-        let npm = resolve_executable("npm").ok_or("Could not check for updates without npm")?;
-        let run = |program: &Path, args: &[&str]| -> Result<String, String> {
-            let mut command = Command::new(program);
-            command.args(args);
-            if let Some(path) = user_path() {
-                command.env("PATH", path);
-            }
-            let output = command.output().map_err(|error| error.to_string())?;
-            if output.status.success() {
-                Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
-            } else {
-                Err(String::from_utf8_lossy(&output.stderr).trim().to_owned())
-            }
         };
         let version = |output: &str| {
             output.split_whitespace().find_map(|word| {
@@ -3096,18 +3058,34 @@ async fn agent_update_available(agent: String) -> Result<bool, String> {
                 .then(|| word.to_owned())
             })
         };
-        let current = version(&run(&executable, &["--version"])?)
+        let mut command = Command::new(executable);
+        command.arg("--version");
+        if let Some(path) = user_path() {
+            command.env("PATH", path);
+        }
+        let output = command.output().map_err(|error| error.to_string())?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).trim().to_owned());
+        }
+        let current = version(&String::from_utf8_lossy(&output.stdout))
             .ok_or("Could not read the installed version")?;
-        let latest = version(&run(
-            &npm,
-            &[
-                "view",
-                package,
-                "version",
-                "--fetch-timeout=5000",
-                "--fetch-retries=0",
-            ],
-        )?)
+        let response = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|error| error.to_string())?
+            .get(latest_url)
+            .send()
+            .and_then(reqwest::blocking::Response::error_for_status)
+            .map_err(|error| error.to_string())?
+            .text()
+            .map_err(|error| error.to_string())?;
+        let latest = if version_field {
+            serde_json::from_str::<serde_json::Value>(&response)
+                .ok()
+                .and_then(|value| value.get("version")?.as_str().map(str::to_owned))
+        } else {
+            version(&response)
+        }
         .ok_or("Could not read the latest version")?;
         Ok(current != latest)
     })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1150,9 +1150,6 @@ fn claude_settings(app: &AppHandle, session_id: &str, run_id: &str) -> Result<Pa
             "preferredNotifChannel": "iterm2",
             "statusLine": { "type": "command", "command": status, "refreshInterval": 1 },
             "hooks": {
-                "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }],
-                "PostToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }],
-                "PostToolUseFailure": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStart": [{ "hooks": [{ "type": "command", "command": activity }] }],
                 "SubagentStop": [{ "hooks": [{ "type": "command", "command": activity }] }]
             }
@@ -1163,9 +1160,9 @@ fn claude_settings(app: &AppHandle, session_id: &str, run_id: &str) -> Result<Pa
     Ok(settings_path)
 }
 
-fn activity_key<'a>(input: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+fn activity_key(input: &serde_json::Value) -> Option<&str> {
     input
-        .get(field)
+        .get("agent_id")
         .and_then(serde_json::Value::as_str)
         .filter(|value| {
             value.chars().all(|character| {
@@ -1186,23 +1183,13 @@ pub fn capture_claude_activity(path: &str) -> Result<(), String> {
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
     match event {
-        "PreToolUse" | "SubagentStart" => {
-            let field = if event == "PreToolUse" {
-                "tool_use_id"
-            } else {
-                "agent_id"
-            };
-            if let Some(key) = activity_key(&input, field) {
+        "SubagentStart" => {
+            if let Some(key) = activity_key(&input) {
                 fs::write(directory.join(key), []).map_err(|error| error.to_string())?;
             }
         }
-        "PostToolUse" | "PostToolUseFailure" | "SubagentStop" => {
-            let field = if event == "SubagentStop" {
-                "agent_id"
-            } else {
-                "tool_use_id"
-            };
-            if let Some(key) = activity_key(&input, field)
+        "SubagentStop" => {
+            if let Some(key) = activity_key(&input)
                 && let Err(error) = fs::remove_file(directory.join(key))
                 && error.kind() != std::io::ErrorKind::NotFound
             {
@@ -3069,6 +3056,7 @@ async fn agent_update_available(agent: String) -> Result<bool, String> {
         }
         let current = version(&String::from_utf8_lossy(&output.stdout))
             .ok_or("Could not read the installed version")?;
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let response = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(5))
             .build()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { clearInspectorCache, Inspector } from "@/inspector";
-import { swapped, without } from "@/lib/utils";
+import { including, swapped, without } from "@/lib/utils";
 import { NewSessionDialog } from "@/new-session-dialog";
 import {
   appendOutput,
@@ -1859,7 +1859,7 @@ function App() {
     const timers = workTimers.current;
     const pending = timers.get(sessionId);
     if (pending) window.clearTimeout(pending);
-    else setWorking((current) => new Set(current).add(sessionId));
+    else setWorking((current) => including(current, sessionId));
     timers.set(
       sessionId,
       window.setTimeout(() => {
@@ -2026,7 +2026,7 @@ function App() {
     recoveryFailures.current.delete(session.id);
     const runId = crypto.randomUUID();
     runs.current.set(session.id, runId);
-    setStartingIds((current) => new Set(current).add(session.id));
+    setStartingIds((current) => including(current, session.id));
     setError("");
     try {
       if (session.worktree) {
@@ -2125,7 +2125,7 @@ function App() {
         });
         const live = sessionsRef.current.find((item) => item.id === session.id);
         if (!folder || !live?.running || closingIds.current.has(session.id) || closingAllRef.current) return;
-        setStartingIds((current) => new Set(current).add(session.id));
+        setStartingIds((current) => including(current, session.id));
         await invoke("stop_session", { sessionId: session.id });
         stopped = true;
         runs.current.delete(session.id);
@@ -2378,7 +2378,7 @@ function App() {
     runs.current.delete(session.id);
     forgetShellAgent(session.id);
     replaceRecentSession(session.id, fresh.id);
-    setStartingIds((current) => new Set(current).add(fresh.id));
+    setStartingIds((current) => including(current, fresh.id));
     setSessions((current) => current.map((item) => (item.id === session.id ? fresh : item)));
     if (select) {
       setSelectedId(fresh.id);
@@ -2630,7 +2630,7 @@ function App() {
       () => true,
       async (reason) => {
         const restored = { ...session, running: false };
-        setStartingIds((current) => new Set(current).add(session.id));
+        setStartingIds((current) => including(current, session.id));
         resumed.current = session.id;
         restore(false);
         if (await launch(restored, true)) {
@@ -2656,7 +2656,7 @@ function App() {
       stopped,
       () => {
         const restored = { ...session, running: false };
-        setStartingIds((current) => new Set(current).add(session.id));
+        setStartingIds((current) => including(current, session.id));
         resumed.current = session.id;
         restore(false);
         return stopped.then(async (successful) => {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -74,7 +74,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
-import { without } from "@/lib/utils";
+import { including, without } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput, subscribeOutput } from "@/output-store";
 import { contentZoomStyle } from "@/theme";
 import {
@@ -480,7 +480,7 @@ function FileTree({
     async (path: string, after: DirectoryCursor | null = null) => {
       if (loading.current.has(path)) return;
       loading.current.add(path);
-      setLoadingPaths((current) => new Set(current).add(path));
+      setLoadingPaths((current) => including(current, path));
       try {
         const listing = await invoke<DirectoryListing>("list_directory", { rootId, path, after });
         setChildren((current) => ({ ...current, [path]: { ...listing, after } }));
@@ -1614,12 +1614,7 @@ export function Inspector({
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
 
   function visitTab(value: string) {
-    setVisited((current) => {
-      if (current.has(value)) return current;
-      const next = new Set(current);
-      next.add(value);
-      return next;
-    });
+    setVisited((current) => including(current, value));
   }
 
   function refreshTab(value: keyof typeof reload) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,6 +16,12 @@ export function without(current: Set<string>, key: string): Set<string> {
   return next;
 }
 
+// The matching add: repeated output and pointer events often report a state the panel already holds,
+// so the set comes back untouched instead of redrawing its consumer for no change.
+export function including(current: Set<string>, key: string): Set<string> {
+  return current.has(key) ? current : new Set(current).add(key);
+}
+
 // One key taking another's place, which is what a session does to the one it replaces: the tab that
 // was starting stops, and the tab standing in for it starts, in the one change the list redraws for.
 export function swapped(current: Set<string>, from: string, to: string): Set<string> {

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -307,12 +307,13 @@ export function NewSessionDialog({
       setAvailability((current) => ({ ...current, ...Object.fromEntries(results) }));
       const result = results.find(([id]) => id === option.id)?.[1];
       if (result && !result.available && result.installable) setError(result.detail);
-      else
-        setUpdates((current) => {
-          const next = { ...current, [option.agent]: false };
-          updateChecks = Promise.resolve(next);
-          return next;
-        });
+      else {
+        updateChecks = (updateChecks ?? Promise.resolve(updates)).then((current) => ({
+          ...current,
+          [option.agent]: false,
+        }));
+        setUpdates((current) => ({ ...current, [option.agent]: false }));
+      }
     } catch (reason) {
       setError(String(reason));
     } finally {

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -28,6 +28,21 @@ const CHOICE_KEY = "lite.newSession.choice.v1";
 const NAME_KEY = "lite.newSession.name.v1";
 const WORKTREE_KEY = "lite.newSession.worktree.v1";
 
+let updateChecks: Promise<Record<string, boolean | null>> | undefined;
+
+function checkAgentUpdates() {
+  updateChecks ??= Promise.all(
+    harnesses.map(async (agent) => {
+      try {
+        return [agent, await invoke<boolean>("agent_update_available", { agent })] as const;
+      } catch {
+        return [agent, null] as const;
+      }
+    }),
+  ).then(Object.fromEntries);
+  return updateChecks;
+}
+
 // The quiet heading that separates the two questions the dialog asks, in the sidebar's own label style.
 const SECTION = "text-[11px] font-medium tracking-wide text-muted-foreground uppercase";
 
@@ -91,20 +106,14 @@ export function NewSessionDialog({
   const status = availability[choice.id];
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
   const missing = status && !status.available ? status : undefined;
-  // Dialog checks are independent, so one slow registry request never holds up another harness.
+  // The first explicit open asks every harness in parallel. The answer is kept for this app run, so
+  // reopening the dialog does not repeat five version processes and five network requests.
   useEffect(() => {
     if (!isOpen) return;
     let disposed = false;
-    setUpdates({});
-    for (const agent of harnesses) {
-      void invoke<boolean>("agent_update_available", { agent })
-        .then((available) => {
-          if (!disposed) setUpdates((current) => ({ ...current, [agent]: available }));
-        })
-        .catch(() => {
-          if (!disposed) setUpdates((current) => ({ ...current, [agent]: null }));
-        });
-    }
+    void checkAgentUpdates().then((result) => {
+      if (!disposed) setUpdates(result);
+    });
     return () => {
       disposed = true;
     };
@@ -298,7 +307,12 @@ export function NewSessionDialog({
       setAvailability((current) => ({ ...current, ...Object.fromEntries(results) }));
       const result = results.find(([id]) => id === option.id)?.[1];
       if (result && !result.available && result.installable) setError(result.detail);
-      else setUpdates((current) => ({ ...current, [option.agent]: false }));
+      else
+        setUpdates((current) => {
+          const next = { ...current, [option.agent]: false };
+          updateChecks = Promise.resolve(next);
+          return next;
+        });
     } catch (reason) {
       setError(String(reason));
     } finally {

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -22,10 +22,9 @@ const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
 
 // Titles and working directories arrive whether or not the session is visible, so their shared OSC
 // owner lives here where every session's output arrives rather than in the mounted terminal. Lite's
-// Claude status line reports work that produces no terminal output — a parent waiting for subagents,
-// a quiet shell command — through a private OSC of its own, which stays invisible and reaches the
-// same owner. One pass reads both: every byte a session prints comes through here, so a second
-// pattern would be a second reading of all of it.
+// Claude status line reports a parent waiting for subagents through a private OSC of its own, which
+// stays invisible and reaches the same owner. One pass reads both: every byte a session prints comes
+// through here, so a second pattern would be a second reading of all of it.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const METADATA = /\x1b\](0|2|7|6973);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 // A bare bell is the portable fallback used by agent harnesses and shells. Remove completed OSC first

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -41,7 +41,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { without } from "@/lib/utils";
+import { including, without } from "@/lib/utils";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
 import type { Theme } from "@/theme";
 import { type Agent, sessionLabel } from "@/types";
@@ -103,7 +103,7 @@ export function SettingsDialog({
   }, [isOpen, read]);
 
   function edit(id: string, open: boolean) {
-    setEditing((current) => (open ? new Set(current).add(id) : without(current, id)));
+    setEditing((current) => (open ? including(current, id) : without(current, id)));
     if (!open) setDrafts((current) => ({ ...current, [id]: "" }));
   }
 


### PR DESCRIPTION
## Summary

- query providers’ official version endpoints directly instead of requiring npm for update checks
- cache the parallel update result for the app run, avoiding repeat processes and network requests when the New Session dialog reopens
- delete Claude’s per-second full process-table scan; ordinary output and its existing subagent lifecycle remain the activity owners
- reuse one Set-add owner so repeated state reports do not redraw unchanged consumers

The session-drag coordinate concern from #79 was already resolved by #88, which compares the pointer and row in viewport coordinates. The remaining file-tree effect and clippy notes are non-user-facing shape observations rather than defects; this PR completes the confirmed behavior and performance items.

Closes #79

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- all five official latest-version endpoints
- Claude subagent activity lifecycle and idle/working OSC markers
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Version 0.0.31 updates agent version checks, caches their results per app run, removes Claude’s full process-table scan, and avoids redundant Set updates to reduce unnecessary work.

### 📊 Key Changes

- Replaced npm-based update checks with direct HTTP requests to the official latest-version endpoints for Claude, Codex, Gemini, Kimi, and Qwen, using Rust `reqwest` with Rustls.
- Cached the parallel agent update request in `NewSessionDialog`, so reopening it reuses existing results instead of starting new version processes and network requests.
- Removed `claude_shell_running`; Claude activity now depends on its activity directory and existing output/subagent lifecycle signals.
- Added the `including` Set helper and applied it to session, loading, editing, and visited-state updates so unchanged state returns the same Set instance.

### 🎯 Purpose & Impact

- Update checks no longer require `npm` and use five-second HTTP client timeouts.
- Reopening the New Session dialog avoids repeating completed update checks during the same app run.
- Claude status tracking no longer performs a full process-table scan on each status report.
- Repeated state notifications that do not change membership no longer trigger consumer redraws.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
