### PR TITLE
Harden GitHub item detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Lint and typecheck
         run: bun run check
 
+      - name: Test frontend
+        run: bun test
+
       - name: Check Rust formatting
         run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "vite",
     "build": "tsgo --noEmit && vite build",
     "preview": "vite preview",
+    "test": "bun test",
     "tauri": "tauri",
     "local": "tauri build --bundles app --config '{\"productName\":\"Lite Dev\",\"identifier\":\"com.ultralytics.lite.dev\",\"bundle\":{\"createUpdaterArtifacts\":false,\"icon\":[\"icons/dev/32x32.png\",\"icons/dev/128x128.png\",\"icons/dev/128x128@2x.png\",\"icons/dev/icon.icns\",\"icons/dev/icon.ico\"]}}'",
     "check": "bun run lint && bun run typecheck && bun run deadcode",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.31"
+version = "0.0.32"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1342,6 +1342,7 @@ struct GitHubItem {
     title: Option<String>,
     state: Option<String>,
     occurred_at: Option<String>,
+    updated_at: Option<String>,
     additions: Option<u64>,
     deletions: Option<u64>,
 }
@@ -1429,7 +1430,7 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
             ));
         }
         query.push_str(
-            "}\nfragment f on IssueOrPullRequest {\n... on Issue { title url state createdAt closedAt }\n... on PullRequest { title url state isDraft createdAt closedAt mergedAt additions deletions }\n}",
+            "}\nfragment f on IssueOrPullRequest {\n... on Issue { title url state createdAt updatedAt closedAt }\n... on PullRequest { title url state isDraft createdAt updatedAt closedAt mergedAt additions deletions }\n}",
         );
         let output = Command::new(gh)
             .args(["api", "graphql", "-f", &format!("query={query}")])
@@ -1485,6 +1486,7 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
                     title: item["title"].as_str().map(str::to_owned),
                     state: Some(state.to_owned()),
                     occurred_at,
+                    updated_at: item["updatedAt"].as_str().map(str::to_owned),
                     additions: item["additions"].as_u64(),
                     deletions: item["deletions"].as_u64(),
                 });
@@ -1496,6 +1498,7 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
                 title: None,
                 state: None,
                 occurred_at: None,
+                updated_at: None,
                 additions: None,
                 deletions: None,
             }),
@@ -1518,6 +1521,7 @@ async fn github_items(urls: Vec<String>) -> Vec<GitHubItem> {
             title: None,
             state: None,
             occurred_at: None,
+            updated_at: None,
             additions: None,
             deletions: None,
         })

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -96,7 +96,7 @@ export function githubItemReferences(output: string, remote: string): GitHubRefe
   return references;
 }
 
-const RECENT_ACTIVITY_MS = 24 * 60 * 60 * 1000;
+const RECENT_ACTIVITY_MS = 30 * 24 * 60 * 60 * 1000;
 
 export function likelyGitHubItems<T extends { updatedAt: string | null; url: string }>(
   items: T[],

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -41,7 +41,11 @@ export function githubItemUrls(output: string): string[] {
   for (const match of text.matchAll(GH_ITEM_COMMAND)) {
     const repositoryMatch = match[2].match(GH_REPOSITORY);
     const repository = repositoryMatch?.slice(2).find(Boolean);
-    const number = match[2].replace(GH_REPOSITORY, "$1").match(/^\s+([1-9]\d{0,8})(?![\w.])/)?.[1];
+    const numbers = match[2]
+      .replace(GH_REPOSITORY, "$1")
+      .replace(/'[^']*'|"(?:\\.|[^"\\])*"/g, "")
+      .match(/(?:^|\s)([1-9]\d{0,8})(?=\s|$)/g);
+    const number = numbers?.length === 1 ? numbers[0].trim() : "";
     if (repository && number) add(match, repository, match[1].toLowerCase() === "pr" ? "pull" : "issues", number, 2);
   }
   for (const match of text.matchAll(GH_API)) {

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -3,17 +3,24 @@
 interface Candidate {
   index: number;
   priority: number;
+  inferred: boolean;
   url: string;
 }
 
-// Only repository-qualified references are actionable. A terminal session can move between folders,
-// so its starting repository is not evidence for a bare number or gh command later in the transcript.
+export interface GitHubReferences {
+  explicit: string[];
+  inferred: string[];
+}
+
+// Repository-qualified references are certain. Bare references use the session repository only as a
+// candidate: GitHub activity must independently confirm them before they reach the panel.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /\bhttps:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(pull|issues)\/([1-9]\d{0,8})(?!\w)/gi;
 const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
 const ITEM_MENTION =
   /(?:^|[^\w./-])(\w[\w.-]*\/\w[\w.-]*)[ \t]+(pull requests?|PRs?|issues?)[ \t]+#?([1-9]\d{0,8})(?![\w.])/gi;
+const BARE_ITEM_MENTION = /(?:^|[^\w./-])(pull requests?|PRs?|issues?)[ \t]+#([1-9]\d{0,8})(?![\w.])/gi;
 const GH_ITEM_COMMAND =
   /\bgh\s+(issue|pr)\s+(?!create\b|list\b|status\b)[\w-]+((?:[^;&|'"\\\r\n]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*)/gi;
 const GH_REPOSITORY =
@@ -21,16 +28,26 @@ const GH_REPOSITORY =
 const GH_API =
   /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
 
-export function githubItemUrls(output: string): string[] {
+export function githubItemReferences(output: string, remote: string): GitHubReferences {
   const text = output.replace(COLOR, "");
   const candidates: Candidate[] = [];
-  const add = (match: RegExpMatchArray, repository: string, kind: string, number: string, priority: number) => {
+  const add = (
+    match: RegExpMatchArray,
+    repository: string,
+    kind: string,
+    number: string,
+    priority: number,
+    inferred = false,
+  ) => {
     candidates.push({
       index: match.index ?? 0,
       priority,
+      inferred,
       url: `https://github.com/${repository}/${kind}/${number}`,
     });
   };
+  const base = remote.match(/^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/i);
+  const repository = base ? `${base[1]}/${base[2]}` : "";
 
   for (const match of text.matchAll(GITHUB_ITEM))
     add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
@@ -38,15 +55,29 @@ export function githubItemUrls(output: string): string[] {
   for (const match of text.matchAll(ITEM_MENTION)) {
     add(match, match[1], match[2].toLowerCase().startsWith("issue") ? "issues" : "pull", match[3], 2);
   }
+  if (repository) {
+    for (const match of text.matchAll(BARE_ITEM_MENTION)) {
+      add(match, repository, match[1].toLowerCase().startsWith("issue") ? "issues" : "pull", match[2], 0, true);
+    }
+  }
   for (const match of text.matchAll(GH_ITEM_COMMAND)) {
     const repositoryMatch = match[2].match(GH_REPOSITORY);
-    const repository = repositoryMatch?.slice(2).find(Boolean);
+    const explicitRepository = repositoryMatch?.slice(2).find(Boolean);
     const numbers = match[2]
       .replace(GH_REPOSITORY, "$1")
       .replace(/'[^']*'|"(?:\\.|[^"\\])*"/g, "")
       .match(/(?:^|\s)([1-9]\d{0,8})(?=\s|$)/g);
     const number = numbers?.length === 1 ? numbers[0].trim() : "";
-    if (repository && number) add(match, repository, match[1].toLowerCase() === "pr" ? "pull" : "issues", number, 2);
+    const targetRepository = explicitRepository || repository;
+    if (targetRepository && number)
+      add(
+        match,
+        targetRepository,
+        match[1].toLowerCase() === "pr" ? "pull" : "issues",
+        number,
+        repositoryMatch ? 2 : 0,
+        !repositoryMatch,
+      );
   }
   for (const match of text.matchAll(GH_API)) {
     add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase() === "pulls" ? "pull" : "issues", match[4], 3);
@@ -60,5 +91,27 @@ export function githubItemUrls(output: string): string[] {
     const current = items.get(key);
     if (!current || candidate.priority > current.priority) items.set(key, candidate);
   }
-  return [...items.values()].map(({ url }) => url);
+  const references: GitHubReferences = { explicit: [], inferred: [] };
+  for (const candidate of items.values()) references[candidate.inferred ? "inferred" : "explicit"].push(candidate.url);
+  return references;
+}
+
+const RECENT_ACTIVITY_MS = 24 * 60 * 60 * 1000;
+
+export function likelyGitHubItems<T extends { updatedAt: string | null; url: string }>(
+  items: T[],
+  inferred: string[],
+  now = Date.now(),
+): T[] {
+  const inferredItems = new Set(inferred.map(itemKey));
+  return items.filter((item) => {
+    if (!inferredItems.has(itemKey(item.url))) return true;
+    const updatedAt = item.updatedAt ? Date.parse(item.updatedAt) : Number.NaN;
+    return Number.isFinite(updatedAt) && now - updatedAt <= RECENT_ACTIVITY_MS;
+  });
+}
+
+function itemKey(url: string) {
+  const [, , , owner, repository, , number] = url.split("/");
+  return `${owner}/${repository}#${number}`.toLowerCase();
 }

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -1,0 +1,60 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+interface Candidate {
+  index: number;
+  priority: number;
+  url: string;
+}
+
+// Only repository-qualified references are actionable. A terminal session can move between folders,
+// so its starting repository is not evidence for a bare number or gh command later in the transcript.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
+const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
+const GITHUB_ITEM = /\bhttps:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(pull|issues)\/([1-9]\d{0,8})(?!\w)/gi;
+const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
+const ITEM_MENTION =
+  /(?:^|[^\w./-])(\w[\w.-]*\/\w[\w.-]*)[ \t]+(pull requests?|PRs?|issues?)[ \t]+#?([1-9]\d{0,8})(?![\w.])/gi;
+const GH_ITEM_COMMAND =
+  /\bgh\s+(issue|pr)\s+(?!create\b|list\b|status\b)[\w-]+((?:[^;&|'"\\\r\n]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*)/gi;
+const GH_REPOSITORY =
+  /^((?:[^'"\\]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*?\s)(?:--repo|-R)(?:=|\s+)(?:([\w.-]+\/[\w.-]+)|'([\w.-]+\/[\w.-]+)'|"([\w.-]+\/[\w.-]+)")/i;
+const GH_API =
+  /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
+
+export function githubItemUrls(output: string): string[] {
+  const text = output.replace(COLOR, "");
+  const candidates: Candidate[] = [];
+  const add = (match: RegExpMatchArray, repository: string, kind: string, number: string, priority: number) => {
+    candidates.push({
+      index: match.index ?? 0,
+      priority,
+      url: `https://github.com/${repository}/${kind}/${number}`,
+    });
+  };
+
+  for (const match of text.matchAll(GITHUB_ITEM))
+    add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
+  for (const match of text.matchAll(QUALIFIED_ITEM)) add(match, `${match[1]}/${match[2]}`, "issues", match[3], 1);
+  for (const match of text.matchAll(ITEM_MENTION)) {
+    add(match, match[1], match[2].toLowerCase().startsWith("issue") ? "issues" : "pull", match[3], 2);
+  }
+  for (const match of text.matchAll(GH_ITEM_COMMAND)) {
+    const repositoryMatch = match[2].match(GH_REPOSITORY);
+    const repository = repositoryMatch?.slice(2).find(Boolean);
+    const number = match[2].replace(GH_REPOSITORY, "$1").match(/^\s+([1-9]\d{0,8})(?![\w.])/)?.[1];
+    if (repository && number) add(match, repository, match[1].toLowerCase() === "pr" ? "pull" : "issues", number, 2);
+  }
+  for (const match of text.matchAll(GH_API)) {
+    add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase() === "pulls" ? "pull" : "issues", match[4], 3);
+  }
+
+  candidates.sort((left, right) => left.index - right.index);
+  const items = new Map<string, Candidate>();
+  for (const candidate of candidates) {
+    const [, , , owner, repository, , number] = candidate.url.split("/");
+    const key = `${owner}/${repository}#${number}`.toLowerCase();
+    const current = items.get(key);
+    if (!current || candidate.priority > current.priority) items.set(key, candidate);
+  }
+  return [...items.values()].map(({ url }) => url);
+}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1326,7 +1326,7 @@ function GitPanel({
   }, [active, remote, sessionId]);
 
   // Explicit references always survive the lookup. A bare reference inferred from the session folder
-  // survives only when GitHub confirms activity in the last day.
+  // survives only when GitHub confirms activity in the last 30 days.
   useEffect(() => {
     const { explicit, inferred } = references;
     const urls = [...explicit, ...inferred];

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -73,6 +73,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { githubItemUrls } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { including, without } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput, subscribeOutput } from "@/output-store";
@@ -91,49 +92,8 @@ import {
 
 const CodePreview = lazy(() => import("@/code-preview"));
 
-// A session's terminal is the only record of what it worked on, so explicit GitHub links, qualified
-// owner/repo references, and gh commands are read back out of the output Lite already bounds. Bare
-// numbers are not work items: they could be prose, images, or line numbers. Only CSI is stripped,
-// so a link inside an OSC hyperlink survives being uncoloured.
-// biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
-const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
-const GITHUB_ITEM = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:pull|issues)\/\d+/g;
-const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
-const ITEM_MENTION =
-  /(?:^|[^\w./-])(\w[\w.-]*\/\w[\w.-]*)[ \t]+(pull requests?|PRs?|issues?)[ \t]+#?([1-9]\d{0,8})(?![\w.])/gi;
-const GH_ITEM_COMMAND =
-  /\bgh\s+(issue|pr)\s+(?!create\b|list\b|status\b)[\w-]+((?:[^;&|'"\\\r\n]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*)/gi;
-const GH_REPOSITORY =
-  /^((?:[^'"\\]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*?\s)(?:--repo|-R)(?:=|\s+)(?:([\w.-]+\/[\w.-]+)|'([\w.-]+\/[\w.-]+)'|"([\w.-]+\/[\w.-]+)")/i;
-const GH_API =
-  /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
-const githubItemsBySession = new Map<string, Set<string>>();
-
-function namedInSession(sessionId: string, remote: string) {
-  const text = readOutput(sessionId).slice(-MAX_OUTPUT_BYTES).replace(COLOR, "");
-  const urls = githubItemsBySession.get(sessionId) ?? new Set<string>();
-  for (const url of text.match(GITHUB_ITEM) ?? []) urls.add(url);
-  const prefix = "https://github.com/";
-  for (const match of text.matchAll(QUALIFIED_ITEM)) {
-    urls.add(`${prefix}${match[1]}/${match[2]}/issues/${match[3]}`);
-  }
-  const base = remote.toLowerCase().startsWith(prefix) ? prefix + remote.slice(prefix.length) : "";
-  for (const match of text.matchAll(ITEM_MENTION)) {
-    urls.add(`${prefix}${match[1]}/${match[2].toLowerCase().startsWith("issue") ? "issues" : "pull"}/${match[3]}`);
-  }
-  for (const match of text.matchAll(GH_ITEM_COMMAND)) {
-    const repositoryMatch = match[2].match(GH_REPOSITORY);
-    const repository = repositoryMatch?.slice(2).find(Boolean);
-    const number = match[2].replace(GH_REPOSITORY, "$1").match(/^\s+([1-9]\d{0,8})(?![\w.])/)?.[1];
-    const repositoryUrl = repository ? `${prefix}${repository}` : base;
-    if (repositoryUrl && number)
-      urls.add(`${repositoryUrl}/${match[1].toLowerCase() === "pr" ? "pull" : "issues"}/${number}`);
-  }
-  for (const match of text.matchAll(GH_API)) {
-    urls.add(`${prefix}${match[1]}/${match[2]}/${match[3].toLowerCase() === "pulls" ? "pull" : "issues"}/${match[4]}`);
-  }
-  githubItemsBySession.set(sessionId, urls);
-  return [...urls];
+function namedInSession(sessionId: string) {
+  return githubItemUrls(readOutput(sessionId).slice(-MAX_OUTPUT_BYTES));
 }
 
 interface GitHubReference {
@@ -1310,7 +1270,6 @@ const usageCache = new Map<string, UsageSnapshot | null>();
 
 export function clearInspectorCache(sessionId: string) {
   usageCache.delete(sessionId);
-  githubItemsBySession.delete(sessionId);
   fileEditorsBySession.delete(sessionId);
 }
 
@@ -1327,7 +1286,7 @@ function GitPanel({
   active: boolean;
   fontSize: number;
 }) {
-  const [urls, setUrls] = useState(() => namedInSession(sessionId, remote));
+  const [urls, setUrls] = useState(() => namedInSession(sessionId));
   const [status, setStatus] = useState<GitStatus | null>();
   const [items, setItems] = useState<GitHubItem[]>();
   const [error, setError] = useState("");
@@ -1345,7 +1304,7 @@ function GitPanel({
     let replaying = true;
     let settle = 0;
     const scan = () => {
-      const next = namedInSession(sessionId, remote);
+      const next = namedInSession(sessionId);
       setUrls((current) =>
         current.length === next.length && current.every((url, index) => url === next[index]) ? current : next,
       );
@@ -1361,7 +1320,7 @@ function GitPanel({
       window.clearTimeout(settle);
       unsubscribe();
     };
-  }, [active, remote, sessionId]);
+  }, [active, sessionId]);
 
   // A visible panel follows newly named items, while refresh rebuilds the current snapshot. Either way,
   // GitHub is asked only when the set of explicit references changes.

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -73,7 +73,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { githubItemUrls } from "@/github-items";
+import { githubItemReferences, likelyGitHubItems } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { including, without } from "@/lib/utils";
 import { MAX_OUTPUT_BYTES, readOutput, subscribeOutput } from "@/output-store";
@@ -92,8 +92,8 @@ import {
 
 const CodePreview = lazy(() => import("@/code-preview"));
 
-function namedInSession(sessionId: string) {
-  return githubItemUrls(readOutput(sessionId).slice(-MAX_OUTPUT_BYTES));
+function namedInSession(sessionId: string, remote: string) {
+  return githubItemReferences(readOutput(sessionId).slice(-MAX_OUTPUT_BYTES), remote);
 }
 
 interface GitHubReference {
@@ -121,6 +121,7 @@ interface GitHubItem {
   title: string | null;
   state: keyof typeof GITHUB_STATE | null;
   occurredAt: string | null;
+  updatedAt: string | null;
   additions: number | null;
   deletions: number | null;
 }
@@ -1286,7 +1287,7 @@ function GitPanel({
   active: boolean;
   fontSize: number;
 }) {
-  const [urls, setUrls] = useState(() => namedInSession(sessionId));
+  const [references, setReferences] = useState(() => namedInSession(sessionId, remote));
   const [status, setStatus] = useState<GitStatus | null>();
   const [items, setItems] = useState<GitHubItem[]>();
   const [error, setError] = useState("");
@@ -1304,10 +1305,12 @@ function GitPanel({
     let replaying = true;
     let settle = 0;
     const scan = () => {
-      const next = namedInSession(sessionId);
-      setUrls((current) =>
-        current.length === next.length && current.every((url, index) => url === next[index]) ? current : next,
-      );
+      const next = namedInSession(sessionId, remote);
+      setReferences((current) => {
+        const same = (key: keyof typeof next) =>
+          current[key].length === next[key].length && current[key].every((url, index) => url === next[key][index]);
+        return same("explicit") && same("inferred") ? current : next;
+      });
     };
     const unsubscribe = subscribeOutput(sessionId, () => {
       if (replaying) return;
@@ -1320,11 +1323,13 @@ function GitPanel({
       window.clearTimeout(settle);
       unsubscribe();
     };
-  }, [active, sessionId]);
+  }, [active, remote, sessionId]);
 
-  // A visible panel follows newly named items, while refresh rebuilds the current snapshot. Either way,
-  // GitHub is asked only when the set of explicit references changes.
+  // Explicit references always survive the lookup. A bare reference inferred from the session folder
+  // survives only when GitHub confirms activity in the last day.
   useEffect(() => {
+    const { explicit, inferred } = references;
+    const urls = [...explicit, ...inferred];
     if (!urls.length) return setItems([]);
     let disposed = false;
     // A remote that arrives after an empty first pass starts a real check, so the panel goes back to
@@ -1332,19 +1337,27 @@ function GitPanel({
     setItems(undefined);
     void invoke<GitHubItem[]>("github_items", { urls })
       .then((checked) => {
-        if (!disposed) setItems(checked);
+        if (!disposed) setItems(likelyGitHubItems(checked, inferred));
       })
-      // A link that could not be checked is still explicit, so it is shown the way it was printed.
+      // An explicit link survives an unavailable GitHub; an inference cannot be verified and does not.
       .catch(() => {
         if (!disposed)
           setItems(
-            urls.map((url) => ({ url, title: null, state: null, occurredAt: null, additions: null, deletions: null })),
+            explicit.map((url) => ({
+              url,
+              title: null,
+              state: null,
+              occurredAt: null,
+              updatedAt: null,
+              additions: null,
+              deletions: null,
+            })),
           );
       });
     return () => {
       disposed = true;
     };
-  }, [urls]);
+  }, [references]);
 
   const refresh = useCallback(async () => {
     setError("");
@@ -1427,7 +1440,9 @@ function GitPanel({
             {lowered && status !== undefined && items && repositories.length && !shown.length ? (
               <p className="text-sm text-muted-foreground">No matches</p>
             ) : null}
-            {items === undefined && urls.length ? <Loading label="Checking GitHub links…" /> : null}
+            {items === undefined && (references.explicit.length || references.inferred.length) ? (
+              <Loading label="Checking GitHub links…" />
+            ) : null}
             {status === null && items && !repositories.length ? (
               <Empty>
                 <EmptyHeader>

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -30,6 +30,7 @@ ultralytics/portal#3608
 ultralytics/assistant issue #3052
 gh pr checks 97 --repo ultralytics/lite
 gh issue close -R=ultralytics/portal 3497
+gh pr view --json number -R ultralytics/lite 94
 gh api repos/ultralytics/assistant/pulls/3048
 `;
 
@@ -39,6 +40,7 @@ gh api repos/ultralytics/assistant/pulls/3048
       "https://github.com/ultralytics/assistant/issues/3052",
       "https://github.com/ultralytics/lite/pull/97",
       "https://github.com/ultralytics/portal/issues/3497",
+      "https://github.com/ultralytics/lite/pull/94",
       "https://github.com/ultralytics/assistant/pull/3048",
     ]);
   });
@@ -50,6 +52,7 @@ gh pr view 102
 gh issue close 3052
 gh pr list --repo ultralytics/lite
 gh pr create --repo ultralytics/lite
+gh pr checks --interval 10 102 --repo ultralytics/lite
 Image #1
 src/components/ui/button.tsx:102
 https://github.com/ultralytics/lite/pull/0

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -124,15 +124,15 @@ ultralytics/lite PR #102
     });
   });
 
-  test("keeps inferred items only when GitHub confirms activity in the last day", () => {
+  test("keeps inferred items only when GitHub confirms activity in the last 30 days", () => {
     const inferred = [
       "https://github.com/ultralytics/portal/pull/102",
       "https://github.com/ultralytics/portal/issues/3052",
     ];
     const now = Date.parse("2026-08-14T18:00:00Z");
     const items = [
-      { url: inferred[0], updatedAt: "2025-12-14T18:00:00Z" },
-      { url: inferred[1], updatedAt: "2026-08-14T17:59:00Z" },
+      { url: inferred[0], updatedAt: "2026-07-14T18:00:00Z" },
+      { url: inferred[1], updatedAt: "2026-07-16T18:00:00Z" },
       { url: "https://github.com/ultralytics/lite/pull/102", updatedAt: null },
     ];
 

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -1,0 +1,99 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import { describe, expect, test } from "bun:test";
+
+import { githubItemUrls } from "../src/github-items";
+
+describe("githubItemUrls", () => {
+  test("does not assign commands from moved worktrees to the session repository", () => {
+    const transcript = `
+$ gh pr view 3608 --repo ultralytics/portal --json url
+{"url":"https://github.com/ultralytics/portal/pull/3608"}
+$ gh pr view 102 --json body,headRefOid,url
+{"url":"https://github.com/ultralytics/lite/pull/102"}
+$ gh issue view 3052
+https://github.com/ultralytics/assistant/pull/3052
+Updated Lite PR #102 (https://github.com/ultralytics/lite/pull/102)
+`;
+
+    expect(githubItemUrls(transcript)).toEqual([
+      "https://github.com/ultralytics/portal/pull/3608",
+      "https://github.com/ultralytics/lite/pull/102",
+      "https://github.com/ultralytics/assistant/pull/3052",
+    ]);
+  });
+
+  test("recognizes every repository-qualified form", () => {
+    const transcript = `
+https://github.com/ultralytics/lite/pull/102/files
+ultralytics/portal#3608
+ultralytics/assistant issue #3052
+gh pr checks 97 --repo ultralytics/lite
+gh issue close -R=ultralytics/portal 3497
+gh api repos/ultralytics/assistant/pulls/3048
+`;
+
+    expect(githubItemUrls(transcript)).toEqual([
+      "https://github.com/ultralytics/lite/pull/102",
+      "https://github.com/ultralytics/portal/issues/3608",
+      "https://github.com/ultralytics/assistant/issues/3052",
+      "https://github.com/ultralytics/lite/pull/97",
+      "https://github.com/ultralytics/portal/issues/3497",
+      "https://github.com/ultralytics/assistant/pull/3048",
+    ]);
+  });
+
+  test("rejects ambiguous and malformed references", () => {
+    const transcript = `
+PR #102 and issue 3052
+gh pr view 102
+gh issue close 3052
+gh pr list --repo ultralytics/lite
+gh pr create --repo ultralytics/lite
+Image #1
+src/components/ui/button.tsx:102
+https://github.com/ultralytics/lite/pull/0
+https://github.com/ultralytics/lite/pull/1234567890
+https://github.com/ultralytics/lite/pull/102abc
+`;
+
+    expect(githubItemUrls(transcript)).toEqual([]);
+  });
+
+  test("keeps command boundaries and quoted arguments isolated", () => {
+    const transcript = `
+gh pr edit 12 --body "mention --repo wrong/repo" && gh pr view 13 -R right/repo
+gh issue view 14; gh pr view 15 --repo next/repo
+gh pr status --repo ignored/repo | gh issue view 16 -R final/repo
+`;
+
+    expect(githubItemUrls(transcript)).toEqual([
+      "https://github.com/right/repo/pull/13",
+      "https://github.com/next/repo/pull/15",
+      "https://github.com/final/repo/issues/16",
+    ]);
+  });
+
+  test("deduplicates forms by repository and number using the strongest kind", () => {
+    const transcript = `
+ultralytics/lite#102
+ultralytics/lite issue #102
+gh api repos/ultralytics/lite/issues/102
+https://github.com/ultralytics/lite/pull/102
+gh issue view 102 --repo ULTRALYTICS/LITE
+`;
+
+    expect(githubItemUrls(transcript)).toEqual(["https://github.com/ultralytics/lite/pull/102"]);
+  });
+
+  test("reads links through terminal color and hyperlink sequences", () => {
+    const transcript =
+      "\u001b[32mhttps://github.com/ultralytics/lite/issues/88\u001b[0m " +
+      "\u001b]8;;https://github.com/ultralytics/lite/pull/90\u0007PR\u001b]8;;\u0007";
+
+    expect(githubItemUrls(transcript)).toEqual([
+      "https://github.com/ultralytics/lite/issues/88",
+      "https://github.com/ultralytics/lite/pull/90",
+    ]);
+  });
+});

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -2,9 +2,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { githubItemUrls } from "../src/github-items";
+import { githubItemReferences, likelyGitHubItems } from "../src/github-items";
 
-describe("githubItemUrls", () => {
+const explicit = (output: string) => githubItemReferences(output, "").explicit;
+
+describe("githubItemReferences", () => {
   test("does not assign commands from moved worktrees to the session repository", () => {
     const transcript = `
 $ gh pr view 3608 --repo ultralytics/portal --json url
@@ -16,7 +18,7 @@ https://github.com/ultralytics/assistant/pull/3052
 Updated Lite PR #102 (https://github.com/ultralytics/lite/pull/102)
 `;
 
-    expect(githubItemUrls(transcript)).toEqual([
+    expect(explicit(transcript)).toEqual([
       "https://github.com/ultralytics/portal/pull/3608",
       "https://github.com/ultralytics/lite/pull/102",
       "https://github.com/ultralytics/assistant/pull/3052",
@@ -34,7 +36,7 @@ gh pr view --json number -R ultralytics/lite 94
 gh api repos/ultralytics/assistant/pulls/3048
 `;
 
-    expect(githubItemUrls(transcript)).toEqual([
+    expect(explicit(transcript)).toEqual([
       "https://github.com/ultralytics/lite/pull/102",
       "https://github.com/ultralytics/portal/issues/3608",
       "https://github.com/ultralytics/assistant/issues/3052",
@@ -60,7 +62,7 @@ https://github.com/ultralytics/lite/pull/1234567890
 https://github.com/ultralytics/lite/pull/102abc
 `;
 
-    expect(githubItemUrls(transcript)).toEqual([]);
+    expect(explicit(transcript)).toEqual([]);
   });
 
   test("keeps command boundaries and quoted arguments isolated", () => {
@@ -70,7 +72,7 @@ gh issue view 14; gh pr view 15 --repo next/repo
 gh pr status --repo ignored/repo | gh issue view 16 -R final/repo
 `;
 
-    expect(githubItemUrls(transcript)).toEqual([
+    expect(explicit(transcript)).toEqual([
       "https://github.com/right/repo/pull/13",
       "https://github.com/next/repo/pull/15",
       "https://github.com/final/repo/issues/16",
@@ -86,7 +88,7 @@ https://github.com/ultralytics/lite/pull/102
 gh issue view 102 --repo ULTRALYTICS/LITE
 `;
 
-    expect(githubItemUrls(transcript)).toEqual(["https://github.com/ultralytics/lite/pull/102"]);
+    expect(explicit(transcript)).toEqual(["https://github.com/ultralytics/lite/pull/102"]);
   });
 
   test("reads links through terminal color and hyperlink sequences", () => {
@@ -94,9 +96,67 @@ gh issue view 102 --repo ULTRALYTICS/LITE
       "\u001b[32mhttps://github.com/ultralytics/lite/issues/88\u001b[0m " +
       "\u001b]8;;https://github.com/ultralytics/lite/pull/90\u0007PR\u001b]8;;\u0007";
 
-    expect(githubItemUrls(transcript)).toEqual([
+    expect(explicit(transcript)).toEqual([
       "https://github.com/ultralytics/lite/issues/88",
       "https://github.com/ultralytics/lite/pull/90",
+    ]);
+  });
+
+  test("separates ambiguous references for recent-activity verification", () => {
+    const references = githubItemReferences(
+      `
+PR #102 and issue #3052
+gh pr view 94
+gh issue close 88
+https://github.com/ultralytics/lite/pull/97
+ultralytics/lite PR #102
+`,
+      "https://github.com/ultralytics/lite",
+    );
+
+    expect(references).toEqual({
+      explicit: ["https://github.com/ultralytics/lite/pull/102", "https://github.com/ultralytics/lite/pull/97"],
+      inferred: [
+        "https://github.com/ultralytics/lite/issues/3052",
+        "https://github.com/ultralytics/lite/pull/94",
+        "https://github.com/ultralytics/lite/issues/88",
+      ],
+    });
+  });
+
+  test("keeps inferred items only when GitHub confirms activity in the last day", () => {
+    const inferred = [
+      "https://github.com/ultralytics/portal/pull/102",
+      "https://github.com/ultralytics/portal/issues/3052",
+    ];
+    const now = Date.parse("2026-08-14T18:00:00Z");
+    const items = [
+      { url: inferred[0], updatedAt: "2025-12-14T18:00:00Z" },
+      { url: inferred[1], updatedAt: "2026-08-14T17:59:00Z" },
+      { url: "https://github.com/ultralytics/lite/pull/102", updatedAt: null },
+    ];
+
+    expect(likelyGitHubItems(items, inferred, now)).toEqual([items[1], items[2]]);
+  });
+
+  test("removes the cross-worktree duplicates from the reported transcript", () => {
+    const references = githubItemReferences(
+      `
+gh pr view 102 --json url
+https://github.com/ultralytics/lite/pull/102
+gh issue view 3052
+https://github.com/ultralytics/assistant/pull/3052
+`,
+      "https://github.com/ultralytics/portal",
+    );
+    const checked = [...references.explicit, ...references.inferred].map((url) => ({
+      url,
+      updatedAt: url.includes("/portal/") ? "2026-07-01T00:00:00Z" : "2026-08-14T17:00:00Z",
+    }));
+
+    expect(likelyGitHubItems(checked, references.inferred, Date.parse("2026-08-14T18:00:00Z"))).toEqual([
+      checked[0],
+      checked[1],
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- classify terminal PR and issue references by evidence instead of blindly assigning every match to the session root
- always retain explicit URLs, qualified repository mentions, `--repo` commands, and GitHub API paths
- retain bare `PR #123`, `issue #123`, and unqualified `gh` commands only when the inferred repository item had GitHub activity within 30 days
- deduplicate issues and pull requests across repositories by case-insensitive repository and number, preferring canonical explicit evidence
- derive matches from bounded terminal output so rejected or expired matches do not remain sticky
- add focused parser and likelihood coverage and run it in CI
- release as Lite 0.0.32

## Validation
- `bun install --frozen-lockfile`
- `bun test`
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- `bun run tauri build` compiled and bundled the macOS app, DMG, and updater archive; local updater signing correctly requires the protected release key

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
GitHub item detection now distinguishes explicit references from repository-inferred references, filters ambiguous stale matches, and deduplicates results to avoid incorrect GitHub panel associations.

### 📊 Key Changes
- Added `githubItemReferences` to recognize explicit URLs, repository-qualified mentions, `--repo`/`-R` commands, and GitHub API paths while separating bare references for verification.
- Bare `PR #123`, `issue #123`, and unqualified `gh` commands are retained only when the corresponding item was updated within the previous 30 days.
- Deduplicated references case-insensitively by repository and number, preferring stronger explicit evidence.
- Changed session scanning to use the bounded current terminal output rather than retaining previously detected matches.
- Added focused frontend parser and activity tests, enabled `bun test` in CI, and bumped the Lite release to 0.0.32.

### 🎯 Purpose & Impact
- The GitHub panel no longer permanently retains rejected or expired inferred matches and does not automatically assign unqualified references to the session’s repository without recent GitHub activity.
- Explicit references remain available even when GitHub lookup fails; inferred references require successful verification.
- Terminal output from moved worktrees and cross-repository commands is associated with the repository shown in the evidence rather than the session root.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
