### PR TITLE
Submit upgrade continuation prompts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1395,6 +1395,7 @@ function startKimiConversation(sessionId: string) {
 // all is still sent the command rather than left holding it.
 const SETTLE_MS = 300;
 const GIVE_UP_MS = 5000;
+const ENTER_DELAY_MS = 100;
 
 function runOnStart(sessionId: string, command: string) {
   let sent = false;
@@ -1405,10 +1406,10 @@ function runOnStart(sessionId: string, command: string) {
     window.clearTimeout(settle);
     window.clearTimeout(patience);
     unsubscribe();
-    // Submit exactly as the terminal does: the text and Enter are separate input events. Interactive
-    // agents may treat one combined write as pasted text and leave it sitting in the composer.
+    // Submit exactly as a person does: let the interface process the text before Enter. The delay is
+    // part of the shared write queue, so an early keystroke cannot overtake the submission.
     writeSession(sessionId, command);
-    writeSession(sessionId, "\r");
+    writeSession(sessionId, "\r", ENTER_DELAY_MS);
   };
   // This waits rather than sends, which is also what keeps it safe: subscribing replays what the
   // session has already said, so a listener that sent from here would be sending before the two lines
@@ -2084,7 +2085,7 @@ function App() {
       const shouldContinue = session.agent !== "shell" && interrupted.current.delete(session.id);
       const launched = await launch(session, true);
       if (shouldContinue) {
-        if (launched) runOnStart(session.id, "continue");
+        if (launched) runOnStart(session.id, "Lite restarted while you were working. Continue the previous task.");
         else interrupted.current.add(session.id);
       }
       return launched;

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -173,16 +173,18 @@ export function holdSessionWrites(sessionId: string, wait: Promise<unknown>) {
   );
 }
 
-export function writeSession(sessionId: string, text: string) {
+export function writeSession(sessionId: string, text: string, delay = 0) {
   const data = Array.from(new TextEncoder().encode(text));
   writes.set(
     sessionId,
-    (writes.get(sessionId) ?? Promise.resolve()).then(() =>
-      // A write that fails must not take the writes queued behind it with it, and a session whose pty
-      // has gone is reported by the session itself; this is the only record that a keystroke was lost.
-      invoke("write_session", { sessionId, data }).catch((reason) =>
-        console.error(`Lite could not write to session ${sessionId}:`, reason),
+    (writes.get(sessionId) ?? Promise.resolve())
+      .then(() => (delay ? new Promise((resolve) => setTimeout(resolve, delay)) : undefined))
+      .then(() =>
+        // A write that fails must not take the writes queued behind it with it, and a session whose pty
+        // has gone is reported by the session itself; this is the only record that a keystroke was lost.
+        invoke("write_session", { sessionId, data }).catch((reason) =>
+          console.error(`Lite could not write to session ${sessionId}:`, reason),
+        ),
       ),
-    ),
   );
 }


### PR DESCRIPTION
## Summary

- prompt only sessions that were actively working when Lite restarted
- explain the restart and ask the agent to continue its previous task
- queue Enter after the prompt with a short processing gap so the resumed TUI submits it automatically

Idle sessions remain untouched.

## Validation

- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite now automatically prompts non-shell sessions that were active during a restart to continue their previous task, submitting the prompt after a short delay.

### 📊 Key Changes

- Replaced the generic `continue` command with: “Lite restarted while you were working. Continue the previous task.”
- Added a 100 ms delay before sending Enter so the resumed interface processes the prompt text first.
- Extended `writeSession` with an optional delay while preserving per-session write ordering and error handling.
- Sessions that were idle at restart remain unchanged.

### 🎯 Purpose & Impact

- Active agent sessions can resume their prior work automatically after Lite restarts, while idle sessions are not prompted.