### PR TITLE
Show project .claude folders on request

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,18 @@ fn stop_pty(session: &mut PtySession) -> Result<(), String> {
 #[derive(Default)]
 struct Sessions(Mutex<HashMap<String, PtySession>>);
 
+struct FileBrowserSettings {
+    home: Option<PathBuf>,
+    show_claude: AtomicBool,
+}
+
+impl FileBrowserSettings {
+    fn project_claude_visible(&self, root: &Path) -> bool {
+        self.show_claude.load(Ordering::Relaxed)
+            && self.home.as_deref().is_some_and(|home| home != root)
+    }
+}
+
 #[derive(Default)]
 struct Roots(Mutex<HashMap<String, PathBuf>>);
 
@@ -250,6 +262,7 @@ fn is_sensitive_component(component: &std::ffi::OsStr) -> bool {
     name == ".env"
         || name.starts_with(".env.")
         || [
+            ".credentials.json",
             ".aws",
             ".azure",
             ".claude",
@@ -276,11 +289,14 @@ fn is_sensitive_root(path: &Path) -> bool {
         .any(|component| is_sensitive_component(component.as_os_str()))
 }
 
-fn is_sensitive_path(root: &Path, path: &Path) -> bool {
+fn is_sensitive_path_with_claude(root: &Path, path: &Path, show_claude: bool) -> bool {
     path.strip_prefix(root).is_ok_and(|relative| {
-        relative
-            .components()
-            .any(|component| is_sensitive_component(component.as_os_str()))
+        relative.components().enumerate().any(|(index, component)| {
+            is_sensitive_component(component.as_os_str())
+                && !(show_claude
+                    && index == 0
+                    && component.as_os_str().eq_ignore_ascii_case(".claude"))
+        })
     })
 }
 
@@ -320,6 +336,26 @@ fn last_directory_path(app: &AppHandle) -> Result<PathBuf, String> {
         .app_data_dir()
         .map_err(|error| error.to_string())?
         .join("last-directory"))
+}
+
+fn show_claude_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?
+        .join("show-claude-folder"))
+}
+
+fn load_file_browser_settings(app: &AppHandle) -> FileBrowserSettings {
+    let home = app
+        .path()
+        .home_dir()
+        .ok()
+        .and_then(|home| fs::canonicalize(home).ok());
+    FileBrowserSettings {
+        home,
+        show_claude: AtomicBool::new(show_claude_path(app).is_ok_and(|path| path.is_file())),
+    }
 }
 
 fn read_roots(path: &Path) -> HashMap<String, PathBuf> {
@@ -3324,6 +3360,7 @@ fn delete_session_data(
 
 #[tauri::command]
 async fn list_directory(
+    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
@@ -3331,6 +3368,7 @@ async fn list_directory(
 ) -> Result<DirectoryListing, String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
+    let show_claude = settings.project_claude_visible(&root);
     let after = after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
     let mut page = BTreeMap::new();
     let mut has_more = false;
@@ -3344,7 +3382,7 @@ async fn list_directory(
             || name == "node_modules"
             || name == "target"
             || name == ".venv"
-            || is_sensitive_path(&root, &entry.path())
+            || is_sensitive_path_with_claude(&root, &entry.path(), show_claude)
         {
             continue;
         }
@@ -3381,13 +3419,14 @@ async fn list_directory(
 
 #[tauri::command]
 async fn read_text_file(
+    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
 ) -> Result<String, String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
-    if is_sensitive_path(&root, &path) {
+    if is_sensitive_path_with_claude(&root, &path, settings.project_claude_visible(&root)) {
         return Err("Sensitive files are hidden from preview".into());
     }
     let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
@@ -3399,6 +3438,27 @@ async fn read_text_file(
         return Err("Binary files cannot be previewed".into());
     }
     String::from_utf8(bytes).map_err(|_| "File is not UTF-8 text".into())
+}
+
+#[tauri::command]
+fn show_claude_folder(settings: State<'_, FileBrowserSettings>) -> bool {
+    settings.show_claude.load(Ordering::Relaxed)
+}
+
+#[tauri::command]
+fn set_show_claude_folder(
+    app: AppHandle,
+    settings: State<'_, FileBrowserSettings>,
+    show: bool,
+) -> Result<(), String> {
+    let path = show_claude_path(&app)?;
+    if show {
+        write_atomic(&path, b"")?;
+    } else {
+        forget_record(&path)?;
+    }
+    settings.show_claude.store(show, Ordering::Relaxed);
+    Ok(())
 }
 
 fn bounded_git_lines(
@@ -4530,6 +4590,7 @@ pub fn run() {
             app.manage(load_roots(app.handle()));
             app.manage(load_provider_sessions(app.handle()));
             app.manage(load_codex_server(app.handle())?);
+            app.manage(load_file_browser_settings(app.handle()));
             #[cfg(target_os = "macos")]
             describe_app(app.handle())?;
             Ok(())
@@ -4549,6 +4610,8 @@ pub fn run() {
             delete_session_data,
             list_directory,
             read_text_file,
+            show_claude_folder,
+            set_show_claude_folder,
             git_status,
             git_remote,
             git_repo,
@@ -4601,5 +4664,44 @@ mod tests {
             command.get_env("LC_CTYPE"),
             cfg!(target_os = "macos").then_some(OsStr::new("UTF-8"))
         );
+    }
+
+    #[test]
+    fn claude_folder_opt_in_keeps_credentials_hidden() {
+        let root = Path::new("/project");
+        let settings = FileBrowserSettings {
+            home: Some(PathBuf::from("/home/user")),
+            show_claude: AtomicBool::new(true),
+        };
+
+        assert!(settings.project_claude_visible(root));
+        assert!(
+            !FileBrowserSettings {
+                home: Some(root.to_owned()),
+                show_claude: AtomicBool::new(true),
+            }
+            .project_claude_visible(root)
+        );
+        assert!(is_sensitive_path_with_claude(
+            root,
+            Path::new("/project/.claude/settings.json"),
+            false
+        ));
+        assert!(!is_sensitive_path_with_claude(
+            root,
+            Path::new("/project/.claude/settings.json"),
+            true
+        ));
+        assert!(is_sensitive_path_with_claude(
+            root,
+            Path::new("/project/.claude/.credentials.json"),
+            true
+        ));
+        assert!(is_sensitive_path_with_claude(
+            root,
+            Path::new("/project/package/.claude/settings.json"),
+            true
+        ));
+        assert!(is_sensitive_root(Path::new("/project/.claude")));
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ import {
   Copy,
   ExternalLink,
   GitBranch,
-  KeyRound,
   Link,
   Moon,
   MoreHorizontal,
@@ -25,6 +24,7 @@ import {
   RotateCcw,
   Scissors,
   Search,
+  Settings2,
   SquareTerminal,
   Sun,
   TextSelect,
@@ -927,6 +927,7 @@ function App() {
   const [attention, setAttention] = useState<string[]>([]);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [fileBrowserVersion, setFileBrowserVersion] = useState(0);
   const [closingAll, setClosingAll] = useState(false);
   // Bulk close is running: the dialog stays up and sessions stay untouched until every stop and
   // cleanup has settled, so nothing can be reopened under its own cleanup.
@@ -2136,8 +2137,8 @@ function App() {
                     </DropdownMenuGroup>
                   ) : null}
                   <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
-                    <KeyRound />
-                    API keys
+                    <Settings2 />
+                    Settings
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => void checkForUpdates()}>
                     <RefreshCw />
@@ -2416,6 +2417,7 @@ function App() {
                       <Inspector
                         session={selected}
                         remote={remote}
+                        fileBrowserVersion={fileBrowserVersion}
                         collapsed={shut.inspector}
                         onExpand={() =>
                           glide(inspectorPanel.current, share(inspectorPanel.current, SIDES.inspector.size))
@@ -2705,7 +2707,12 @@ function App() {
             onCreate={createSession}
             sessions={sessions}
           />
-          <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} onSignIn={signIn} />
+          <SettingsDialog
+            open={settingsOpen}
+            onOpenChange={setSettingsOpen}
+            onSignIn={signIn}
+            onFileBrowserChange={() => setFileBrowserVersion((version) => version + 1)}
+          />
           <Toaster />
         </div>
       </AppContextMenu>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1080,12 +1080,14 @@ function UsagePanel({ session }: { session: Session }) {
 export function Inspector({
   session,
   remote,
+  fileBrowserVersion,
   collapsed,
   onExpand,
   onCollapse,
 }: {
   session: Session;
   remote: string;
+  fileBrowserVersion: number;
   collapsed: boolean;
   onExpand: () => void;
   onCollapse: () => void;
@@ -1199,7 +1201,7 @@ export function Inspector({
           </div>
           {visited.has("files") ? (
             <TabsContent value="files" keepMounted className="min-h-0 overflow-hidden">
-              <FilesPanel key={reload.files} root={session.cwd} rootId={session.rootId} />
+              <FilesPanel key={`${reload.files}-${fileBrowserVersion}`} root={session.cwd} rootId={session.rootId} />
             </TabsContent>
           ) : null}
           {visited.has("git") ? (

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -17,8 +17,19 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
-import { Item, ItemActions, ItemContent, ItemFooter, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemFooter,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
+import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
 import type { Agent } from "@/types";
 
@@ -29,12 +40,15 @@ export function SettingsDialog({
   open: isOpen,
   onOpenChange,
   onSignIn,
+  onFileBrowserChange,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSignIn: (agent: Agent) => void;
+  onFileBrowserChange: () => void;
 }) {
   const [auth, setAuth] = useState<ProviderAuth[]>();
+  const [showClaude, setShowClaude] = useState<boolean>();
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [editing, setEditing] = useState<Set<string>>(new Set());
   const [revealed, setRevealed] = useState<Set<string>>(new Set());
@@ -42,7 +56,12 @@ export function SettingsDialog({
   const [error, setError] = useState("");
 
   const read = useCallback(async () => {
-    setAuth(await invoke<ProviderAuth[]>("provider_auth"));
+    const [nextAuth, nextShowClaude] = await Promise.all([
+      invoke<ProviderAuth[]>("provider_auth"),
+      invoke<boolean>("show_claude_folder"),
+    ]);
+    setAuth(nextAuth);
+    setShowClaude(nextShowClaude);
   }, []);
 
   useEffect(() => {
@@ -101,15 +120,26 @@ export function SettingsDialog({
     }
   }
 
+  async function changeShowClaude(show: boolean) {
+    setError("");
+    setBusy(".claude");
+    try {
+      await invoke("set_show_claude_folder", { show });
+      setShowClaude(show);
+      onFileBrowserChange();
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setBusy("");
+    }
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>API keys</DialogTitle>
-          <DialogDescription>
-            Each row shows how new sessions sign in. API keys saved here stay on this computer and take priority over
-            provider sign-in.
-          </DialogDescription>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription>Manage local API keys and file browser access.</DialogDescription>
         </DialogHeader>
         <DialogBody>
           <ItemGroup>
@@ -202,6 +232,24 @@ export function SettingsDialog({
               );
             })}
           </ItemGroup>
+          <Item variant="outline" className="mt-4">
+            <ItemContent>
+              <ItemTitle>
+                <Label htmlFor="show-claude-folder">Show .claude folders</Label>
+              </ItemTitle>
+              <ItemDescription>
+                Allow the file browser to show and preview the project’s .claude folder.
+              </ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <Switch
+                id="show-claude-folder"
+                checked={showClaude ?? false}
+                disabled={showClaude === undefined || busy === ".claude"}
+                onCheckedChange={(show) => void changeShowClaude(show)}
+              />
+            </ItemActions>
+          </Item>
           {error ? (
             <p role="alert" className="mt-4 text-sm text-destructive">
               {error}


### PR DESCRIPTION
PR #10 correctly blocked provider configuration after the [security review](https://github.com/ultralytics/lite/pull/10#discussion_r3724360833) and [Glenn’s follow-up](https://github.com/ultralytics/lite/pull/10#discussion_r3724388608). Project `.claude` folders also hold active repo settings, so this adds a narrow opt-in while keeping that secure default.

```diff
- project .claude: always hidden
+ project .claude: visible after opt-in
  ~/.claude and .credentials.json: always hidden
```

- refreshes the open file tree when the setting changes

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a Settings option to show project-level `.claude` folders in the file browser on request.

### 📊 Key Changes
- Adds a persistent `.claude` visibility preference with Rust commands to read and update it.
- Allows only the project root `.claude` folder to be listed and previewed when enabled.
- Keeps sensitive files such as `.credentials.json`, nested `.claude` folders, and the home directory’s `.claude` folder hidden.
- Updates the settings dialog, file browser refresh behavior, and renames the API keys dialog to Settings.
- Adds Rust tests covering visibility rules and credential protection.

### 🎯 Purpose & Impact
- Gives users controlled access to project-specific Claude configuration files without broadly exposing sensitive data.
- Persists the preference across launches and refreshes open file browser panels when changed.
- Improves settings discoverability while preserving existing sensitive-path safeguards.