### PR TITLE
Show all files by default

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -430,6 +430,30 @@ fn set_keep_awake(wake_lock: State<WakeLock>, enabled: bool) -> Result<(), Strin
 #[derive(Default)]
 struct Roots(Mutex<HashMap<String, PathBuf>>);
 
+struct FileBrowserSettings {
+    home: Option<PathBuf>,
+    show_claude: AtomicBool,
+}
+
+impl FileBrowserSettings {
+    fn project_claude_visible(&self, root: &Path) -> bool {
+        self.show_claude.load(Ordering::Relaxed)
+            && self.home.as_deref().is_some_and(|home| home != root)
+    }
+
+    fn is_sensitive_path(&self, root: &Path, path: &Path) -> bool {
+        let show_claude = self.project_claude_visible(root);
+        path.strip_prefix(root).is_ok_and(|relative| {
+            relative.components().enumerate().any(|(index, component)| {
+                is_sensitive_component(component.as_os_str())
+                    && !(show_claude
+                        && index == 0
+                        && component.as_os_str().eq_ignore_ascii_case(".claude"))
+            })
+        })
+    }
+}
+
 #[derive(Default)]
 struct ProviderSessions(Mutex<HashMap<String, String>>);
 
@@ -606,6 +630,7 @@ fn is_sensitive_component(component: &std::ffi::OsStr) -> bool {
     name == ".env"
         || name.starts_with(".env.")
         || [
+            ".credentials.json",
             ".aws",
             ".azure",
             ".claude",
@@ -630,14 +655,6 @@ fn is_sensitive_component(component: &std::ffi::OsStr) -> bool {
 fn is_sensitive_root(path: &Path) -> bool {
     path.components()
         .any(|component| is_sensitive_component(component.as_os_str()))
-}
-
-fn is_sensitive_path(root: &Path, path: &Path) -> bool {
-    path.strip_prefix(root).is_ok_and(|relative| {
-        relative
-            .components()
-            .any(|component| is_sensitive_component(component.as_os_str()))
-    })
 }
 
 fn command_output(git: &Path, directory: &Path, args: &[&str]) -> Result<String, String> {
@@ -676,6 +693,25 @@ fn last_directory_path(app: &AppHandle) -> Result<PathBuf, String> {
         .app_data_dir()
         .map_err(|error| error.to_string())?
         .join("last-directory"))
+}
+
+fn show_claude_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?
+        .join("show-claude-folder"))
+}
+
+fn load_file_browser_settings(app: &AppHandle) -> FileBrowserSettings {
+    FileBrowserSettings {
+        home: app
+            .path()
+            .home_dir()
+            .ok()
+            .and_then(|home| fs::canonicalize(home).ok()),
+        show_claude: AtomicBool::new(show_claude_path(app).is_ok_and(|path| path.is_file())),
+    }
 }
 
 fn read_roots(path: &Path) -> HashMap<String, PathBuf> {
@@ -3690,6 +3726,7 @@ fn delete_session_data(
 
 #[tauri::command]
 async fn list_directory(
+    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
@@ -3710,7 +3747,7 @@ async fn list_directory(
             || name == "node_modules"
             || name == "target"
             || name == ".venv"
-            || is_sensitive_path(&root, &entry.path())
+            || settings.is_sensitive_path(&root, &entry.path())
         {
             continue;
         }
@@ -3747,13 +3784,14 @@ async fn list_directory(
 
 #[tauri::command]
 async fn read_text_file(
+    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
 ) -> Result<String, String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
-    if is_sensitive_path(&root, &path) {
+    if settings.is_sensitive_path(&root, &path) {
         return Err("Sensitive files are hidden from preview".into());
     }
     let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
@@ -3769,6 +3807,7 @@ async fn read_text_file(
 
 #[tauri::command]
 async fn write_text_file(
+    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
@@ -3779,7 +3818,7 @@ async fn write_text_file(
     }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
-    if is_sensitive_path(&root, &path) {
+    if settings.is_sensitive_path(&root, &path) {
         return Err("Sensitive files cannot be edited in Lite".into());
     }
     if !path.is_file() {
@@ -3793,10 +3832,15 @@ async fn write_text_file(
 }
 
 #[tauri::command]
-async fn delete_file(roots: State<'_, Roots>, root_id: String, path: String) -> Result<(), String> {
+async fn delete_file(
+    settings: State<'_, FileBrowserSettings>,
+    roots: State<'_, Roots>,
+    root_id: String,
+    path: String,
+) -> Result<(), String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_entry(&root, &path)?;
-    if is_sensitive_path(&root, &path) {
+    if settings.is_sensitive_path(&root, &path) {
         return Err("Sensitive files cannot be deleted from Lite".into());
     }
     let file_type = fs::symlink_metadata(&path)
@@ -3806,6 +3850,27 @@ async fn delete_file(roots: State<'_, Roots>, root_id: String, path: String) -> 
         return Err("Only files can be deleted".into());
     }
     fs::remove_file(path).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn show_claude_folder(settings: State<'_, FileBrowserSettings>) -> bool {
+    settings.show_claude.load(Ordering::Relaxed)
+}
+
+#[tauri::command]
+fn set_show_claude_folder(
+    app: AppHandle,
+    settings: State<'_, FileBrowserSettings>,
+    show: bool,
+) -> Result<(), String> {
+    let path = show_claude_path(&app)?;
+    if show {
+        write_atomic(&path, b"")?;
+    } else {
+        forget_record(&path)?;
+    }
+    settings.show_claude.store(show, Ordering::Relaxed);
+    Ok(())
 }
 
 fn bounded_git_changes(
@@ -3923,6 +3988,7 @@ fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
 
 #[tauri::command]
 async fn git_diff(
+    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
@@ -3967,7 +4033,9 @@ async fn git_diff(
                 .into(),
         );
     }
-    if is_sensitive_path(&granted, &file) || is_sensitive_path(&granted, &ancestor) {
+    if settings.is_sensitive_path(&granted, &file)
+        || settings.is_sensitive_path(&granted, &ancestor)
+    {
         return Err("Sensitive files are hidden from Git diffs".into());
     }
     let pathspec = path_text(relative);
@@ -5175,6 +5243,7 @@ pub fn run() {
             app.manage(load_roots(app.handle()));
             app.manage(load_provider_sessions(app.handle()));
             app.manage(load_codex_server(app.handle())?);
+            app.manage(load_file_browser_settings(app.handle()));
             #[cfg(target_os = "macos")]
             {
                 describe_app(app.handle())?;
@@ -5200,6 +5269,8 @@ pub fn run() {
             read_text_file,
             write_text_file,
             delete_file,
+            show_claude_folder,
+            set_show_claude_folder,
             git_status,
             git_diff,
             git_remote,
@@ -5256,6 +5327,33 @@ mod tests {
         assert_eq!(
             command.get_env("LC_CTYPE"),
             cfg!(target_os = "macos").then_some(OsStr::new("UTF-8"))
+        );
+    }
+
+    #[test]
+    fn claude_folder_opt_in_keeps_credentials_hidden() {
+        let root = Path::new("/project");
+        let settings = FileBrowserSettings {
+            home: Some(PathBuf::from("/home/user")),
+            show_claude: AtomicBool::new(false),
+        };
+
+        assert!(settings.is_sensitive_path(root, Path::new("/project/.claude/settings.json")));
+        settings.show_claude.store(true, Ordering::Relaxed);
+        assert!(settings.project_claude_visible(root));
+        for (path, sensitive) in [
+            ("/project/.claude/settings.json", false),
+            ("/project/.claude/.credentials.json", true),
+            ("/project/package/.claude/settings.json", true),
+        ] {
+            assert_eq!(settings.is_sensitive_path(root, Path::new(path)), sensitive);
+        }
+        assert!(
+            FileBrowserSettings {
+                home: Some(root.to_owned()),
+                show_claude: AtomicBool::new(true),
+            }
+            .is_sensitive_path(root, Path::new("/project/.claude/settings.json"))
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -432,27 +432,7 @@ struct Roots(Mutex<HashMap<String, PathBuf>>);
 
 #[derive(Default)]
 struct FileBrowserSettings {
-    home: Option<PathBuf>,
-    show_claude: AtomicBool,
-}
-
-impl FileBrowserSettings {
-    fn project_claude_visible(&self, root: &Path) -> bool {
-        self.show_claude.load(Ordering::Relaxed)
-            && self.home.as_deref().is_some_and(|home| home != root)
-    }
-
-    fn is_sensitive_path(&self, root: &Path, path: &Path) -> bool {
-        let show_claude = self.project_claude_visible(root);
-        path.strip_prefix(root).is_ok_and(|relative| {
-            relative.components().enumerate().any(|(index, component)| {
-                is_sensitive_component(component.as_os_str())
-                    && !(show_claude
-                        && index == 0
-                        && component.as_os_str().eq_ignore_ascii_case(".claude"))
-            })
-        })
-    }
+    hide_hidden: AtomicBool,
 }
 
 #[derive(Default)]
@@ -596,12 +576,7 @@ fn root_path(roots: &Roots, root_id: &str) -> Result<PathBuf, String> {
     let root = roots
         .get(root_id)
         .ok_or("Folder permission is no longer available")?;
-    let root = fs::canonicalize(root).map_err(|_| MISSING_DIRECTORY.to_owned())?;
-    if is_sensitive_root(&root) {
-        Err("Credential and configuration folders cannot be opened".into())
-    } else {
-        Ok(root)
-    }
+    fs::canonicalize(root).map_err(|_| MISSING_DIRECTORY.to_owned())
 }
 
 fn scoped_path(root: &Path, path: &str) -> Result<PathBuf, String> {
@@ -628,77 +603,17 @@ fn scoped_entry(root: &Path, path: &str) -> Result<PathBuf, String> {
     Ok(parent.join(name))
 }
 
-fn contains_sensitive_entry(
-    settings: &FileBrowserSettings,
-    root: &Path,
-    path: &Path,
-) -> Result<bool, String> {
-    for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
-        let entry = entry.map_err(|error| error.to_string())?;
-        if settings.is_sensitive_path(root, &entry.path()) {
-            return Ok(true);
-        }
-        if entry
-            .file_type()
-            .map_err(|error| error.to_string())?
-            .is_dir()
-            && contains_sensitive_entry(settings, root, &entry.path())?
-        {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-fn remove_entry(settings: &FileBrowserSettings, root: &Path, path: &Path) -> Result<(), String> {
-    if settings.is_sensitive_path(root, path) {
-        return Err("Sensitive files and folders cannot be deleted from Lite".into());
-    }
+fn remove_entry(path: &Path) -> Result<(), String> {
     let file_type = fs::symlink_metadata(path)
         .map_err(|error| error.to_string())?
         .file_type();
     if file_type.is_dir() {
-        if contains_sensitive_entry(settings, root, path)? {
-            return Err("Folders containing sensitive files cannot be deleted from Lite".into());
-        }
         fs::remove_dir_all(path).map_err(|error| error.to_string())
     } else if file_type.is_file() || file_type.is_symlink() {
         fs::remove_file(path).map_err(|error| error.to_string())
     } else {
         Err("Only files and folders can be deleted".into())
     }
-}
-
-fn is_sensitive_component(component: &std::ffi::OsStr) -> bool {
-    let name = component.to_string_lossy().to_lowercase();
-    name == ".env"
-        || name.starts_with(".env.")
-        || [
-            ".credentials.json",
-            ".aws",
-            ".azure",
-            ".claude",
-            ".codex",
-            ".config",
-            ".docker",
-            ".gemini",
-            ".git-credentials",
-            ".gnupg",
-            ".kimi-code",
-            ".netrc",
-            ".npmrc",
-            ".pypirc",
-            ".qwen",
-            ".ssh",
-            "id_ed25519",
-            "id_rsa",
-        ]
-        .contains(&name.as_str())
-}
-
-fn is_sensitive_root(path: &Path) -> bool {
-    path.components()
-        .any(|component| is_sensitive_component(component.as_os_str()))
 }
 
 fn command_output(git: &Path, directory: &Path, args: &[&str]) -> Result<String, String> {
@@ -739,22 +654,17 @@ fn last_directory_path(app: &AppHandle) -> Result<PathBuf, String> {
         .join("last-directory"))
 }
 
-fn show_claude_path(app: &AppHandle) -> Result<PathBuf, String> {
+fn hide_hidden_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(app
         .path()
         .app_data_dir()
         .map_err(|error| error.to_string())?
-        .join("show-claude-folder"))
+        .join("hide-hidden-files"))
 }
 
 fn load_file_browser_settings(app: &AppHandle) -> FileBrowserSettings {
     FileBrowserSettings {
-        home: app
-            .path()
-            .home_dir()
-            .ok()
-            .and_then(|home| fs::canonicalize(home).ok()),
-        show_claude: AtomicBool::new(show_claude_path(app).is_ok_and(|path| path.is_file())),
+        hide_hidden: AtomicBool::new(hide_hidden_path(app).is_ok_and(|path| path.is_file())),
     }
 }
 
@@ -1080,9 +990,6 @@ fn grant_directory(
     root_id: Option<String>,
 ) -> Result<DirectoryGrant, String> {
     let path = fs::canonicalize(path).map_err(|error| error.to_string())?;
-    if is_sensitive_root(&path) {
-        return Err("Credential and configuration folders cannot be opened".into());
-    }
     let id = root_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     update_roots(app, roots, |roots| {
         roots.insert(id.clone(), path.clone());
@@ -1384,16 +1291,6 @@ async fn use_directory(
 ) -> Result<DirectoryGrant, String> {
     let path = typed_path(&app, &path)?;
     if !path.exists() {
-        // Resolve the closest existing ancestor before creating through it: a symlink into a sensitive
-        // configuration folder must not let the final canonical-path check happen after the mutation.
-        let mut ancestor = path.as_path();
-        while !ancestor.exists() {
-            ancestor = ancestor.parent().ok_or("That folder cannot be created")?;
-        }
-        let ancestor = fs::canonicalize(ancestor).map_err(|error| error.to_string())?;
-        if is_sensitive_root(&ancestor) || is_sensitive_root(&path) {
-            return Err("Credential and configuration folders cannot be opened".into());
-        }
         fs::create_dir_all(&path).map_err(|error| error.to_string())?;
     }
     if !path.is_dir() {
@@ -3317,9 +3214,6 @@ async fn spawn_session(
     {
         uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
         let path = fs::canonicalize(cwd).map_err(|_| MISSING_DIRECTORY)?;
-        if is_sensitive_root(&path) {
-            return Err("Credential and configuration folders cannot be opened".into());
-        }
         update_roots(&app, &roots, |roots| {
             roots.entry(root_id.clone()).or_insert(path);
         })?;
@@ -3822,12 +3716,7 @@ async fn list_directory(
             continue;
         };
         let name = entry.file_name().to_string_lossy().into_owned();
-        if name == ".git"
-            || name == "node_modules"
-            || name == "target"
-            || name == ".venv"
-            || settings.is_sensitive_path(&root, &entry.path())
-        {
+        if settings.hide_hidden.load(Ordering::Relaxed) && name.starts_with('.') {
             continue;
         }
         let entry = FileEntry {
@@ -3863,16 +3752,12 @@ async fn list_directory(
 
 #[tauri::command]
 async fn read_text_file(
-    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
 ) -> Result<String, String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
-    if settings.is_sensitive_path(&root, &path) {
-        return Err("Sensitive files are hidden from preview".into());
-    }
     let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
     if metadata.len() > MAX_FILE_BYTES {
         return Err("File is larger than 500 KB".into());
@@ -3886,7 +3771,6 @@ async fn read_text_file(
 
 #[tauri::command]
 async fn write_text_file(
-    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
@@ -3897,9 +3781,6 @@ async fn write_text_file(
     }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
-    if settings.is_sensitive_path(&root, &path) {
-        return Err("Sensitive files cannot be edited in Lite".into());
-    }
     if !path.is_file() {
         return Err("Only files can be edited".into());
     }
@@ -3912,34 +3793,33 @@ async fn write_text_file(
 
 #[tauri::command]
 async fn delete_entry(
-    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
 ) -> Result<(), String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_entry(&root, &path)?;
-    remove_entry(&settings, &root, &path)
+    remove_entry(&path)
 }
 
 #[tauri::command]
-fn show_claude_folder(settings: State<'_, FileBrowserSettings>) -> bool {
-    settings.show_claude.load(Ordering::Relaxed)
+fn hide_hidden_files(settings: State<'_, FileBrowserSettings>) -> bool {
+    settings.hide_hidden.load(Ordering::Relaxed)
 }
 
 #[tauri::command]
-fn set_show_claude_folder(
+fn set_hide_hidden_files(
     app: AppHandle,
     settings: State<'_, FileBrowserSettings>,
-    show: bool,
+    hide: bool,
 ) -> Result<(), String> {
-    let path = show_claude_path(&app)?;
-    if show {
+    let path = hide_hidden_path(&app)?;
+    if hide {
         write_atomic(&path, b"")?;
     } else {
         forget_record(&path)?;
     }
-    settings.show_claude.store(show, Ordering::Relaxed);
+    settings.hide_hidden.store(hide, Ordering::Relaxed);
     Ok(())
 }
 
@@ -4058,7 +3938,6 @@ fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
 
 #[tauri::command]
 async fn git_diff(
-    settings: State<'_, FileBrowserSettings>,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
@@ -4102,11 +3981,6 @@ async fn git_diff(
             "This change is outside the selected folder; start a session from the repository root to view it"
                 .into(),
         );
-    }
-    if settings.is_sensitive_path(&granted, &file)
-        || settings.is_sensitive_path(&granted, &ancestor)
-    {
-        return Err("Sensitive files are hidden from Git diffs".into());
     }
     let pathspec = path_text(relative);
     let file = path_text(&file);
@@ -5182,10 +5056,8 @@ fn local_repo() -> Option<&'static str> {
     option_env!("LITE_REPO")
 }
 
-// That same tree, opened for the one thing Lite does with it. The path is the one compiled into this
-// build rather than one handed in, and it deliberately does not go through use_directory: that records
-// what it opens as the folder to offer next, and rebuilding Lite is not the same as choosing to work
-// in it. The sensitive-folder rule still applies, as it does to every other grant.
+// That same tree, opened for the one thing Lite does with it. It deliberately bypasses the last folder
+// preference because rebuilding Lite is not the same as choosing a workspace.
 #[tauri::command]
 async fn grant_repo(app: AppHandle, roots: State<'_, Roots>) -> Result<DirectoryGrant, String> {
     let repo = option_env!("LITE_REPO").ok_or("This build did not record where it came from")?;
@@ -5339,8 +5211,8 @@ pub fn run() {
             read_text_file,
             write_text_file,
             delete_entry,
-            show_claude_folder,
-            set_show_claude_folder,
+            hide_hidden_files,
+            set_hide_hidden_files,
             git_status,
             git_diff,
             git_remote,
@@ -5400,33 +5272,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn claude_folder_opt_in_keeps_credentials_hidden() {
-        let root = Path::new("/project");
-        let settings = FileBrowserSettings {
-            home: Some(PathBuf::from("/home/user")),
-            show_claude: AtomicBool::new(false),
-        };
-
-        assert!(settings.is_sensitive_path(root, Path::new("/project/.claude/settings.json")));
-        settings.show_claude.store(true, Ordering::Relaxed);
-        assert!(settings.project_claude_visible(root));
-        for (path, sensitive) in [
-            ("/project/.claude/settings.json", false),
-            ("/project/.claude/.credentials.json", true),
-            ("/project/package/.claude/settings.json", true),
-        ] {
-            assert_eq!(settings.is_sensitive_path(root, Path::new(path)), sensitive);
-        }
-        assert!(
-            FileBrowserSettings {
-                home: Some(root.to_owned()),
-                show_claude: AtomicBool::new(true),
-            }
-            .is_sensitive_path(root, Path::new("/project/.claude/settings.json"))
-        );
-    }
-
     #[cfg(unix)]
     #[test]
     fn scoped_entry_keeps_a_symlink_as_the_deletion_target() {
@@ -5453,34 +5298,9 @@ mod tests {
         fs::create_dir_all(directory.join("nested")).unwrap();
         fs::write(directory.join("nested/file.txt"), "delete").unwrap();
 
-        remove_entry(
-            &FileBrowserSettings::default(),
-            directory.parent().unwrap(),
-            &directory,
-        )
-        .unwrap();
+        remove_entry(&directory).unwrap();
 
         assert!(!directory.exists());
-    }
-
-    #[test]
-    fn remove_entry_preserves_sensitive_descendants() {
-        let directory =
-            std::env::temp_dir().join(format!("lite-delete-directory-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(directory.join("nested")).unwrap();
-        fs::write(directory.join("nested/.env"), "keep").unwrap();
-
-        assert!(
-            remove_entry(
-                &FileBrowserSettings::default(),
-                directory.parent().unwrap(),
-                &directory
-            )
-            .is_err()
-        );
-        assert!(directory.join("nested/.env").exists());
-
-        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1464,6 +1464,7 @@ function App() {
   const [attention, setAttention] = useState<string[]>([]);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [fileBrowserVersion, setFileBrowserVersion] = useState(0);
   const [notifications, setNotifications] = useState(() => localStorage.getItem(NOTIFICATIONS_KEY) !== "false");
   const [keepAwake, setKeepAwake] = useState(() => localStorage.getItem(KEEP_AWAKE_KEY) === "true");
   const [closeWarningCount, setCloseWarningCount] = useState(0);
@@ -3265,6 +3266,7 @@ function App() {
                         session={selected}
                         remote={remote}
                         fontSize={inspectorFontSize}
+                        fileBrowserVersion={fileBrowserVersion}
                         collapsed={shut.inspector}
                         onExpand={() =>
                           glide(inspectorPanel.current, share(inspectorPanel.current, SIDES.inspector.size))
@@ -3628,6 +3630,12 @@ function App() {
             built={built}
             repo={repo}
             onCheckForUpdates={() => void checkForUpdates()}
+            onFileBrowserChange={() => {
+              sessions.forEach((session) => {
+                clearInspectorCache(session.id);
+              });
+              setFileBrowserVersion((version) => version + 1);
+            }}
           />
           <Toaster />
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3675,12 +3675,7 @@ function App() {
             built={built}
             repo={repo}
             onCheckForUpdates={() => void checkForUpdates()}
-            onFileBrowserChange={() => {
-              sessions.forEach((session) => {
-                clearInspectorCache(session.id);
-              });
-              setFileBrowserVersion((version) => version + 1);
-            }}
+            onFileBrowserChange={() => setFileBrowserVersion((version) => version + 1)}
           />
           <Toaster />
         </div>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1570,6 +1570,7 @@ export function Inspector({
   session,
   remote,
   fontSize,
+  fileBrowserVersion,
   collapsed,
   onExpand,
   onCollapse,
@@ -1577,6 +1578,7 @@ export function Inspector({
   session: Session;
   remote: string;
   fontSize: number;
+  fileBrowserVersion: number;
   collapsed: boolean;
   onExpand: () => void;
   onCollapse: () => void;
@@ -1691,7 +1693,7 @@ export function Inspector({
           {visited.has("files") ? (
             <TabsContent value="files" keepMounted className="min-h-0 overflow-hidden">
               <FilesPanel
-                key={`${session.rootId}:${reload.files}`}
+                key={`${session.rootId}:${reload.files}:${fileBrowserVersion}`}
                 root={session.cwd}
                 rootId={session.rootId}
                 sessionId={session.id}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1038,6 +1038,7 @@ function FilesPanel({
   rootId,
   sessionId,
   fontSize,
+  fileBrowserVersion,
   searchRef,
   onLoad,
 }: {
@@ -1045,6 +1046,7 @@ function FilesPanel({
   rootId: string;
   sessionId: string;
   fontSize: number;
+  fileBrowserVersion: number;
   searchRef: Ref<HTMLInputElement>;
   onLoad: (tab: InspectorTab) => void;
 }) {
@@ -1144,7 +1146,7 @@ function FilesPanel({
         <ScrollArea className="min-h-0 flex-1">
           <div style={contentZoomStyle(fontSize)}>
             <FileTree
-              key={rootId}
+              key={`${rootId}:${fileBrowserVersion}`}
               root={root}
               rootId={rootId}
               query={query}
@@ -1775,11 +1777,12 @@ export function Inspector({
           {visited.has("files") ? (
             <TabsContent value="files" keepMounted className="min-h-0 overflow-hidden">
               <FilesPanel
-                key={`${session.rootId}:${reload.files}:${fileBrowserVersion}`}
+                key={`${session.rootId}:${reload.files}`}
                 root={session.cwd}
                 rootId={session.rootId}
                 sessionId={session.id}
                 fontSize={fontSize}
+                fileBrowserVersion={fileBrowserVersion}
                 searchRef={fileSearch}
                 onLoad={finishRefresh}
               />

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1788,7 +1788,7 @@ export function Inspector({
           {visited.has("git") ? (
             <TabsContent value="git" keepMounted className="min-h-0 overflow-hidden">
               <GitPanel
-                key={`${session.rootId}:${reload.git}:${fileBrowserVersion}`}
+                key={`${session.rootId}:${reload.git}`}
                 rootId={session.rootId}
                 sessionId={session.id}
                 remote={remote}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1704,7 +1704,7 @@ export function Inspector({
           {visited.has("git") ? (
             <TabsContent value="git" keepMounted className="min-h-0 overflow-hidden">
               <GitPanel
-                key={`${session.rootId}:${reload.git}`}
+                key={`${session.rootId}:${reload.git}:${fileBrowserVersion}`}
                 rootId={session.rootId}
                 sessionId={session.id}
                 remote={remote}

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Eye,
   EyeOff,
+  FolderCog,
   Info,
   KeyRound,
   Moon,
@@ -63,6 +64,7 @@ export function SettingsDialog({
   built,
   repo,
   onCheckForUpdates,
+  onFileBrowserChange,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -78,8 +80,10 @@ export function SettingsDialog({
   built: string;
   repo: string;
   onCheckForUpdates: () => void;
+  onFileBrowserChange: () => void;
 }) {
   const [auth, setAuth] = useState<ProviderAuth[]>();
+  const [showClaude, setShowClaude] = useState<boolean>();
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [editing, setEditing] = useState<Set<string>>(new Set());
   const [revealed, setRevealed] = useState<Set<string>>(new Set());
@@ -97,9 +101,11 @@ export function SettingsDialog({
     setDrafts({});
     setEditing(new Set());
     setRevealed(new Set());
-    void Promise.all([read(), invoke<boolean>("notifications_supported").then(setNotificationsSupported)]).catch(
-      (reason) => setError(String(reason)),
-    );
+    void Promise.all([
+      read(),
+      invoke<boolean>("notifications_supported").then(setNotificationsSupported),
+      invoke<boolean>("show_claude_folder").then(setShowClaude),
+    ]).catch((reason) => setError(String(reason)));
   }, [isOpen, read]);
 
   function edit(id: string, open: boolean) {
@@ -149,6 +155,20 @@ export function SettingsDialog({
     setBusy("notifications");
     try {
       await onNotificationsChange(enabled);
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function changeShowClaude(show: boolean) {
+    setError("");
+    setBusy(".claude");
+    try {
+      await invoke("set_show_claude_folder", { show });
+      setShowClaude(show);
+      onFileBrowserChange();
     } catch (reason) {
       setError(String(reason));
     } finally {
@@ -230,6 +250,23 @@ export function SettingsDialog({
                     </ItemActions>
                   </Item>
                 ) : null}
+                <Item variant="outline">
+                  <ItemMedia variant="icon">
+                    <FolderCog />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>Show Project .claude Folders</ItemTitle>
+                    <ItemDescription>Show project settings, hooks, and plugins in Files.</ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Switch
+                      aria-label="Show project .claude folders"
+                      checked={showClaude ?? false}
+                      disabled={showClaude === undefined || busy === ".claude"}
+                      onCheckedChange={(show) => void changeShowClaude(show)}
+                    />
+                  </ItemActions>
+                </Item>
               </ItemGroup>
             </TabsContent>
             <TabsContent value="keys" className="min-w-0">

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -83,7 +83,7 @@ export function SettingsDialog({
   onFileBrowserChange: () => void;
 }) {
   const [auth, setAuth] = useState<ProviderAuth[]>();
-  const [showClaude, setShowClaude] = useState<boolean>();
+  const [hideHidden, setHideHidden] = useState<boolean>();
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [editing, setEditing] = useState<Set<string>>(new Set());
   const [revealed, setRevealed] = useState<Set<string>>(new Set());
@@ -104,7 +104,7 @@ export function SettingsDialog({
     void Promise.all([
       read(),
       invoke<boolean>("notifications_supported").then(setNotificationsSupported),
-      invoke<boolean>("show_claude_folder").then(setShowClaude),
+      invoke<boolean>("hide_hidden_files").then(setHideHidden),
     ]).catch((reason) => setError(String(reason)));
   }, [isOpen, read]);
 
@@ -162,12 +162,12 @@ export function SettingsDialog({
     }
   }
 
-  async function changeShowClaude(show: boolean) {
+  async function changeHideHidden(hide: boolean) {
     setError("");
-    setBusy(".claude");
+    setBusy("hidden-files");
     try {
-      await invoke("set_show_claude_folder", { show });
-      setShowClaude(show);
+      await invoke("set_hide_hidden_files", { hide });
+      setHideHidden(hide);
       onFileBrowserChange();
     } catch (reason) {
       setError(String(reason));
@@ -193,6 +193,10 @@ export function SettingsDialog({
               <TabsTrigger value="keys">
                 <KeyRound />
                 API Keys
+              </TabsTrigger>
+              <TabsTrigger value="files">
+                <FolderCog />
+                Files
               </TabsTrigger>
               <TabsTrigger value="about">
                 <Info />
@@ -250,23 +254,6 @@ export function SettingsDialog({
                     </ItemActions>
                   </Item>
                 ) : null}
-                <Item variant="outline">
-                  <ItemMedia variant="icon">
-                    <FolderCog />
-                  </ItemMedia>
-                  <ItemContent>
-                    <ItemTitle>Show Project .claude Folders</ItemTitle>
-                    <ItemDescription>Show project settings, hooks, and plugins in Files.</ItemDescription>
-                  </ItemContent>
-                  <ItemActions>
-                    <Switch
-                      aria-label="Show project .claude folders"
-                      checked={showClaude ?? false}
-                      disabled={showClaude === undefined || busy === ".claude"}
-                      onCheckedChange={(show) => void changeShowClaude(show)}
-                    />
-                  </ItemActions>
-                </Item>
               </ItemGroup>
             </TabsContent>
             <TabsContent value="keys" className="min-w-0">
@@ -362,6 +349,29 @@ export function SettingsDialog({
                     </Item>
                   );
                 })}
+              </ItemGroup>
+            </TabsContent>
+            <TabsContent value="files" className="min-w-0">
+              <h2 className="text-base font-semibold">Files</h2>
+              <p className="mt-1 mb-4 text-sm text-muted-foreground">Choose which files appear in the browser.</p>
+              <ItemGroup>
+                <Item variant="outline">
+                  <ItemMedia variant="icon">
+                    <EyeOff />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>Hide Hidden Files</ItemTitle>
+                    <ItemDescription>Hide files and folders whose names begin with a period.</ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Switch
+                      aria-label="Hide hidden files"
+                      checked={hideHidden ?? false}
+                      disabled={hideHidden === undefined || busy === "hidden-files"}
+                      onCheckedChange={(hide) => void changeHideHidden(hide)}
+                    />
+                  </ItemActions>
+                </Item>
               </ItemGroup>
             </TabsContent>
             <TabsContent value="about" className="min-w-0">


### PR DESCRIPTION
Lite now shows every file and directory by default, including dotfiles and provider configuration.

- removes provider- and credential-specific shielding from the file browser
- adds a dedicated Files settings section with an opt-in **Hide Hidden Files** toggle
- refreshes directory trees without discarding open editor drafts

Closes #105.