### PR TITLE
Fix terminal GitHub reference detection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.32"
+version = "0.0.33"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -16,6 +16,8 @@ export interface GitHubReferences {
 // candidate: GitHub activity must independently confirm them before they reach the panel.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC hyperlinks are terminal framing.
+const HYPERLINK = /\u001b]8;[^;]*;([^\u0007\u001b]*)(?:\u0007|\u001b\\)/g;
 const GITHUB_ITEM = /\bhttps:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(pull|issues)\/([1-9]\d{0,8})(?!\w)/gi;
 const GITHUB_REPOSITORY =
   /\bhttps:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?=\/(?:pulls?|issues)(?:[/?#\s]|$)|\/?(?:[?#\s]|$))/gi;
@@ -58,8 +60,10 @@ export function githubItemReferences(output: string, remote: string, terminalStr
 
   for (const match of text.matchAll(GITHUB_ITEM))
     add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
-  for (const match of terminalStream.replace(COLOR, "").matchAll(GITHUB_ITEM))
-    add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
+  for (const hyperlink of terminalStream.matchAll(HYPERLINK)) {
+    for (const match of hyperlink[1].matchAll(GITHUB_ITEM))
+      add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
+  }
   for (const match of text.matchAll(QUALIFIED_ITEM)) add(match, `${match[1]}/${match[2]}`, "issues", match[3], 1);
   const qualifiedMentions: [number, number][] = [];
   for (const match of text.matchAll(ITEM_MENTION)) {

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -17,10 +17,12 @@ export interface GitHubReferences {
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a color code has to be named to be removed.
 const COLOR = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
 const GITHUB_ITEM = /\bhttps:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/(pull|issues)\/([1-9]\d{0,8})(?!\w)/gi;
+const GITHUB_REPOSITORY =
+  /\bhttps:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?=\/(?:pulls?|issues)(?:[/?#\s]|$)|\/?(?:[?#\s]|$))/gi;
 const QUALIFIED_ITEM = /(?:^|[^\w./-])(\w[\w.-]*)\/(\w[\w.-]*)#([1-9]\d{0,8})(?!\w)/g;
 const ITEM_MENTION =
-  /(?:^|[^\w./-])(\w[\w.-]*\/\w[\w.-]*)[ \t]+(pull requests?|PRs?|issues?)[ \t]+#?([1-9]\d{0,8})(?![\w.])/gi;
-const BARE_ITEM_MENTION = /(?:^|[^\w./-])(pull requests?|PRs?|issues?)[ \t]+#([1-9]\d{0,8})(?![\w.])/gi;
+  /(?:^|[^\w./-])(\w[\w.-]*\/\w[\w.-]*)[ \t]+(pull requests?|PRs?|issues?)[ \t]+#?([1-9]\d{0,8})(?!\w|\.\d)/gi;
+const BARE_ITEM_MENTION = /(?:^|[^\w./-])(pull requests?|PRs?|issues?)[ \t]+#?([1-9]\d{0,8})(?!\w|\.\d)/gi;
 const GH_ITEM_COMMAND =
   /\bgh\s+(issue|pr)\s+(?!create\b|list\b|status\b)[\w-]+((?:[^;&|'"\\\r\n]|\\.|'[^']*'|"(?:\\.|[^"\\])*")*)/gi;
 const GH_REPOSITORY =
@@ -47,16 +49,21 @@ export function githubItemReferences(output: string, remote: string): GitHubRefe
     });
   };
   const base = remote.match(/^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/i);
-  const repository = base ? `${base[1]}/${base[2]}` : "";
+  const repositories = new Set<string>();
+  for (const match of text.matchAll(GITHUB_REPOSITORY)) repositories.add(`${match[1]}/${match[2]}`);
+  const repository = base ? `${base[1]}/${base[2]}` : repositories.size === 1 ? [...repositories][0] : "";
 
   for (const match of text.matchAll(GITHUB_ITEM))
     add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
-  for (const match of text.matchAll(QUALIFIED_ITEM)) add(match, `${match[1]}/${match[2]}`, "issues", match[3], 1);
+  for (const match of text.matchAll(QUALIFIED_ITEM)) add(match, `${match[1]}/${match[2]}`, "issues", match[3], 1, true);
+  const qualifiedMentions: [number, number][] = [];
   for (const match of text.matchAll(ITEM_MENTION)) {
     add(match, match[1], match[2].toLowerCase().startsWith("issue") ? "issues" : "pull", match[3], 2);
+    qualifiedMentions.push([match.index, match.index + match[0].length]);
   }
   if (repository) {
     for (const match of text.matchAll(BARE_ITEM_MENTION)) {
+      if (qualifiedMentions.some(([start, end]) => match.index >= start && match.index < end)) continue;
       add(match, repository, match[1].toLowerCase().startsWith("issue") ? "issues" : "pull", match[2], 0, true);
     }
   }

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -30,7 +30,7 @@ const GH_REPOSITORY =
 const GH_API =
   /\bgh\s+api\s+["']?(?:https:\/\/api\.github\.com\/)?\/?repos\/([\w.-]+)\/([\w.-]+)\/(issues|pulls)\/([1-9]\d{0,8})(?![\w/])/gi;
 
-export function githubItemReferences(output: string, remote: string): GitHubReferences {
+export function githubItemReferences(output: string, remote: string, terminalStream = ""): GitHubReferences {
   const text = output.replace(COLOR, "");
   const candidates: Candidate[] = [];
   const add = (
@@ -55,7 +55,9 @@ export function githubItemReferences(output: string, remote: string): GitHubRefe
 
   for (const match of text.matchAll(GITHUB_ITEM))
     add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
-  for (const match of text.matchAll(QUALIFIED_ITEM)) add(match, `${match[1]}/${match[2]}`, "issues", match[3], 1, true);
+  for (const match of terminalStream.replace(COLOR, "").matchAll(GITHUB_ITEM))
+    add(match, `${match[1]}/${match[2]}`, match[3].toLowerCase(), match[4], 4);
+  for (const match of text.matchAll(QUALIFIED_ITEM)) add(match, `${match[1]}/${match[2]}`, "issues", match[3], 1);
   const qualifiedMentions: [number, number][] = [];
   for (const match of text.matchAll(ITEM_MENTION)) {
     add(match, match[1], match[2].toLowerCase().startsWith("issue") ? "issues" : "pull", match[3], 2);

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -50,7 +50,10 @@ export function githubItemReferences(output: string, remote: string, terminalStr
   };
   const base = remote.match(/^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/i);
   const repositories = new Set<string>();
-  for (const match of text.matchAll(GITHUB_REPOSITORY)) repositories.add(`${match[1]}/${match[2]}`);
+  for (const match of text.matchAll(GITHUB_REPOSITORY)) {
+    const name = match[2].replace(/\.+$/, "").replace(/\.git$/i, "");
+    if (name) repositories.add(`${match[1]}/${name}`);
+  }
   const repository = base ? `${base[1]}/${base[2]}` : repositories.size === 1 ? [...repositories][0] : "";
 
   for (const match of text.matchAll(GITHUB_ITEM))

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -76,7 +76,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { githubItemReferences, likelyGitHubItems } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { including, without } from "@/lib/utils";
-import { readTerminalOutput, subscribeTerminalOutput } from "@/output-store";
+import { readTerminalOutput, readTerminalStream, subscribeTerminalOutput } from "@/output-store";
 import { contentZoomStyle } from "@/theme";
 import {
   type DirectoryCursor,
@@ -93,7 +93,7 @@ import {
 const CodePreview = lazy(() => import("@/code-preview"));
 
 function namedInSession(sessionId: string, remote: string) {
-  return githubItemReferences(readTerminalOutput(sessionId), remote);
+  return githubItemReferences(readTerminalOutput(sessionId), remote, readTerminalStream(sessionId));
 }
 
 interface GitHubReference {
@@ -1305,9 +1305,14 @@ function GitPanel({
     const scan = () => {
       const next = namedInSession(sessionId, remote);
       setReferences((current) => {
-        const same = (key: keyof typeof next) =>
-          current[key].length === next[key].length && current[key].every((url, index) => url === next[key][index]);
-        return same("explicit") && same("inferred") ? current : next;
+        // Alternate-screen redraws can hide earlier conversation text, so an observed reference stays
+        // with this session until the user explicitly refreshes the panel.
+        const explicit = [...new Set([...current.explicit, ...next.explicit])];
+        const certain = new Set(explicit);
+        const inferred = [...new Set([...current.inferred, ...next.inferred])].filter((url) => !certain.has(url));
+        return explicit.length === current.explicit.length && inferred.length === current.inferred.length
+          ? current
+          : { explicit, inferred };
       });
     };
     const unsubscribe = subscribeTerminalOutput(sessionId, () => {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -76,7 +76,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { githubItemReferences, likelyGitHubItems } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { including, without } from "@/lib/utils";
-import { MAX_OUTPUT_BYTES, readOutput, subscribeOutput } from "@/output-store";
+import { readTerminalOutput, subscribeTerminalOutput } from "@/output-store";
 import { contentZoomStyle } from "@/theme";
 import {
   type DirectoryCursor,
@@ -93,7 +93,7 @@ import {
 const CodePreview = lazy(() => import("@/code-preview"));
 
 function namedInSession(sessionId: string, remote: string) {
-  return githubItemReferences(readOutput(sessionId).slice(-MAX_OUTPUT_BYTES), remote);
+  return githubItemReferences(readTerminalOutput(sessionId), remote);
 }
 
 interface GitHubReference {
@@ -1298,11 +1298,9 @@ function GitPanel({
   const [diffLoading, setDiffLoading] = useState(false);
   const diffRequest = useRef(0);
 
-  // While Git is visible, follow the output stream it summarizes. Subscribing replays the existing
-  // chunks synchronously, so one initial scan replaces rescanning the whole bounded buffer per chunk.
+  // While Git is visible, follow the terminal text it summarizes after xterm has applied redraws.
   useEffect(() => {
     if (!active) return;
-    let replaying = true;
     let settle = 0;
     const scan = () => {
       const next = namedInSession(sessionId, remote);
@@ -1312,12 +1310,10 @@ function GitPanel({
         return same("explicit") && same("inferred") ? current : next;
       });
     };
-    const unsubscribe = subscribeOutput(sessionId, () => {
-      if (replaying) return;
+    const unsubscribe = subscribeTerminalOutput(sessionId, () => {
       window.clearTimeout(settle);
       settle = window.setTimeout(scan, 250);
     });
-    replaying = false;
     scan();
     return () => {
       window.clearTimeout(settle);

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -146,7 +146,7 @@ export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) 
 // The buffer is bytes because a terminal is bytes. Anything that wants to read back what a session
 // said needs the same bytes as text, decoded as one stream so a character split across two chunks
 // survives the join.
-function readOutput(sessionId: string) {
+export function readTerminalStream(sessionId: string) {
   const buffer = buffers.get(sessionId);
   if (!buffer) return "";
   const decoder = new TextDecoder();
@@ -165,7 +165,7 @@ export function connectTerminalOutput(sessionId: string, read: () => string) {
 }
 
 export function readTerminalOutput(sessionId: string) {
-  return terminalReaders.get(sessionId)?.() ?? terminalSnapshots.get(sessionId) ?? readOutput(sessionId);
+  return terminalReaders.get(sessionId)?.() ?? terminalSnapshots.get(sessionId) ?? readTerminalStream(sessionId);
 }
 
 export function notifyTerminalOutput(sessionId: string) {

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -19,6 +19,9 @@ interface Buffer {
 
 const buffers = new Map<string, Buffer>();
 const listeners = new Map<string, Set<(data: Uint8Array) => void>>();
+const terminalReaders = new Map<string, () => string>();
+const terminalSnapshots = new Map<string, string>();
+const terminalListeners = new Map<string, Set<() => void>>();
 
 // Titles and working directories arrive whether or not the session is visible, so their shared OSC
 // owner lives here where every session's output arrives rather than in the mounted terminal. Lite's
@@ -143,15 +146,44 @@ export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) 
 // The buffer is bytes because a terminal is bytes. Anything that wants to read back what a session
 // said needs the same bytes as text, decoded as one stream so a character split across two chunks
 // survives the join.
-export function readOutput(sessionId: string) {
+function readOutput(sessionId: string) {
   const buffer = buffers.get(sessionId);
   if (!buffer) return "";
   const decoder = new TextDecoder();
   return buffer.chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") + decoder.decode();
 }
 
+// The terminal owns what its control stream means. Consumers that need what a person can actually
+// read ask that owner instead of guessing at cursor movement, erased lines, and soft wrapping.
+export function connectTerminalOutput(sessionId: string, read: () => string) {
+  terminalReaders.set(sessionId, read);
+  return () => {
+    if (terminalReaders.get(sessionId) !== read) return;
+    terminalSnapshots.set(sessionId, read());
+    terminalReaders.delete(sessionId);
+  };
+}
+
+export function readTerminalOutput(sessionId: string) {
+  return terminalReaders.get(sessionId)?.() ?? terminalSnapshots.get(sessionId) ?? readOutput(sessionId);
+}
+
+export function notifyTerminalOutput(sessionId: string) {
+  for (const listener of terminalListeners.get(sessionId) ?? []) listener();
+}
+
+export function subscribeTerminalOutput(sessionId: string, listener: () => void) {
+  const sessionListeners = terminalListeners.get(sessionId) ?? new Set();
+  sessionListeners.add(listener);
+  terminalListeners.set(sessionId, sessionListeners);
+  return () => sessionListeners.delete(listener);
+}
+
 export function clearOutput(sessionId: string) {
   buffers.delete(sessionId);
+  terminalReaders.delete(sessionId);
+  terminalSnapshots.delete(sessionId);
+  terminalListeners.delete(sessionId);
   writes.delete(sessionId);
 }
 

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -7,7 +7,13 @@ import { type ITheme, Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 
-import { subscribeOutput, writeSession } from "@/output-store";
+import {
+  connectTerminalOutput,
+  MAX_OUTPUT_BYTES,
+  notifyTerminalOutput,
+  subscribeOutput,
+  writeSession,
+} from "@/output-store";
 import { type Theme, zoomStep } from "@/theme";
 import type { Agent } from "@/types";
 
@@ -76,6 +82,21 @@ const SEQUENCES = /\x1b(?:[\]P][\s\S]*?(?:\x07|\x1b\\)|\[[\x30-\x3f]*[ -/]*[@-~]
 // it is the Escape key, and holding it back would swallow the next character typed.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: a control sequence is defined by them
 const PARTIAL = /\x1b(?:[\]P](?:(?!\x07|\x1b\\)[\s\S])*|\[[\x30-\x3f]*[ -/]*|O)$/;
+
+function renderedOutput(terminal: Terminal) {
+  let text = "";
+  const { active, normal } = terminal.buffer;
+  for (const buffer of active.type === "normal" ? [active] : [normal, active]) {
+    if (text) text += "\n";
+    for (let index = 0; index < buffer.length; index++) {
+      const line = buffer.getLine(index);
+      if (!line) continue;
+      if (index && !line.isWrapped) text += "\n";
+      text += line.translateToString(true);
+    }
+  }
+  return text.slice(-MAX_OUTPUT_BYTES);
+}
 
 export function TerminalView({
   sessionId,
@@ -154,6 +175,8 @@ export function TerminalView({
       }),
     );
     terminal.open(container);
+    const disconnectTerminalOutput = connectTerminalOutput(sessionId, () => renderedOutput(terminal));
+    const parsed = terminal.onWriteParsed(() => notifyTerminalOutput(sessionId));
     const unsubscribe = subscribeOutput(sessionId, (data) => terminal.write(data));
     // What the user types before the first Enter is the closest thing a session has to a subject.
     // Typing, pasting, and the terminal's own answers to the program's cursor, focus, and color
@@ -245,6 +268,8 @@ export function TerminalView({
       observer.disconnect();
       input.dispose();
       unsubscribe();
+      parsed.dispose();
+      disconnectTerminalOutput();
       terminal.dispose();
       terminalRef.current = null;
       resizeRef.current = () => undefined;

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -88,7 +88,18 @@ function renderedOutput(terminal: Terminal) {
   const { active, normal } = terminal.buffer;
   for (const buffer of active.type === "normal" ? [active] : [normal, active]) {
     if (text) text += "\n";
+    let inputStart = -1;
+    let inputEnd = -1;
+    if (buffer === active) {
+      inputStart = buffer.baseY + buffer.cursorY;
+      inputEnd = inputStart;
+      while (inputStart > 0 && buffer.getLine(inputStart)?.isWrapped) inputStart--;
+      while (inputEnd + 1 < buffer.length && buffer.getLine(inputEnd + 1)?.isWrapped) inputEnd++;
+    }
     for (let index = 0; index < buffer.length; index++) {
+      // The cursor's logical line is still being typed or streamed. It becomes readable history only
+      // after the terminal advances, which keeps partial URLs and PR numbers out of the inspector.
+      if (index >= inputStart && index <= inputEnd) continue;
       const line = buffer.getLine(index);
       if (!line) continue;
       if (index && !line.isWrapped) text += "\n";

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -92,7 +92,7 @@ function renderedOutput(terminal: Terminal) {
       const line = buffer.getLine(index);
       if (!line) continue;
       if (index && !line.isWrapped) text += "\n";
-      text += line.translateToString(true);
+      text += line.translateToString(true, 0, Math.min(line.length, terminal.cols));
     }
   }
   return text.slice(-MAX_OUTPUT_BYTES);

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -144,6 +144,13 @@ Reviewed PR 3612, pull request #3611, and issue 3497.`,
     });
   });
 
+  test("excludes sentence punctuation from a repository link", () => {
+    expect(githubItemReferences("See https://github.com/ultralytics/portal. Then review PR 3612.", "")).toEqual({
+      explicit: [],
+      inferred: ["https://github.com/ultralytics/portal/pull/3612"],
+    });
+  });
+
   test("keeps inferred items only when GitHub confirms activity in the last 30 days", () => {
     const inferred = [
       "https://github.com/ultralytics/portal/pull/102",

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -39,13 +39,14 @@ gh api repos/ultralytics/assistant/pulls/3048
     expect(githubItemReferences(transcript, "")).toEqual({
       explicit: [
         "https://github.com/ultralytics/lite/pull/102",
+        "https://github.com/ultralytics/portal/issues/3608",
         "https://github.com/ultralytics/assistant/issues/3052",
         "https://github.com/ultralytics/lite/pull/97",
         "https://github.com/ultralytics/portal/issues/3497",
         "https://github.com/ultralytics/lite/pull/94",
         "https://github.com/ultralytics/assistant/pull/3048",
       ],
-      inferred: ["https://github.com/ultralytics/portal/issues/3608"],
+      inferred: [],
     });
   });
 
@@ -98,7 +99,7 @@ gh issue view 102 --repo ULTRALYTICS/LITE
       "\u001b[32mhttps://github.com/ultralytics/lite/issues/88\u001b[0m " +
       "\u001b]8;;https://github.com/ultralytics/lite/pull/90\u0007PR\u001b]8;;\u0007";
 
-    expect(explicit(transcript)).toEqual([
+    expect(githubItemReferences("PR", "", transcript).explicit).toEqual([
       "https://github.com/ultralytics/lite/issues/88",
       "https://github.com/ultralytics/lite/pull/90",
     ]);

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -99,10 +99,15 @@ gh issue view 102 --repo ULTRALYTICS/LITE
       "\u001b[32mhttps://github.com/ultralytics/lite/issues/88\u001b[0m " +
       "\u001b]8;;https://github.com/ultralytics/lite/pull/90\u0007PR\u001b]8;;\u0007";
 
-    expect(githubItemReferences("PR", "", transcript).explicit).toEqual([
+    expect(githubItemReferences("https://github.com/ultralytics/lite/issues/88 PR", "", transcript).explicit).toEqual([
       "https://github.com/ultralytics/lite/issues/88",
       "https://github.com/ultralytics/lite/pull/90",
     ]);
+  });
+
+  test("does not recover incomplete plain URLs from the control stream", () => {
+    const stream = "https://github.com/ultralytics/lite/pull/36\u001b[2D12";
+    expect(githubItemReferences("", "", stream)).toEqual({ explicit: [], inferred: [] });
   });
 
   test("separates ambiguous references for recent-activity verification", () => {

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -36,15 +36,17 @@ gh pr view --json number -R ultralytics/lite 94
 gh api repos/ultralytics/assistant/pulls/3048
 `;
 
-    expect(explicit(transcript)).toEqual([
-      "https://github.com/ultralytics/lite/pull/102",
-      "https://github.com/ultralytics/portal/issues/3608",
-      "https://github.com/ultralytics/assistant/issues/3052",
-      "https://github.com/ultralytics/lite/pull/97",
-      "https://github.com/ultralytics/portal/issues/3497",
-      "https://github.com/ultralytics/lite/pull/94",
-      "https://github.com/ultralytics/assistant/pull/3048",
-    ]);
+    expect(githubItemReferences(transcript, "")).toEqual({
+      explicit: [
+        "https://github.com/ultralytics/lite/pull/102",
+        "https://github.com/ultralytics/assistant/issues/3052",
+        "https://github.com/ultralytics/lite/pull/97",
+        "https://github.com/ultralytics/portal/issues/3497",
+        "https://github.com/ultralytics/lite/pull/94",
+        "https://github.com/ultralytics/assistant/pull/3048",
+      ],
+      inferred: ["https://github.com/ultralytics/portal/issues/3608"],
+    });
   });
 
   test("rejects ambiguous and malformed references", () => {
@@ -120,6 +122,23 @@ ultralytics/lite PR #102
         "https://github.com/ultralytics/lite/issues/3052",
         "https://github.com/ultralytics/lite/pull/94",
         "https://github.com/ultralytics/lite/issues/88",
+      ],
+    });
+  });
+
+  test("uses one named repository to resolve bare references without a Git remote", () => {
+    const references = githubItemReferences(
+      `Let's fix and merge https://github.com/ultralytics/portal/pulls
+Reviewed PR 3612, pull request #3611, and issue 3497.`,
+      "",
+    );
+
+    expect(references).toEqual({
+      explicit: [],
+      inferred: [
+        "https://github.com/ultralytics/portal/pull/3612",
+        "https://github.com/ultralytics/portal/pull/3611",
+        "https://github.com/ultralytics/portal/issues/3497",
       ],
     });
   });


### PR DESCRIPTION
## Summary

- detect GitHub work items from xterm’s rendered buffer instead of the raw control stream
- reconstruct soft-wrapped references and follow parsed terminal updates across every harness
- resolve bare PR/issue mentions from a sole GitHub repository link while verification filters uncertain shorthand
- release as Lite 0.0.33

## Validation

- `bun test`
- `bun run check`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- xterm headless replay: erased text excluded, soft-wrapped repository URL reconstructed, visible PR 3612 and PR 3611 detected

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

GitHub reference detection now uses xterm’s rendered terminal state and parsed updates to avoid stale control-stream text and recover references across redraws and soft wraps.

### 📊 Key Changes

- Added terminal-owned rendered output snapshots that exclude erased text and the currently active input line while reconstructing soft-wrapped lines.
- Updated the Git panel to scan rendered terminal output and hyperlink control sequences, then retain references observed during terminal redraws.
- Added repository-link parsing so bare mentions such as `PR 3612` or `issue 3497` can be resolved when exactly one GitHub repository is identified; qualified mentions take precedence during verification.
- Added coverage for incomplete control-stream URLs, soft-wrapped and hyperlink references, repository-based inference, punctuation handling, and the Lite `0.0.33` release version.

### 🎯 Purpose & Impact

- The Git panel no longer treats overwritten or incomplete terminal control-stream text as a valid GitHub reference.
- References remain available after alternate-screen redraws or other terminal updates, while inferred references remain separated from explicit references for later verification.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
