### PR TITLE
Add directory deletion to file sidebar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -592,7 +592,9 @@ fn scoped_path(root: &Path, path: &str) -> Result<PathBuf, String> {
 // entry itself: following a symlink here would delete its target instead of the link the user chose.
 fn scoped_entry(root: &Path, path: &str) -> Result<PathBuf, String> {
     let path = Path::new(path);
-    let name = path.file_name().ok_or("Path is not a file")?;
+    let Some(std::path::Component::Normal(name)) = path.components().next_back() else {
+        return Err("Path is outside the selected folder".into());
+    };
     let parent = path.parent().ok_or("Path is outside the selected folder")?;
     let parent = fs::canonicalize(parent).map_err(|error| error.to_string())?;
     if !parent.starts_with(root) {
@@ -601,11 +603,35 @@ fn scoped_entry(root: &Path, path: &str) -> Result<PathBuf, String> {
     Ok(parent.join(name))
 }
 
-fn remove_entry(path: &Path) -> Result<(), String> {
+fn contains_sensitive_entry(path: &Path) -> Result<bool, String> {
+    for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        if is_sensitive_component(&entry.file_name()) {
+            return Ok(true);
+        }
+        if entry
+            .file_type()
+            .map_err(|error| error.to_string())?
+            .is_dir()
+            && contains_sensitive_entry(&entry.path())?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn remove_entry(root: &Path, path: &Path) -> Result<(), String> {
+    if is_sensitive_path(root, path) {
+        return Err("Sensitive files and folders cannot be deleted from Lite".into());
+    }
     let file_type = fs::symlink_metadata(path)
         .map_err(|error| error.to_string())?
         .file_type();
     if file_type.is_dir() {
+        if contains_sensitive_entry(path)? {
+            return Err("Folders containing sensitive files cannot be deleted from Lite".into());
+        }
         fs::remove_dir_all(path).map_err(|error| error.to_string())
     } else if file_type.is_file() || file_type.is_symlink() {
         fs::remove_file(path).map_err(|error| error.to_string())
@@ -3813,10 +3839,7 @@ async fn delete_entry(
 ) -> Result<(), String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_entry(&root, &path)?;
-    if is_sensitive_path(&root, &path) {
-        return Err("Sensitive files and folders cannot be deleted from Lite".into());
-    }
-    remove_entry(&path)
+    remove_entry(&root, &path)
 }
 
 fn bounded_git_changes(
@@ -5296,9 +5319,33 @@ mod tests {
         fs::create_dir_all(directory.join("nested")).unwrap();
         fs::write(directory.join("nested/file.txt"), "delete").unwrap();
 
-        remove_entry(&directory).unwrap();
+        remove_entry(directory.parent().unwrap(), &directory).unwrap();
 
         assert!(!directory.exists());
+    }
+
+    #[test]
+    fn remove_entry_preserves_sensitive_descendants() {
+        let directory =
+            std::env::temp_dir().join(format!("lite-delete-directory-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(directory.join("nested")).unwrap();
+        fs::write(directory.join("nested/.env"), "keep").unwrap();
+
+        assert!(remove_entry(directory.parent().unwrap(), &directory).is_err());
+        assert!(directory.join("nested/.env").exists());
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn scoped_entry_rejects_parent_segments() {
+        let root = std::env::temp_dir().join(format!("lite-scoped-entry-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(root.join("child")).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+
+        assert!(scoped_entry(&root, &path_text(&root.join("child/.."))).is_err());
+
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -601,6 +601,19 @@ fn scoped_entry(root: &Path, path: &str) -> Result<PathBuf, String> {
     Ok(parent.join(name))
 }
 
+fn remove_entry(path: &Path) -> Result<(), String> {
+    let file_type = fs::symlink_metadata(path)
+        .map_err(|error| error.to_string())?
+        .file_type();
+    if file_type.is_dir() {
+        fs::remove_dir_all(path).map_err(|error| error.to_string())
+    } else if file_type.is_file() || file_type.is_symlink() {
+        fs::remove_file(path).map_err(|error| error.to_string())
+    } else {
+        Err("Only files and folders can be deleted".into())
+    }
+}
+
 fn is_sensitive_component(component: &std::ffi::OsStr) -> bool {
     let name = component.to_string_lossy().to_lowercase();
     name == ".env"
@@ -3793,19 +3806,17 @@ async fn write_text_file(
 }
 
 #[tauri::command]
-async fn delete_file(roots: State<'_, Roots>, root_id: String, path: String) -> Result<(), String> {
+async fn delete_entry(
+    roots: State<'_, Roots>,
+    root_id: String,
+    path: String,
+) -> Result<(), String> {
     let root = root_path(&roots, &root_id)?;
     let path = scoped_entry(&root, &path)?;
     if is_sensitive_path(&root, &path) {
-        return Err("Sensitive files cannot be deleted from Lite".into());
+        return Err("Sensitive files and folders cannot be deleted from Lite".into());
     }
-    let file_type = fs::symlink_metadata(&path)
-        .map_err(|error| error.to_string())?
-        .file_type();
-    if !file_type.is_file() && !file_type.is_symlink() {
-        return Err("Only files can be deleted".into());
-    }
-    fs::remove_file(path).map_err(|error| error.to_string())
+    remove_entry(&path)
 }
 
 fn bounded_git_changes(
@@ -5199,7 +5210,7 @@ pub fn run() {
             list_directory,
             read_text_file,
             write_text_file,
-            delete_file,
+            delete_entry,
             git_status,
             git_diff,
             git_remote,
@@ -5276,6 +5287,18 @@ mod tests {
         let entry = scoped_entry(&root, link.to_str().unwrap()).unwrap();
         fs::remove_dir_all(base).unwrap();
         assert_eq!(entry, root.join("link.txt"));
+    }
+
+    #[test]
+    fn remove_entry_deletes_nonempty_directories() {
+        let directory =
+            std::env::temp_dir().join(format!("lite-delete-directory-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(directory.join("nested")).unwrap();
+        fs::write(directory.join("nested/file.txt"), "delete").unwrap();
+
+        remove_entry(&directory).unwrap();
+
+        assert!(!directory.exists());
     }
 
     #[cfg(not(windows))]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -341,7 +341,7 @@ type AppMenuContext = {
   collapsePanel: HTMLButtonElement | null;
   collapseSessions: HTMLButtonElement | null;
   directory: HTMLButtonElement | null;
-  deleteFile: HTMLButtonElement | null;
+  deleteEntry: HTMLButtonElement | null;
   editable: Editable | null;
   expandFiles: HTMLButtonElement | null;
   expandPanel: HTMLButtonElement | null;
@@ -363,7 +363,7 @@ const EMPTY_MENU_CONTEXT: AppMenuContext = {
   collapsePanel: null,
   collapseSessions: null,
   directory: null,
-  deleteFile: null,
+  deleteEntry: null,
   editable: null,
   expandFiles: null,
   expandPanel: null,
@@ -407,7 +407,7 @@ function menuContext(target: EventTarget | null): AppMenuContext {
     collapsePanel: surface?.querySelector<HTMLButtonElement>("[data-context-collapse-panel]") ?? null,
     collapseSessions: surface?.querySelector<HTMLButtonElement>("[data-context-collapse-sessions]") ?? null,
     directory,
-    deleteFile: fileRow?.querySelector<HTMLButtonElement>("[data-context-delete-file]") ?? null,
+    deleteEntry: fileRow?.querySelector<HTMLButtonElement>("[data-context-delete-entry]") ?? null,
     editable,
     expandFiles: files?.querySelector<HTMLButtonElement>("[data-context-expand-files]") ?? null,
     expandPanel: surface?.querySelector<HTMLButtonElement>("[data-context-expand-panel]") ?? null,
@@ -587,12 +587,12 @@ function AppContextMenu({
             {context.valueLabel}
           </ContextMenuItem>
         ) : null}
-        {context.deleteFile ? (
+        {context.deleteEntry ? (
           <>
             <ContextMenuSeparator />
-            <ContextMenuItem variant="destructive" onClick={() => context.deleteFile?.click()}>
+            <ContextMenuItem variant="destructive" onClick={() => context.deleteEntry?.click()}>
               <Trash2 />
-              Delete File
+              Delete {context.directory ? "folder" : "file"}
             </ContextMenuItem>
           </>
         ) : null}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -516,21 +516,33 @@ function FileTree({
 
   const lowered = query.trim().toLowerCase();
 
-  async function deleteFile() {
+  async function deleteEntry() {
     if (!deleting) return;
     setDeleteBusy(true);
     setDeleteError("");
     try {
-      await invoke("delete_file", { rootId, path: deleting.path });
+      await invoke("delete_entry", { rootId, path: deleting.path });
       setChildren((current) => {
         const next = { ...current };
         for (const [path, listing] of Object.entries(next)) {
-          if (listing.entries.some((entry) => entry.path === deleting.path)) {
+          if (path === deleting.path || path.startsWith(`${deleting.path}/`) || path.startsWith(`${deleting.path}\\`))
+            delete next[path];
+          else if (listing.entries.some((entry) => entry.path === deleting.path))
             next[path] = { ...listing, entries: listing.entries.filter((entry) => entry.path !== deleting.path) };
-          }
         }
         return next;
       });
+      setExpanded(
+        (current) =>
+          new Set(
+            [...current].filter(
+              (path) =>
+                path !== deleting.path &&
+                !path.startsWith(`${deleting.path}/`) &&
+                !path.startsWith(`${deleting.path}\\`),
+            ),
+          ),
+      );
       setDeleting(undefined);
       setError("");
     } catch (reason) {
@@ -601,9 +613,8 @@ function FileTree({
                   onClick={() => (entry.isDirectory ? void toggle(entry.path) : onOpen(entry))}
                   onKeyDown={(event) => {
                     if (
-                      entry.isDirectory ||
-                      (event.key !== "Delete" &&
-                        !(navigator.platform.includes("Mac") && event.metaKey && event.key === "Backspace"))
+                      event.key !== "Delete" &&
+                      !(navigator.platform.includes("Mac") && event.metaKey && event.key === "Backspace")
                     )
                       return;
                     event.preventDefault();
@@ -626,17 +637,15 @@ function FileTree({
                   )}
                   <span className="truncate">{entry.name}</span>
                 </button>
-                {!entry.isDirectory ? (
-                  <button
-                    type="button"
-                    hidden
-                    data-context-delete-file
-                    onClick={() => {
-                      setDeleteError("");
-                      setDeleting(entry);
-                    }}
-                  />
-                ) : null}
+                <button
+                  type="button"
+                  hidden
+                  data-context-delete-entry
+                  onClick={() => {
+                    setDeleteError("");
+                    setDeleting(entry);
+                  }}
+                />
               </div>
               {open ? rows(entry.path, depth + 1) : null}
             </div>
@@ -677,7 +686,10 @@ function FileTree({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete “{deleting?.name}”?</DialogTitle>
-            <DialogDescription>This permanently deletes the file from your computer.</DialogDescription>
+            <DialogDescription>
+              This permanently deletes the {deleting?.isDirectory ? "folder and its contents" : "file"} from your
+              computer.
+            </DialogDescription>
             {deleteError ? (
               <p role="alert" className="text-sm text-destructive">
                 {deleteError}
@@ -688,9 +700,9 @@ function FileTree({
             <Button variant="outline" disabled={deleteBusy} onClick={() => setDeleting(undefined)}>
               Cancel
             </Button>
-            <Button variant="destructive" disabled={deleteBusy} onClick={() => void deleteFile()}>
+            <Button variant="destructive" disabled={deleteBusy} onClick={() => void deleteEntry()}>
               {deleteBusy ? <Spinner /> : <Trash2 />}
-              {deleteBusy ? "Deleting…" : "Delete File"}
+              {deleteBusy ? "Deleting…" : `Delete ${deleting?.isDirectory ? "Folder" : "File"}`}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- add a destructive Delete folder action to directory context menus
- reuse the existing confirmation flow for recursive folder deletion
- support Delete and Command-Backspace for both files and folders
- remove deleted directory subtrees from loaded and expanded file-tree state

## Validation
- bun run check
- bun run build
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added recursive folder deletion to the file sidebar by extending the existing file deletion flow and preserving protections for sensitive files and folders.

### 📊 Key Changes
- Replaced the Rust `delete_file` command with `delete_entry`, which deletes files, symlinks, and non-empty directories.
- Added recursive checks that reject deletion of sensitive entries, including sensitive files nested inside folders.
- Added **Delete** and macOS **Command-Backspace** handling for both files and folders.
- Updated context menus and confirmation dialogs to display file- or folder-specific deletion actions and messages.
- Removed deleted directory subtrees from loaded file listings and expanded tree state.

### 🎯 Purpose & Impact
- Users can delete folders and their contents from the file sidebar after confirmation.
- Deleted folders no longer remain in loaded or expanded tree state.
- Attempts to delete sensitive files or folders, including folders containing sensitive descendants, are rejected.