### PR TITLE
Add contextual workspace search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tailwindcss/vite": "latest",
         "@tauri-apps/api": "latest",
         "@xterm/addon-fit": "latest",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "latest",
         "@xterm/xterm": "latest",
         "class-variance-authority": "latest",
@@ -397,6 +398,8 @@
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.5", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@tauri-apps/api": "^2.11.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.33"
+version = "0.0.34"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2752,6 +2752,7 @@ fn agent_command(
     agent: &str,
     provider: Option<&str>,
     model: Option<&str>,
+    reasoning_effort: Option<&str>,
     resume: bool,
     session_id: &str,
     provider_session_id: Option<&str>,
@@ -2786,6 +2787,16 @@ fn agent_command(
                     }
                 } else {
                     provider.model
+                };
+                let reasoning_effort = if provider.id == "deepseek" {
+                    match reasoning_effort {
+                        Some("low") => Some("low"),
+                        Some("max") => Some("max"),
+                        Some(_) => Some("high"),
+                        None => None,
+                    }
+                } else {
+                    None
                 };
                 if !key && codex_profile_exists(app, provider.id) {
                     // A profile the user wrote owns the provider and catalog; a model chosen for this
@@ -2826,6 +2837,12 @@ fn agent_command(
                             .replace('"', "\\\"");
                         command.args(["-c", &format!("model_catalog_json=\"{catalog}\"")]);
                     }
+                }
+                if let Some(reasoning_effort) = reasoning_effort {
+                    command.args([
+                        "-c",
+                        &format!("model_reasoning_effort=\"{reasoning_effort}\""),
+                    ]);
                 }
             }
             if let Some(provider_session_id) = provider_session_id {
@@ -3244,6 +3261,7 @@ async fn spawn_session(
     agent: String,
     provider: Option<String>,
     model: Option<String>,
+    reasoning_effort: Option<String>,
     mode: Option<String>,
     theme: Option<String>,
     resume: bool,
@@ -3369,6 +3387,7 @@ async fn spawn_session(
             &agent,
             provider.as_deref(),
             model.as_deref(),
+            reasoning_effort.as_deref(),
             resume,
             &session_id,
             provider_session_id.as_deref(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2751,6 +2751,7 @@ fn agent_command(
     app: &AppHandle,
     agent: &str,
     provider: Option<&str>,
+    model: Option<&str>,
     resume: bool,
     session_id: &str,
     provider_session_id: Option<&str>,
@@ -2777,9 +2778,22 @@ fn agent_command(
             // Providers are selected per launch so the user's default Codex provider stays untouched.
             if let Some(provider) = codex_provider(provider) {
                 let key = saved_api_key(app, agent, Some(provider.id)).is_some();
+                let model_selected = model.is_some();
+                let model = if provider.id == "deepseek" {
+                    match model {
+                        Some("deepseek-v4-pro") => "deepseek-v4-pro",
+                        _ => DEEPSEEK_MODEL,
+                    }
+                } else {
+                    provider.model
+                };
                 if !key && codex_profile_exists(app, provider.id) {
-                    // A profile the user wrote owns the whole model configuration, catalog included.
+                    // A profile the user wrote owns the provider and catalog; a model chosen for this
+                    // DeepSeek session still overrides its default without changing the profile.
                     command.args(["--profile", provider.id]);
+                    if provider.id == "deepseek" && model_selected {
+                        command.args(["-c", &format!("model=\"{model}\"")]);
+                    }
                 } else {
                     if key {
                         // A key held by Lite defines the provider inline and is read from the
@@ -2800,7 +2814,7 @@ fn agent_command(
                         }
                     }
                     command.args(["-c", &format!("model_provider=\"{}\"", provider.id)]);
-                    command.args(["-c", &format!("model=\"{}\"", provider.model)]);
+                    command.args(["-c", &format!("model=\"{model}\"")]);
                     if let Some(catalog) = (provider.id == "deepseek"
                         && !codex_declares_catalog(app))
                     .then(|| deepseek_catalog(app))
@@ -3229,6 +3243,7 @@ async fn spawn_session(
     mut provider_session_id: Option<String>,
     agent: String,
     provider: Option<String>,
+    model: Option<String>,
     mode: Option<String>,
     theme: Option<String>,
     resume: bool,
@@ -3353,6 +3368,7 @@ async fn spawn_session(
             &app,
             &agent,
             provider.as_deref(),
+            model.as_deref(),
             resume,
             &session_id,
             provider_session_id.as_deref(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2050,6 +2050,7 @@ function App() {
         providerSessionId: session.providerSessionId,
         agent: session.agent,
         provider: session.provider,
+        model: session.model,
         mode: session.mode,
         theme: themeRef.current,
         resume,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2051,6 +2051,7 @@ function App() {
         agent: session.agent,
         provider: session.provider,
         model: session.model,
+        reasoningEffort: session.reasoningEffort,
         mode: session.mode,
         theme: themeRef.current,
         resume,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1855,13 +1855,17 @@ function App() {
   }, [commit, askRelease]);
 
   // Output arrives as a stream of chunks, so this touches React state only on the two edges of a
-  // burst: the first chunk marks the session working, and a quiet spell marks it idle again. Between
-  // those the timer is just reset, which keeps a busy session from re-rendering the sidebar per chunk.
-  const markWorking = useCallback((sessionId: string) => {
+  // burst. Claude's explicit background activity holds the working edge until its last descendant
+  // stops; ordinary output still becomes idle after one quiet spell.
+  const markWorking = useCallback((sessionId: string, sustained = false) => {
     const timers = workTimers.current;
     const pending = timers.get(sessionId);
     if (pending) window.clearTimeout(pending);
     else setWorking((current) => including(current, sessionId));
+    if (sustained) {
+      timers.delete(sessionId);
+      return;
+    }
     timers.set(
       sessionId,
       window.setTimeout(() => {
@@ -1931,11 +1935,16 @@ function App() {
     void Promise.all([
       listen<{ sessionId: string; runId: string; data: number[] }>("pty-output", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
-        const { title, path, activity, notification } = appendOutput(payload.sessionId, payload.data);
+        const { title, path, activity, activityChanged, backgroundActivity, notification } = appendOutput(
+          payload.sessionId,
+          payload.data,
+        );
         if (title) markTitle(payload.sessionId, title);
         if (path) markDirectory(payload.sessionId, path);
+        if (activity === true) clearAttention(payload.sessionId);
         if (
           notification &&
+          !backgroundActivity &&
           (selectedRef.current?.id !== payload.sessionId || !document.hasFocus()) &&
           markAttention(payload.sessionId)
         ) {
@@ -1943,7 +1952,8 @@ function App() {
           if (notificationsRef.current && session)
             void invoke("send_notification", { sessionName: session.name, sessionId: session.id }).catch(() => {});
         }
-        if (activity !== false) markWorking(payload.sessionId);
+        if (activity !== false) markWorking(payload.sessionId, backgroundActivity);
+        else if (activityChanged) markWorking(payload.sessionId);
       }),
       listen<{ sessionId: string; runId: string }>("pty-exit", ({ payload }) => {
         if (runs.current.get(payload.sessionId) !== payload.runId) return;
@@ -1993,7 +2003,7 @@ function App() {
       for (const timer of timers.values()) window.clearTimeout(timer);
       timers.clear();
     };
-  }, [forgetShellAgent, markAttention, markDirectory, markWorking, markTitle]);
+  }, [clearAttention, forgetShellAgent, markAttention, markDirectory, markWorking, markTitle]);
 
   const changeNotifications = useCallback(async (enabled: boolean) => {
     const stored = localStorage.getItem(NOTIFICATIONS_KEY);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1077,12 +1077,12 @@ function SessionMark({ session }: { session: Session }) {
 
 function SessionActionButtons({
   name,
-  disabled = false,
+  starting = false,
   onRestart,
   onClose,
 }: {
   name: string;
-  disabled?: boolean;
+  starting?: boolean;
   onRestart: () => void;
   onClose: () => void;
 }) {
@@ -1090,19 +1090,19 @@ function SessionActionButtons({
     <>
       <ActionIconButton
         size="icon-sm"
-        tooltip="Restart"
-        aria-label={`Restart ${name}`}
-        disabled={disabled}
+        tooltip={starting ? "Restarting…" : "Restart"}
+        aria-label={starting ? `Restarting ${name}` : `Restart ${name}`}
+        disabled={starting}
         onClick={onRestart}
       >
-        <RotateCcw />
+        {starting ? <Spinner /> : <RotateCcw />}
       </ActionIconButton>
       <ActionIconButton
         size="icon-sm"
         className="hover:text-destructive"
         tooltip="Close session"
         aria-label={`Close ${name}`}
-        disabled={disabled}
+        disabled={starting}
         onClick={onClose}
       >
         <Trash2 />
@@ -1352,7 +1352,7 @@ function SessionRow({
         className="hidden shrink-0 gap-0.5 group-hover/item:flex group-focus-within/item:flex"
         onClick={(event) => event.stopPropagation()}
       >
-        <SessionActionButtons name={session.name} disabled={starting} onRestart={onRestart} onClose={onClose} />
+        <SessionActionButtons name={session.name} starting={starting} onRestart={onRestart} onClose={onClose} />
       </ItemActions>
     </Item>
   );
@@ -3169,7 +3169,7 @@ function App() {
                         ) : null,
                       )}
                     </Suspense>
-                    {selected.running ? (
+                    {selected.running || selectedStarting ? (
                       <fieldset
                         aria-label="Session actions"
                         className="absolute top-2 right-2 z-20 hidden items-center gap-0.5 rounded-lg bg-background/90 p-0.5 text-muted-foreground shadow-sm"
@@ -3180,6 +3180,7 @@ function App() {
                           size="icon-sm"
                           tooltip="Find in terminal"
                           aria-label="Find in terminal"
+                          disabled={selectedStarting}
                           onClick={() =>
                             document
                               .querySelector<HTMLElement>(
@@ -3194,6 +3195,7 @@ function App() {
                           size="icon-sm"
                           tooltip="Scroll to bottom"
                           aria-label="Scroll to bottom"
+                          disabled={selectedStarting}
                           onClick={() =>
                             document
                               .querySelector<HTMLElement>(
@@ -3206,6 +3208,7 @@ function App() {
                         </ActionIconButton>
                         <SessionActionButtons
                           name={selected.name}
+                          starting={selectedStarting}
                           onRestart={() => void restartSession(selected)}
                           onClose={() => closeSession(selected)}
                         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3172,10 +3172,24 @@ function App() {
                     {selected.running ? (
                       <fieldset
                         aria-label="Session actions"
-                        className="absolute top-2 right-2 z-20 hidden items-center gap-0.5 rounded-lg bg-background/90 p-0.5 shadow-sm"
+                        className="absolute top-2 right-2 z-20 hidden items-center gap-0.5 rounded-lg bg-background/90 p-0.5 text-muted-foreground shadow-sm"
                         data-terminal-action
                         onMouseDown={(event) => event.preventDefault()}
                       >
+                        <ActionIconButton
+                          size="icon-sm"
+                          tooltip="Find in terminal"
+                          aria-label="Find in terminal"
+                          onClick={() =>
+                            document
+                              .querySelector<HTMLElement>(
+                                `[data-context-session="${CSS.escape(selected.id)}"] [data-terminal-search]`,
+                              )
+                              ?.click()
+                          }
+                        >
+                          <Search />
+                        </ActionIconButton>
                         <ActionIconButton
                           size="icon-sm"
                           tooltip="Scroll to bottom"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1496,6 +1496,7 @@ function App() {
   const interrupted = useRef(new Set(working));
   const [shellAgents, setShellAgents] = useState<Map<string, Agent>>(new Map());
   const [query, setQuery] = useState("");
+  const sessionSearch = useRef<HTMLInputElement>(null);
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [renamingId, setRenamingId] = useState("");
@@ -2915,6 +2916,19 @@ function App() {
                 data-context-surface
                 data-zoom-panel="sidebar"
                 className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground"
+                onKeyDownCapture={(event) => {
+                  if (
+                    !shut.sidebar &&
+                    (event.metaKey || event.ctrlKey) &&
+                    !event.altKey &&
+                    !event.shiftKey &&
+                    event.key.toLowerCase() === "f"
+                  ) {
+                    event.preventDefault();
+                    sessionSearch.current?.focus();
+                    sessionSearch.current?.select();
+                  }
+                }}
               >
                 <PanelZoomControls
                   zoom={(step) => setSidebarFontSize((current) => zoomedFontSize(SIDEBAR_FONT_KEY, current, step))}
@@ -2982,6 +2996,7 @@ function App() {
                           <Search />
                         </InputGroupAddon>
                         <InputGroupInput
+                          ref={sessionSearch}
                           value={query}
                           placeholder="Search sessions"
                           aria-label="Search sessions"

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -471,7 +471,13 @@ function FileTree({
   );
 
   useEffect(() => {
-    void load(root).finally(() => onLoad("files"));
+    let mounted = true;
+    void load(root).finally(() => {
+      if (mounted) onLoad("files");
+    });
+    return () => {
+      mounted = false;
+    };
   }, [load, onLoad, root]);
 
   async function toggle(path: string) {

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -271,6 +271,7 @@ const TABS = [
   { value: "git", label: "Git", icon: GitBranch },
   { value: "usage", label: "Usage", icon: ChartNoAxesColumn },
 ] as const;
+type InspectorTab = (typeof TABS)[number]["value"];
 
 // Every optional field arrives from Serde as null, never as a missing key.
 interface UsageWindow {
@@ -423,11 +424,13 @@ function FileTree({
   rootId,
   query,
   onOpen,
+  onLoad,
 }: {
   root: string;
   rootId: string;
   query: string;
   onOpen: (entry: FileEntry) => void;
+  onLoad: (tab: InspectorTab) => void;
 }) {
   const [children, setChildren] = useState<Record<string, DirectoryListing & { after: DirectoryCursor | null }>>({});
   // The root is the folder the session works in; showing it shut asks for a click to say what the
@@ -463,8 +466,8 @@ function FileTree({
   );
 
   useEffect(() => {
-    void load(root);
-  }, [load, root]);
+    void load(root).finally(() => onLoad("files"));
+  }, [load, onLoad, root]);
 
   async function toggle(path: string) {
     const next = new Set(expanded);
@@ -1025,12 +1028,14 @@ function FilesPanel({
   sessionId,
   fontSize,
   searchRef,
+  onLoad,
 }: {
   root: string;
   rootId: string;
   sessionId: string;
   fontSize: number;
   searchRef: Ref<HTMLInputElement>;
+  onLoad: (tab: InspectorTab) => void;
 }) {
   const [cached] = useState(() => {
     const current = fileEditorsBySession.get(sessionId);
@@ -1127,7 +1132,14 @@ function FilesPanel({
         <SearchInput inputRef={searchRef} value={query} placeholder="Search files" onChange={setQuery} />
         <ScrollArea className="min-h-0 flex-1">
           <div style={contentZoomStyle(fontSize)}>
-            <FileTree key={rootId} root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
+            <FileTree
+              key={rootId}
+              root={root}
+              rootId={rootId}
+              query={query}
+              onOpen={(entry) => void openFile(entry)}
+              onLoad={onLoad}
+            />
           </div>
         </ScrollArea>
       </div>
@@ -1299,6 +1311,7 @@ function GitPanel({
   active,
   fontSize,
   searchRef,
+  onLoad,
 }: {
   rootId: string;
   sessionId: string;
@@ -1306,6 +1319,7 @@ function GitPanel({
   active: boolean;
   fontSize: number;
   searchRef: Ref<HTMLInputElement>;
+  onLoad: (tab: InspectorTab) => void;
 }) {
   const [references, setReferences] = useState(() => namedInSession(sessionId, remote));
   const [status, setStatus] = useState<GitStatus | null>();
@@ -1414,6 +1428,10 @@ function GitPanel({
     void refresh();
   }, [refresh]);
 
+  useEffect(() => {
+    if ((status !== undefined || error) && items !== undefined) onLoad("git");
+  }, [error, items, onLoad, status]);
+
   const repositories = repositoryGroups(remote, status ?? null, items ?? []);
   // Searching narrows each card to what matches — a changed path, an item's title or number, or the
   // repository's own name — and drops the cards left holding nothing.
@@ -1489,7 +1507,15 @@ function missingUsage(session: Session): string {
   return `${sessionLabel(session)} reports session context after its first response.`;
 }
 
-function UsagePanel({ session, fontSize }: { session: Session; fontSize: number }) {
+function UsagePanel({
+  session,
+  fontSize,
+  onLoad,
+}: {
+  session: Session;
+  fontSize: number;
+  onLoad: (tab: InspectorTab) => void;
+}) {
   const [usage, setUsage] = useState<UsageSnapshot | null | undefined>(() => usageCache.get(session.id));
   const [error, setError] = useState("");
 
@@ -1509,11 +1535,14 @@ function UsagePanel({ session, fontSize }: { session: Session; fontSize: number 
       })
       .catch((reason) => {
         if (!disposed) setError(String(reason));
+      })
+      .finally(() => {
+        if (!disposed) onLoad("usage");
       });
     return () => {
       disposed = true;
     };
-  }, [session.agent, session.provider, session.id]);
+  }, [onLoad, session.agent, session.provider, session.id]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -1609,12 +1638,18 @@ export function Inspector({
   // A tab already names the panel it shows, so the panel does not name itself again. The refresh button
   // rebuilds whichever is open, and every explicit Files visit rebuilds that disk snapshot as well.
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
+  const [refreshing, setRefreshing] = useState<InspectorTab>();
+
+  const finishRefresh = useCallback((value: InspectorTab) => {
+    setRefreshing((current) => (current === value ? undefined : current));
+  }, []);
 
   function visitTab(value: string) {
     setVisited((current) => including(current, value));
   }
 
-  function refreshTab(value: keyof typeof reload) {
+  function refreshTab(value: InspectorTab) {
+    setRefreshing(value);
     setReload((counts) => ({ ...counts, [value]: counts[value] + 1 }));
   }
 
@@ -1714,12 +1749,13 @@ export function Inspector({
               <ActionIconButton
                 size="icon-sm"
                 className="ml-auto"
-                tooltip="Refresh"
-                aria-label="Refresh"
+                tooltip={refreshing === tab ? "Refreshing…" : "Refresh"}
+                aria-label={refreshing === tab ? "Refreshing" : "Refresh"}
                 data-context-refresh
+                disabled={refreshing === tab}
                 onClick={() => refreshTab(tab as keyof typeof reload)}
               >
-                <RefreshCw />
+                {refreshing === tab ? <Spinner /> : <RefreshCw />}
               </ActionIconButton>
             )}
           </div>
@@ -1732,6 +1768,7 @@ export function Inspector({
                 sessionId={session.id}
                 fontSize={fontSize}
                 searchRef={fileSearch}
+                onLoad={finishRefresh}
               />
             </TabsContent>
           ) : null}
@@ -1745,12 +1782,13 @@ export function Inspector({
                 active={tab === "git" && !collapsed}
                 fontSize={fontSize}
                 searchRef={gitSearch}
+                onLoad={finishRefresh}
               />
             </TabsContent>
           ) : null}
           {visited.has("usage") ? (
             <TabsContent value="usage" keepMounted className="min-h-0 overflow-hidden">
-              <UsagePanel key={reload.usage} session={session} fontSize={fontSize} />
+              <UsagePanel key={reload.usage} session={session} fontSize={fontSize} onLoad={finishRefresh} />
             </TabsContent>
           ) : null}
         </Tabs>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -46,6 +46,7 @@ import {
   lazy,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
+  type Ref,
   Suspense,
   useCallback,
   useEffect,
@@ -377,10 +378,12 @@ function SearchInput({
   value,
   placeholder,
   onChange,
+  inputRef,
 }: {
   value: string;
   placeholder: string;
   onChange: (value: string) => void;
+  inputRef?: Ref<HTMLInputElement>;
 }) {
   return (
     <div className="shrink-0 p-2">
@@ -389,6 +392,7 @@ function SearchInput({
           <Search />
         </InputGroupAddon>
         <InputGroupInput
+          ref={inputRef}
           value={value}
           placeholder={placeholder}
           aria-label={placeholder}
@@ -1020,11 +1024,13 @@ function FilesPanel({
   rootId,
   sessionId,
   fontSize,
+  searchRef,
 }: {
   root: string;
   rootId: string;
   sessionId: string;
   fontSize: number;
+  searchRef: Ref<HTMLInputElement>;
 }) {
   const [cached] = useState(() => {
     const current = fileEditorsBySession.get(sessionId);
@@ -1118,7 +1124,7 @@ function FilesPanel({
         />
       ) : null}
       <div data-context-files className={`min-h-0 flex-1 flex-col ${selected ? "hidden" : "flex"}`}>
-        <SearchInput value={query} placeholder="Search files" onChange={setQuery} />
+        <SearchInput inputRef={searchRef} value={query} placeholder="Search files" onChange={setQuery} />
         <ScrollArea className="min-h-0 flex-1">
           <div style={contentZoomStyle(fontSize)}>
             <FileTree key={rootId} root={root} rootId={rootId} query={query} onOpen={(entry) => void openFile(entry)} />
@@ -1292,12 +1298,14 @@ function GitPanel({
   remote,
   active,
   fontSize,
+  searchRef,
 }: {
   rootId: string;
   sessionId: string;
   remote: string;
   active: boolean;
   fontSize: number;
+  searchRef: Ref<HTMLInputElement>;
 }) {
   const [references, setReferences] = useState(() => namedInSession(sessionId, remote));
   const [status, setStatus] = useState<GitStatus | null>();
@@ -1438,7 +1446,7 @@ function GitPanel({
         />
       ) : null}
       <div className={`min-h-0 flex-1 flex-col ${diffPath ? "hidden" : "flex"}`}>
-        <SearchInput value={query} placeholder="Search items" onChange={setQuery} />
+        <SearchInput inputRef={searchRef} value={query} placeholder="Search items" onChange={setQuery} />
         <ScrollArea className="min-h-0 flex-1">
           <div className="flex flex-col gap-3 p-3" style={contentZoomStyle(fontSize)}>
             {error ? <p className="text-sm text-destructive">{error}</p> : null}
@@ -1595,6 +1603,8 @@ export function Inspector({
   onCollapse: () => void;
 }) {
   const [tab, setTab] = useState<string>(TABS[0].value);
+  const fileSearch = useRef<HTMLInputElement>(null);
+  const gitSearch = useRef<HTMLInputElement>(null);
   const [visited, setVisited] = useState(() => new Set<string>([TABS[0].value]));
   // A tab already names the panel it shows, so the panel does not name itself again. The refresh button
   // rebuilds whichever is open, and every explicit Files visit rebuilds that disk snapshot as well.
@@ -1656,7 +1666,19 @@ export function Inspector({
   return (
     <>
       {collapsed ? rail : null}
-      <div data-context-surface className={collapsed ? "hidden" : "h-full"}>
+      <div
+        data-context-surface
+        className={collapsed ? "hidden" : "h-full"}
+        onKeyDownCapture={(event) => {
+          if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
+            const input = tab === "files" ? fileSearch.current : tab === "git" ? gitSearch.current : null;
+            if (!input?.offsetParent) return;
+            event.preventDefault();
+            input.focus();
+            input.select();
+          }
+        }}
+      >
         <Tabs value={tab} onValueChange={selectTab} className="h-full min-h-0 gap-0">
           <div className="flex h-11 shrink-0 items-center gap-0.5 border-b pr-3 pl-1.5">
             <ActionIconButton
@@ -1709,6 +1731,7 @@ export function Inspector({
                 rootId={session.rootId}
                 sessionId={session.id}
                 fontSize={fontSize}
+                searchRef={fileSearch}
               />
             </TabsContent>
           ) : null}
@@ -1721,6 +1744,7 @@ export function Inspector({
                 remote={remote}
                 active={tab === "git" && !collapsed}
                 fontSize={fontSize}
+                searchRef={gitSearch}
               />
             </TabsContent>
           ) : null}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -26,6 +26,7 @@ const choices = [...Object.values(AUTH_PROVIDERS), { id: "shell", agent: "shell"
 const harnesses = [...new Set(choices.map((option) => option.agent).filter((agent) => agent !== "shell"))];
 const CHOICE_KEY = "lite.newSession.choice.v1";
 const DEEPSEEK_MODEL_KEY = "lite.newSession.deepseekModel.v1";
+const DEEPSEEK_REASONING_KEY = "lite.newSession.deepseekReasoning.v1";
 const NAME_KEY = "lite.newSession.name.v1";
 const WORKTREE_KEY = "lite.newSession.worktree.v1";
 const DEEPSEEK_MODELS = [
@@ -33,6 +34,8 @@ const DEEPSEEK_MODELS = [
   { value: "deepseek-v4-pro", label: "Pro" },
 ] as const;
 type DeepSeekModel = (typeof DEEPSEEK_MODELS)[number]["value"];
+const DEEPSEEK_REASONING = ["low", "high", "max"] as const;
+type DeepSeekReasoning = (typeof DEEPSEEK_REASONING)[number];
 
 let updateChecks: Promise<Record<string, boolean | null>> | undefined;
 
@@ -91,6 +94,10 @@ export function NewSessionDialog({
   const [deepseekModel, setDeepseekModel] = useState<DeepSeekModel>(() => {
     const stored = localStorage.getItem(DEEPSEEK_MODEL_KEY);
     return DEEPSEEK_MODELS.find(({ value }) => value === stored)?.value ?? DEEPSEEK_MODELS[0].value;
+  });
+  const [deepseekReasoning, setDeepseekReasoning] = useState<DeepSeekReasoning>(() => {
+    const stored = localStorage.getItem(DEEPSEEK_REASONING_KEY);
+    return DEEPSEEK_REASONING.find((effort) => effort === stored) ?? "high";
   });
   const [directory, setDirectory] = useState<DirectoryGrant>();
   const [path, setPath] = useState("");
@@ -280,6 +287,7 @@ export function NewSessionDialog({
         agent: choice.agent,
         provider: choice.provider,
         model: choice.provider === "deepseek" ? deepseekModel : undefined,
+        reasoningEffort: choice.provider === "deepseek" ? deepseekReasoning : undefined,
         cwd: folder.path,
         rootId: folder.id,
         name: name || defaultSessionName(folder.path),
@@ -550,30 +558,58 @@ export function NewSessionDialog({
                         </div>
                       </Button>
                       {active && deepseek ? (
-                        <div className="flex items-center border-t px-3 py-2">
-                          <span id="deepseek-model-label" className="text-xs font-medium text-muted-foreground">
-                            Model
-                          </span>
-                          <fieldset
-                            className="ml-auto flex rounded-lg border-0 bg-background/70 p-0.5"
-                            aria-labelledby="deepseek-model-label"
-                          >
-                            {DEEPSEEK_MODELS.map((model) => (
-                              <Button
-                                key={model.value}
-                                type="button"
-                                size="xs"
-                                variant={deepseekModel === model.value ? "secondary" : "ghost"}
-                                aria-pressed={deepseekModel === model.value}
-                                onClick={() => {
-                                  localStorage.setItem(DEEPSEEK_MODEL_KEY, model.value);
-                                  setDeepseekModel(model.value);
-                                }}
-                              >
-                                {model.label}
-                              </Button>
-                            ))}
-                          </fieldset>
+                        <div className="space-y-1 border-t px-3 py-2">
+                          <div className="flex items-center">
+                            <span id="deepseek-model-label" className="text-xs font-medium text-muted-foreground">
+                              Model
+                            </span>
+                            <fieldset
+                              className="ml-auto flex rounded-lg border-0 bg-background/70 p-0.5"
+                              aria-labelledby="deepseek-model-label"
+                            >
+                              {DEEPSEEK_MODELS.map((model) => (
+                                <Button
+                                  key={model.value}
+                                  type="button"
+                                  size="xs"
+                                  variant={deepseekModel === model.value ? "secondary" : "ghost"}
+                                  aria-pressed={deepseekModel === model.value}
+                                  onClick={() => {
+                                    localStorage.setItem(DEEPSEEK_MODEL_KEY, model.value);
+                                    setDeepseekModel(model.value);
+                                  }}
+                                >
+                                  {model.label}
+                                </Button>
+                              ))}
+                            </fieldset>
+                          </div>
+                          <div className="flex items-center">
+                            <span id="deepseek-reasoning-label" className="text-xs font-medium text-muted-foreground">
+                              Thinking
+                            </span>
+                            <fieldset
+                              className="ml-auto flex rounded-lg border-0 bg-background/70 p-0.5"
+                              aria-labelledby="deepseek-reasoning-label"
+                            >
+                              {DEEPSEEK_REASONING.map((effort) => (
+                                <Button
+                                  key={effort}
+                                  type="button"
+                                  size="xs"
+                                  variant={deepseekReasoning === effort ? "secondary" : "ghost"}
+                                  className="capitalize"
+                                  aria-pressed={deepseekReasoning === effort}
+                                  onClick={() => {
+                                    localStorage.setItem(DEEPSEEK_REASONING_KEY, effort);
+                                    setDeepseekReasoning(effort);
+                                  }}
+                                >
+                                  {effort}
+                                </Button>
+                              ))}
+                            </fieldset>
+                          </div>
                         </div>
                       ) : null}
                       {action ? (

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -25,8 +25,14 @@ import { defaultSessionName, type Session, sessionLabel } from "@/types";
 const choices = [...Object.values(AUTH_PROVIDERS), { id: "shell", agent: "shell" as const, provider: undefined }];
 const harnesses = [...new Set(choices.map((option) => option.agent).filter((agent) => agent !== "shell"))];
 const CHOICE_KEY = "lite.newSession.choice.v1";
+const DEEPSEEK_MODEL_KEY = "lite.newSession.deepseekModel.v1";
 const NAME_KEY = "lite.newSession.name.v1";
 const WORKTREE_KEY = "lite.newSession.worktree.v1";
+const DEEPSEEK_MODELS = [
+  { value: "deepseek-v4-flash", label: "Flash" },
+  { value: "deepseek-v4-pro", label: "Pro" },
+] as const;
+type DeepSeekModel = (typeof DEEPSEEK_MODELS)[number]["value"];
 
 let updateChecks: Promise<Record<string, boolean | null>> | undefined;
 
@@ -81,6 +87,10 @@ export function NewSessionDialog({
   const [choiceId, setChoiceId] = useState(() => {
     const stored = localStorage.getItem(CHOICE_KEY);
     return choices.find((option) => option.id === stored)?.id ?? choices[0].id;
+  });
+  const [deepseekModel, setDeepseekModel] = useState<DeepSeekModel>(() => {
+    const stored = localStorage.getItem(DEEPSEEK_MODEL_KEY);
+    return DEEPSEEK_MODELS.find(({ value }) => value === stored)?.value ?? DEEPSEEK_MODELS[0].value;
   });
   const [directory, setDirectory] = useState<DirectoryGrant>();
   const [path, setPath] = useState("");
@@ -269,6 +279,7 @@ export function NewSessionDialog({
         id: crypto.randomUUID(),
         agent: choice.agent,
         provider: choice.provider,
+        model: choice.provider === "deepseek" ? deepseekModel : undefined,
         cwd: folder.path,
         rootId: folder.id,
         name: name || defaultSessionName(folder.path),
@@ -483,6 +494,7 @@ export function NewSessionDialog({
               <div className="grid min-w-0 grid-cols-2 gap-2">
                 {choices.map((option) => {
                   const active = choiceId === option.id;
+                  const deepseek = option.id === "deepseek";
                   const state = availability[option.id];
                   const update = updates[option.agent];
                   const managed = option.agent !== "shell" && state && !state.installable;
@@ -499,12 +511,15 @@ export function NewSessionDialog({
                   const authProvider = "configured" in option ? option : undefined;
                   const authStatus = authProvider ? auth?.find((entry) => entry.name === authProvider.id) : undefined;
                   return (
-                    <div key={option.id} className="relative min-w-0">
+                    <div
+                      key={option.id}
+                      className={`relative min-w-0 ${active && deepseek ? "col-span-2 rounded-lg bg-secondary" : ""}`}
+                    >
                       <Button
                         type="button"
                         size="lg"
-                        variant={active ? "secondary" : "outline"}
-                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-11" : "pr-3"}`}
+                        variant={active && !deepseek ? "secondary" : active ? "ghost" : "outline"}
+                        className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-11" : "pr-3"} ${active && deepseek ? "rounded-b-none" : ""}`}
                         aria-pressed={active}
                         disabled={Boolean(installing)}
                         title={"note" in option ? option.note : sessionLabel(option)}
@@ -534,12 +549,39 @@ export function NewSessionDialog({
                           )}
                         </div>
                       </Button>
+                      {active && deepseek ? (
+                        <div className="flex items-center border-t px-3 py-2">
+                          <span id="deepseek-model-label" className="text-xs font-medium text-muted-foreground">
+                            Model
+                          </span>
+                          <fieldset
+                            className="ml-auto flex rounded-lg border-0 bg-background/70 p-0.5"
+                            aria-labelledby="deepseek-model-label"
+                          >
+                            {DEEPSEEK_MODELS.map((model) => (
+                              <Button
+                                key={model.value}
+                                type="button"
+                                size="xs"
+                                variant={deepseekModel === model.value ? "secondary" : "ghost"}
+                                aria-pressed={deepseekModel === model.value}
+                                onClick={() => {
+                                  localStorage.setItem(DEEPSEEK_MODEL_KEY, model.value);
+                                  setDeepseekModel(model.value);
+                                }}
+                              >
+                                {model.label}
+                              </Button>
+                            ))}
+                          </fieldset>
+                        </div>
+                      ) : null}
                       {action ? (
                         <ActionIconButton
                           type="button"
                           size="icon"
                           variant="outline"
-                          className="absolute top-1/2 right-2 -mt-4"
+                          className={`absolute right-2 ${active && deepseek ? "top-3" : "top-1/2 -mt-4"}`}
                           tooltip={
                             busy
                               ? `${action.working} ${sessionLabel(option)}…`

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -513,7 +513,7 @@ export function NewSessionDialog({
                   return (
                     <div
                       key={option.id}
-                      className={`relative min-w-0 ${active && deepseek ? "col-span-2 rounded-lg bg-secondary" : ""}`}
+                      className={`relative min-w-0 ${active && deepseek ? "rounded-lg bg-secondary" : ""}`}
                     >
                       <Button
                         type="button"

--- a/src/output-store.ts
+++ b/src/output-store.ts
@@ -15,6 +15,7 @@ interface Buffer {
   tail: string;
   controlTail: string;
   themeReporting: boolean;
+  backgroundActivity?: boolean;
 }
 
 const buffers = new Map<string, Buffer>();
@@ -85,6 +86,7 @@ export function appendOutput(sessionId: string, data: number[]) {
     tail: "",
     controlTail: "",
     themeReporting: false,
+    backgroundActivity: undefined,
   };
   buffer.chunks.push(bytes);
   buffer.size += bytes.byteLength;
@@ -128,10 +130,20 @@ export function appendOutput(sessionId: string, data: number[]) {
       if (working || match[2] === "lite-idle") activity = working;
     } else title = match[2];
   }
+  const previousActivity = buffer.backgroundActivity;
+  const activityChanged = activity !== undefined && activity !== previousActivity;
+  if (activity !== undefined) buffer.backgroundActivity = activity;
   const tail = text.match(UNTERMINATED)?.[0] ?? "";
   if (activity === undefined && tail.startsWith("\x1b]6973;lite-")) activity = false;
   buffer.tail = tail.length > MAX_TAIL ? "" : tail;
-  return { title, path, activity, notification };
+  return {
+    title,
+    path,
+    activity,
+    activityChanged,
+    backgroundActivity: buffer.backgroundActivity,
+    notification,
+  };
 }
 
 export function subscribeOutput(sessionId: string, listener: (data: Uint8Array) => void) {

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -421,6 +421,13 @@ export function TerminalView({
     terminalRef.current?.focus();
   }
 
+  function openSearch() {
+    if (searchOpen) {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    } else setSearchOpen(true);
+  }
+
   // The padding belongs on the wrapper, never on the element the terminal is opened in. The fit addon
   // sizes the terminal from getComputedStyle(parent).height, which WebKit reports as the border box,
   // and it only subtracts padding declared on the terminal's own element. Padding here would be
@@ -451,19 +458,17 @@ export function TerminalView({
         if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
           event.preventDefault();
           event.stopPropagation();
-          if (searchOpen) {
-            searchInputRef.current?.focus();
-            searchInputRef.current?.select();
-          } else setSearchOpen(true);
+          openSearch();
         }
       }}
     >
       <button type="button" hidden data-context-zoom-in onClick={() => zoomRef.current(1)} />
       <button type="button" hidden data-context-zoom-out onClick={() => zoomRef.current(-1)} />
       <button type="button" hidden data-context-zoom-reset onClick={() => zoomRef.current(0)} />
+      <button type="button" hidden data-terminal-search onClick={openSearch} />
       <button type="button" hidden data-terminal-scroll-bottom onClick={() => terminalRef.current?.scrollToBottom()} />
       {searchOpen ? (
-        <div className="absolute top-2 right-[6.5rem] z-10 w-72 max-w-[calc(100%-7rem)] rounded-lg bg-background shadow-lg">
+        <div className="absolute top-2 right-[8.5rem] z-10 w-72 max-w-[calc(100%-9rem)] rounded-lg bg-background shadow-lg">
           <InputGroup>
             <InputGroupAddon>
               <Search />

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -22,17 +22,19 @@ import type { Agent } from "@/types";
 
 const SEARCH_HIGHLIGHT_LIMIT = 5000;
 const countFormat = new Intl.NumberFormat();
+const searchHighlights: Record<Theme, { match: string; active: string }> = {
+  light: { match: "#fff8c5", active: "#d4a72c" },
+  dark: { match: "#5a4314", active: "#9e6a03" },
+};
 
 function searchOptions(theme: Theme): ISearchOptions {
-  const dark = theme === "dark";
+  const highlights = searchHighlights[theme];
   return {
     decorations: {
-      matchBackground: dark ? "#92400e" : "#fde68a",
-      matchBorder: dark ? "#fbbf24" : "#f59e0b",
-      matchOverviewRuler: "#f59e0b",
-      activeMatchBackground: dark ? "#c2410c" : "#fdba74",
-      activeMatchBorder: "#fb923c",
-      activeMatchColorOverviewRuler: "#f97316",
+      matchBackground: highlights.match,
+      matchOverviewRuler: "#d4a72c",
+      activeMatchBackground: highlights.active,
+      activeMatchColorOverviewRuler: "#9a6700",
     },
   };
 }
@@ -368,7 +370,7 @@ export function TerminalView({
   useEffect(() => {
     if (terminalRef.current)
       terminalRef.current.options.theme = searchQueryRef.current
-        ? { ...themes[theme], selectionBackground: theme === "dark" ? "#c2410c" : "#fdba74" }
+        ? { ...themes[theme], selectionBackground: searchHighlights[theme].active }
         : themes[theme];
   }, [theme]);
 
@@ -397,9 +399,11 @@ export function TerminalView({
       setSearchResult(result);
       return;
     }
-    const dark = themeRef.current === "dark";
     if (terminal && terminal.options.theme?.selectionBackground === themes[themeRef.current].selectionBackground)
-      terminal.options.theme = { ...themes[themeRef.current], selectionBackground: dark ? "#c2410c" : "#fdba74" };
+      terminal.options.theme = {
+        ...themes[themeRef.current],
+        selectionBackground: searchHighlights[themeRef.current].active,
+      };
     searchAddon[previous ? "findPrevious" : "findNext"](term, { ...searchOptions(themeRef.current), incremental });
     if (searchResultRef.current.resultIndex >= 0) desiredSearchResultRef.current = searchResultRef.current.resultIndex;
   }

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -435,6 +435,15 @@ export function TerminalView({
           closeSearch();
           return;
         }
+        if (
+          searchOpen &&
+          (event.key === "F3" || ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "g"))
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          find(searchQuery, event.shiftKey);
+          return;
+        }
         if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
           event.preventDefault();
           event.stopPropagation();
@@ -467,7 +476,10 @@ export function TerminalView({
                 find(event.target.value, false, true);
               }}
               onKeyDown={(event) => {
-                if (event.key === "Enter") {
+                if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+                  event.preventDefault();
+                  find(searchQuery, event.key === "ArrowUp");
+                } else if (event.key === "Enter") {
                   event.preventDefault();
                   find(searchQuery, event.shiftKey);
                 }

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -408,8 +408,14 @@ export function TerminalView({
         ...themes[themeRef.current],
         selectionBackground: searchHighlights[themeRef.current].active,
       };
+    const current = desiredSearchResultRef.current;
     searchAddon[previous ? "findPrevious" : "findNext"](term, { ...searchOptions(themeRef.current), incremental });
-    if (searchResultRef.current.resultIndex >= 0) desiredSearchResultRef.current = searchResultRef.current.resultIndex;
+    const result = searchResultRef.current;
+    if (result.resultIndex >= 0) desiredSearchResultRef.current = result.resultIndex;
+    else if (result.resultCount)
+      desiredSearchResultRef.current = incremental
+        ? 0
+        : (current + (previous ? -1 : 1) + result.resultCount) % result.resultCount;
   }
 
   function closeSearch() {

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -358,10 +358,17 @@ export function TerminalView({
   }, [starting]);
 
   useEffect(() => {
-    if (terminalRef.current)
-      terminalRef.current.options.theme = searchQueryRef.current
-        ? { ...themes[theme], selectionBackground: searchHighlights[theme].active }
-        : themes[theme];
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const query = searchQueryRef.current;
+    terminal.options.theme = query
+      ? { ...themes[theme], selectionBackground: searchHighlights[theme].active }
+      : themes[theme];
+    const searchAddon = searchAddonRef.current;
+    if (query && searchAddon) {
+      searchAddon.clearDecorations();
+      searchAddon.findNext(query, { ...searchOptions(theme), incremental: true });
+    }
   }, [theme]);
 
   useEffect(() => {

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -170,8 +170,6 @@ export function TerminalView({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResult, setSearchResult] = useState({ resultIndex: -1, resultCount: 0 });
   const searchQueryRef = useRef("");
-  const searchResultRef = useRef(searchResult);
-  const desiredSearchResultRef = useRef(0);
   const resizeRef = useRef<() => void>(() => undefined);
   const checkRef = useRef(true);
   const workingRef = useRef(working);
@@ -215,7 +213,6 @@ export function TerminalView({
     searchAddonRef.current = searchAddon;
     terminal.loadAddon(searchAddon);
     const searchResults = searchAddon.onDidChangeResults((result) => {
-      searchResultRef.current = result;
       setSearchResult(result);
     });
     // Links go to the system browser, the way every other terminal handles them.
@@ -228,20 +225,15 @@ export function TerminalView({
     terminal.open(container);
     const disconnectTerminalOutput = connectTerminalOutput(sessionId, () => renderedOutput(terminal));
     // The addon waits for output to go quiet before rebuilding its result map, which a live TUI may
-    // never do. Refresh at a bounded rate while it writes, then once more after its final redraw.
+    // never do. Refresh at a bounded rate while it writes; the addon's own timer handles the final pass.
     let searchRefresh = 0;
-    let searchSettle = 0;
     const refreshSearch = () => {
       const query = searchQueryRef.current;
       if (!query) return;
-      const activeResult = desiredSearchResultRef.current;
-      const options = searchOptions(themeRef.current);
-      terminal.clearSelection();
+      // Clearing decorations leaves xterm's selection in place, so the addon rebuilds highlights and
+      // reselects that same match directly instead of replaying every earlier match.
       searchAddon.clearDecorations();
-      searchAddon.findNext(query, options);
-      const target = Math.min(activeResult, searchResultRef.current.resultCount - 1);
-      for (let index = 0; index < target; index++) searchAddon.findNext(query, options);
-      desiredSearchResultRef.current = Math.max(0, target);
+      searchAddon.findNext(query, { ...searchOptions(themeRef.current), incremental: true });
     };
     const parsed = terminal.onWriteParsed(() => {
       notifyTerminalOutput(sessionId);
@@ -251,11 +243,6 @@ export function TerminalView({
           searchRefresh = 0;
           refreshSearch();
         }, 200);
-      window.clearTimeout(searchSettle);
-      searchSettle = window.setTimeout(() => {
-        searchSettle = 0;
-        refreshSearch();
-      }, 250);
     });
     const unsubscribe = subscribeOutput(sessionId, (data) => terminal.write(data));
     // What the user types before the first Enter is the closest thing a session has to a subject.
@@ -349,7 +336,6 @@ export function TerminalView({
     return () => {
       window.clearTimeout(settle);
       window.clearTimeout(searchRefresh);
-      window.clearTimeout(searchSettle);
       observer.disconnect();
       searchResults.dispose();
       input.dispose();
@@ -399,7 +385,6 @@ export function TerminalView({
       searchAddon.clearDecorations();
       if (terminal) terminal.options.theme = themes[themeRef.current];
       const result = { resultIndex: -1, resultCount: 0 };
-      searchResultRef.current = result;
       setSearchResult(result);
       return;
     }
@@ -408,14 +393,7 @@ export function TerminalView({
         ...themes[themeRef.current],
         selectionBackground: searchHighlights[themeRef.current].active,
       };
-    const current = desiredSearchResultRef.current;
     searchAddon[previous ? "findPrevious" : "findNext"](term, { ...searchOptions(themeRef.current), incremental });
-    const result = searchResultRef.current;
-    if (result.resultIndex >= 0) desiredSearchResultRef.current = result.resultIndex;
-    else if (result.resultCount)
-      desiredSearchResultRef.current = incremental
-        ? 0
-        : (current + (previous ? -1 : 1) + result.resultCount) % result.resultCount;
   }
 
   function closeSearch() {
@@ -424,9 +402,7 @@ export function TerminalView({
     setSearchOpen(false);
     setSearchQuery("");
     searchQueryRef.current = "";
-    desiredSearchResultRef.current = 0;
     const result = { resultIndex: -1, resultCount: 0 };
-    searchResultRef.current = result;
     setSearchResult(result);
     terminalRef.current?.focus();
   }
@@ -490,7 +466,6 @@ export function TerminalView({
               aria-label="Find in terminal"
               onChange={(event) => {
                 searchQueryRef.current = event.target.value;
-                desiredSearchResultRef.current = 0;
                 setSearchQuery(event.target.value);
                 find(event.target.value, false, true);
               }}

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -2,7 +2,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { FitAddon } from "@xterm/addon-fit";
-import { SearchAddon } from "@xterm/addon-search";
+import { type ISearchOptions, SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import { ChevronDown, ChevronUp, Search, X } from "lucide-react";
@@ -22,6 +22,20 @@ import type { Agent } from "@/types";
 
 const SEARCH_HIGHLIGHT_LIMIT = 5000;
 const countFormat = new Intl.NumberFormat();
+
+function searchOptions(theme: Theme): ISearchOptions {
+  const dark = theme === "dark";
+  return {
+    decorations: {
+      matchBackground: dark ? "#92400e" : "#fde68a",
+      matchBorder: dark ? "#fbbf24" : "#f59e0b",
+      matchOverviewRuler: "#f59e0b",
+      activeMatchBackground: dark ? "#c2410c" : "#fdba74",
+      activeMatchBorder: "#fb923c",
+      activeMatchColorOverviewRuler: "#f97316",
+    },
+  };
+}
 
 // Surface colors follow the app tokens; ANSI colors follow GitHub light and dark, matching the code preview.
 const themes: Record<Theme, ITheme> = {
@@ -152,6 +166,9 @@ export function TerminalView({
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResult, setSearchResult] = useState({ resultIndex: -1, resultCount: 0 });
+  const searchQueryRef = useRef("");
+  const searchResultRef = useRef(searchResult);
+  const desiredSearchResultRef = useRef(0);
   const resizeRef = useRef<() => void>(() => undefined);
   const checkRef = useRef(true);
   const workingRef = useRef(working);
@@ -194,7 +211,10 @@ export function TerminalView({
     const searchAddon = new SearchAddon({ highlightLimit: SEARCH_HIGHLIGHT_LIMIT });
     searchAddonRef.current = searchAddon;
     terminal.loadAddon(searchAddon);
-    const searchResults = searchAddon.onDidChangeResults(setSearchResult);
+    const searchResults = searchAddon.onDidChangeResults((result) => {
+      searchResultRef.current = result;
+      setSearchResult(result);
+    });
     // Links go to the system browser, the way every other terminal handles them.
     terminal.loadAddon(
       new WebLinksAddon((event, url) => {
@@ -204,7 +224,36 @@ export function TerminalView({
     );
     terminal.open(container);
     const disconnectTerminalOutput = connectTerminalOutput(sessionId, () => renderedOutput(terminal));
-    const parsed = terminal.onWriteParsed(() => notifyTerminalOutput(sessionId));
+    // The addon waits for output to go quiet before rebuilding its result map, which a live TUI may
+    // never do. Refresh at a bounded rate while it writes, then once more after its final redraw.
+    let searchRefresh = 0;
+    let searchSettle = 0;
+    const refreshSearch = () => {
+      const query = searchQueryRef.current;
+      if (!query) return;
+      const activeResult = desiredSearchResultRef.current;
+      const options = searchOptions(themeRef.current);
+      terminal.clearSelection();
+      searchAddon.clearDecorations();
+      searchAddon.findNext(query, options);
+      const target = Math.min(activeResult, searchResultRef.current.resultCount - 1);
+      for (let index = 0; index < target; index++) searchAddon.findNext(query, options);
+      desiredSearchResultRef.current = Math.max(0, target);
+    };
+    const parsed = terminal.onWriteParsed(() => {
+      notifyTerminalOutput(sessionId);
+      if (!searchQueryRef.current) return;
+      if (!searchRefresh)
+        searchRefresh = window.setTimeout(() => {
+          searchRefresh = 0;
+          refreshSearch();
+        }, 200);
+      window.clearTimeout(searchSettle);
+      searchSettle = window.setTimeout(() => {
+        searchSettle = 0;
+        refreshSearch();
+      }, 250);
+    });
     const unsubscribe = subscribeOutput(sessionId, (data) => terminal.write(data));
     // What the user types before the first Enter is the closest thing a session has to a subject.
     // Typing, pasting, and the terminal's own answers to the program's cursor, focus, and color
@@ -293,6 +342,8 @@ export function TerminalView({
 
     return () => {
       window.clearTimeout(settle);
+      window.clearTimeout(searchRefresh);
+      window.clearTimeout(searchSettle);
       observer.disconnect();
       searchResults.dispose();
       input.dispose();
@@ -315,7 +366,10 @@ export function TerminalView({
   }, [starting]);
 
   useEffect(() => {
-    if (terminalRef.current) terminalRef.current.options.theme = themes[theme];
+    if (terminalRef.current)
+      terminalRef.current.options.theme = searchQueryRef.current
+        ? { ...themes[theme], selectionBackground: theme === "dark" ? "#c2410c" : "#fdba74" }
+        : themes[theme];
   }, [theme]);
 
   useEffect(() => {
@@ -334,30 +388,32 @@ export function TerminalView({
   function find(term: string, previous = false, incremental = false) {
     const searchAddon = searchAddonRef.current;
     if (!searchAddon) return;
+    const terminal = terminalRef.current;
     if (!term) {
       searchAddon.clearDecorations();
-      setSearchResult({ resultIndex: -1, resultCount: 0 });
+      if (terminal) terminal.options.theme = themes[themeRef.current];
+      const result = { resultIndex: -1, resultCount: 0 };
+      searchResultRef.current = result;
+      setSearchResult(result);
       return;
     }
     const dark = themeRef.current === "dark";
-    searchAddon[previous ? "findPrevious" : "findNext"](term, {
-      incremental,
-      decorations: {
-        matchBackground: dark ? "#78350f" : "#fde68a",
-        matchBorder: dark ? "#fbbf24" : "#f59e0b",
-        matchOverviewRuler: "#f59e0b",
-        activeMatchBackground: dark ? "#c2410c" : "#fdba74",
-        activeMatchBorder: "#fb923c",
-        activeMatchColorOverviewRuler: "#f97316",
-      },
-    });
+    if (terminal && terminal.options.theme?.selectionBackground === themes[themeRef.current].selectionBackground)
+      terminal.options.theme = { ...themes[themeRef.current], selectionBackground: dark ? "#c2410c" : "#fdba74" };
+    searchAddon[previous ? "findPrevious" : "findNext"](term, { ...searchOptions(themeRef.current), incremental });
+    if (searchResultRef.current.resultIndex >= 0) desiredSearchResultRef.current = searchResultRef.current.resultIndex;
   }
 
   function closeSearch() {
     searchAddonRef.current?.clearDecorations();
+    if (terminalRef.current) terminalRef.current.options.theme = themes[themeRef.current];
     setSearchOpen(false);
     setSearchQuery("");
-    setSearchResult({ resultIndex: -1, resultCount: 0 });
+    searchQueryRef.current = "";
+    desiredSearchResultRef.current = 0;
+    const result = { resultIndex: -1, resultCount: 0 };
+    searchResultRef.current = result;
+    setSearchResult(result);
     terminalRef.current?.focus();
   }
 
@@ -405,6 +461,8 @@ export function TerminalView({
               placeholder="Find in terminal"
               aria-label="Find in terminal"
               onChange={(event) => {
+                searchQueryRef.current = event.target.value;
+                desiredSearchResultRef.current = 0;
                 setSearchQuery(event.target.value);
                 find(event.target.value, false, true);
               }}

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -2,11 +2,14 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { FitAddon } from "@xterm/addon-fit";
+import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { type ITheme, Terminal } from "@xterm/xterm";
-import { useEffect, useRef } from "react";
+import { ChevronDown, ChevronUp, Search, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
 import {
   connectTerminalOutput,
   MAX_OUTPUT_BYTES,
@@ -141,6 +144,11 @@ export function TerminalView({
   const zoomRef = useRef(onZoom);
   zoomRef.current = onZoom;
   const terminalRef = useRef<Terminal | null>(null);
+  const searchAddonRef = useRef<SearchAddon | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResult, setSearchResult] = useState({ resultIndex: 0, resultCount: 0 });
   const resizeRef = useRef<() => void>(() => undefined);
   const checkRef = useRef(true);
   const workingRef = useRef(working);
@@ -178,6 +186,10 @@ export function TerminalView({
     terminalRef.current = terminal;
     const fit = new FitAddon();
     terminal.loadAddon(fit);
+    const searchAddon = new SearchAddon();
+    searchAddonRef.current = searchAddon;
+    terminal.loadAddon(searchAddon);
+    const searchResults = searchAddon.onDidChangeResults(setSearchResult);
     // Links go to the system browser, the way every other terminal handles them.
     terminal.loadAddon(
       new WebLinksAddon((event, url) => {
@@ -277,12 +289,14 @@ export function TerminalView({
     return () => {
       window.clearTimeout(settle);
       observer.disconnect();
+      searchResults.dispose();
       input.dispose();
       unsubscribe();
       parsed.dispose();
       disconnectTerminalOutput();
       terminal.dispose();
       terminalRef.current = null;
+      searchAddonRef.current = null;
       resizeRef.current = () => undefined;
     };
   }, [sessionId]);
@@ -306,6 +320,39 @@ export function TerminalView({
     requestAnimationFrame(() => resizeRef.current());
   }, [fontSize]);
 
+  useEffect(() => {
+    if (!searchOpen) return;
+    searchInputRef.current?.focus();
+    searchInputRef.current?.select();
+  }, [searchOpen]);
+
+  function find(term: string, previous = false, incremental = false) {
+    const searchAddon = searchAddonRef.current;
+    if (!searchAddon) return;
+    if (!term) {
+      searchAddon.clearDecorations();
+      setSearchResult({ resultIndex: 0, resultCount: 0 });
+      return;
+    }
+    const dark = themeRef.current === "dark";
+    searchAddon[previous ? "findPrevious" : "findNext"](term, {
+      incremental,
+      decorations: {
+        matchBackground: dark ? "#1e3a5f" : "#dbeafe",
+        matchOverviewRuler: dark ? "#60a5fa" : "#2563eb",
+        activeMatchBackground: dark ? "#1d4ed8" : "#93c5fd",
+        activeMatchColorOverviewRuler: dark ? "#bfdbfe" : "#1d4ed8",
+      },
+    });
+  }
+
+  function closeSearch() {
+    searchAddonRef.current?.clearDecorations();
+    setSearchOpen(false);
+    setSearchResult({ resultIndex: 0, resultCount: 0 });
+    terminalRef.current?.focus();
+  }
+
   // The padding belongs on the wrapper, never on the element the terminal is opened in. The fit addon
   // sizes the terminal from getComputedStyle(parent).height, which WebKit reports as the border box,
   // and it only subtracts padding declared on the terminal's own element. Padding here would be
@@ -313,11 +360,76 @@ export function TerminalView({
   // them past the edge, which also left the last row below the viewport where the scrollbar could
   // neither show nor reach it.
   return (
-    <div data-context-session={sessionId} data-context-zoom className="h-full w-full bg-background p-3 pr-1.5">
+    <div
+      data-context-session={sessionId}
+      data-context-zoom
+      className="relative h-full w-full bg-background p-3 pr-1.5"
+      onKeyDownCapture={(event) => {
+        if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
+          event.preventDefault();
+          if (searchOpen) {
+            searchInputRef.current?.focus();
+            searchInputRef.current?.select();
+          } else setSearchOpen(true);
+        }
+      }}
+    >
       <button type="button" hidden data-context-zoom-in onClick={() => zoomRef.current(1)} />
       <button type="button" hidden data-context-zoom-out onClick={() => zoomRef.current(-1)} />
       <button type="button" hidden data-context-zoom-reset onClick={() => zoomRef.current(0)} />
       <button type="button" hidden data-terminal-scroll-bottom onClick={() => terminalRef.current?.scrollToBottom()} />
+      {searchOpen ? (
+        <div className="absolute top-2 right-2 z-10 w-80 max-w-[calc(100%-1rem)] rounded-lg bg-background shadow-lg">
+          <InputGroup>
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
+              ref={searchInputRef}
+              value={searchQuery}
+              placeholder="Find in terminal"
+              aria-label="Find in terminal"
+              onChange={(event) => {
+                setSearchQuery(event.target.value);
+                find(event.target.value, false, true);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.stopPropagation();
+                  closeSearch();
+                } else if (event.key === "Enter") {
+                  event.preventDefault();
+                  find(searchQuery, event.shiftKey);
+                }
+              }}
+            />
+            <InputGroupAddon align="inline-end" className="gap-0 pr-1 text-xs tabular-nums">
+              <span className="px-1">
+                {searchResult.resultCount ? `${searchResult.resultIndex + 1}/${searchResult.resultCount}` : "0/0"}
+              </span>
+              <InputGroupButton
+                size="icon-xs"
+                aria-label="Previous match"
+                disabled={!searchQuery}
+                onClick={() => find(searchQuery, true)}
+              >
+                <ChevronUp />
+              </InputGroupButton>
+              <InputGroupButton
+                size="icon-xs"
+                aria-label="Next match"
+                disabled={!searchQuery}
+                onClick={() => find(searchQuery)}
+              >
+                <ChevronDown />
+              </InputGroupButton>
+              <InputGroupButton size="icon-xs" aria-label="Close search" onClick={closeSearch}>
+                <X />
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+        </div>
+      ) : null}
       <div ref={containerRef} className="h-full w-full" />
     </div>
   );

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -20,6 +20,9 @@ import {
 import { type Theme, zoomStep } from "@/theme";
 import type { Agent } from "@/types";
 
+const SEARCH_HIGHLIGHT_LIMIT = 5000;
+const countFormat = new Intl.NumberFormat();
+
 // Surface colors follow the app tokens; ANSI colors follow GitHub light and dark, matching the code preview.
 const themes: Record<Theme, ITheme> = {
   light: {
@@ -148,6 +151,7 @@ export function TerminalView({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [searchResult, setSearchResult] = useState({ resultIndex: -1, resultCount: 0 });
   const resizeRef = useRef<() => void>(() => undefined);
   const checkRef = useRef(true);
   const workingRef = useRef(working);
@@ -168,6 +172,8 @@ export function TerminalView({
     if (!container) return;
 
     const terminal = new Terminal({
+      // The official search addon uses xterm decorations to count and mark every match.
+      allowProposedApi: true,
       cursorBlink: true,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       fontSize: fontSizeRef.current,
@@ -185,9 +191,10 @@ export function TerminalView({
     terminalRef.current = terminal;
     const fit = new FitAddon();
     terminal.loadAddon(fit);
-    const searchAddon = new SearchAddon();
+    const searchAddon = new SearchAddon({ highlightLimit: SEARCH_HIGHLIGHT_LIMIT });
     searchAddonRef.current = searchAddon;
     terminal.loadAddon(searchAddon);
+    const searchResults = searchAddon.onDidChangeResults(setSearchResult);
     // Links go to the system browser, the way every other terminal handles them.
     terminal.loadAddon(
       new WebLinksAddon((event, url) => {
@@ -287,6 +294,7 @@ export function TerminalView({
     return () => {
       window.clearTimeout(settle);
       observer.disconnect();
+      searchResults.dispose();
       input.dispose();
       unsubscribe();
       parsed.dispose();
@@ -328,15 +336,28 @@ export function TerminalView({
     if (!searchAddon) return;
     if (!term) {
       searchAddon.clearDecorations();
+      setSearchResult({ resultIndex: -1, resultCount: 0 });
       return;
     }
-    searchAddon[previous ? "findPrevious" : "findNext"](term, { incremental });
+    const dark = themeRef.current === "dark";
+    searchAddon[previous ? "findPrevious" : "findNext"](term, {
+      incremental,
+      decorations: {
+        matchBackground: dark ? "#78350f" : "#fde68a",
+        matchBorder: dark ? "#fbbf24" : "#f59e0b",
+        matchOverviewRuler: "#f59e0b",
+        activeMatchBackground: dark ? "#c2410c" : "#fdba74",
+        activeMatchBorder: "#fb923c",
+        activeMatchColorOverviewRuler: "#f97316",
+      },
+    });
   }
 
   function closeSearch() {
     searchAddonRef.current?.clearDecorations();
     setSearchOpen(false);
     setSearchQuery("");
+    setSearchResult({ resultIndex: -1, resultCount: 0 });
     terminalRef.current?.focus();
   }
 
@@ -352,6 +373,12 @@ export function TerminalView({
       data-context-zoom
       className="relative h-full w-full bg-background p-3 pr-1.5"
       onKeyDownCapture={(event) => {
+        if (searchOpen && event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          closeSearch();
+          return;
+        }
         if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
           event.preventDefault();
           event.stopPropagation();
@@ -382,16 +409,22 @@ export function TerminalView({
                 find(event.target.value, false, true);
               }}
               onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  event.stopPropagation();
-                  closeSearch();
-                } else if (event.key === "Enter") {
+                if (event.key === "Enter") {
                   event.preventDefault();
                   find(searchQuery, event.shiftKey);
                 }
               }}
             />
             <InputGroupAddon align="inline-end" className="gap-0 pr-1">
+              <span className="min-w-14 px-1 text-center text-xs tabular-nums" aria-live="polite" aria-atomic="true">
+                {searchResult.resultCount
+                  ? searchResult.resultIndex >= 0
+                    ? countFormat.format(searchResult.resultIndex + 1)
+                    : "–"
+                  : "0"}{" "}
+                / {countFormat.format(searchResult.resultCount)}
+                {searchResult.resultCount >= SEARCH_HIGHLIGHT_LIMIT ? "+" : ""}
+              </span>
               <InputGroupButton
                 size="icon-xs"
                 aria-label="Previous match"

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -148,7 +148,6 @@ export function TerminalView({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResult, setSearchResult] = useState({ resultIndex: 0, resultCount: 0 });
   const resizeRef = useRef<() => void>(() => undefined);
   const checkRef = useRef(true);
   const workingRef = useRef(working);
@@ -189,7 +188,6 @@ export function TerminalView({
     const searchAddon = new SearchAddon();
     searchAddonRef.current = searchAddon;
     terminal.loadAddon(searchAddon);
-    const searchResults = searchAddon.onDidChangeResults(setSearchResult);
     // Links go to the system browser, the way every other terminal handles them.
     terminal.loadAddon(
       new WebLinksAddon((event, url) => {
@@ -289,7 +287,6 @@ export function TerminalView({
     return () => {
       window.clearTimeout(settle);
       observer.disconnect();
-      searchResults.dispose();
       input.dispose();
       unsubscribe();
       parsed.dispose();
@@ -331,25 +328,15 @@ export function TerminalView({
     if (!searchAddon) return;
     if (!term) {
       searchAddon.clearDecorations();
-      setSearchResult({ resultIndex: 0, resultCount: 0 });
       return;
     }
-    const dark = themeRef.current === "dark";
-    searchAddon[previous ? "findPrevious" : "findNext"](term, {
-      incremental,
-      decorations: {
-        matchBackground: dark ? "#1e3a5f" : "#dbeafe",
-        matchOverviewRuler: dark ? "#60a5fa" : "#2563eb",
-        activeMatchBackground: dark ? "#1d4ed8" : "#93c5fd",
-        activeMatchColorOverviewRuler: dark ? "#bfdbfe" : "#1d4ed8",
-      },
-    });
+    searchAddon[previous ? "findPrevious" : "findNext"](term, { incremental });
   }
 
   function closeSearch() {
     searchAddonRef.current?.clearDecorations();
     setSearchOpen(false);
-    setSearchResult({ resultIndex: 0, resultCount: 0 });
+    setSearchQuery("");
     terminalRef.current?.focus();
   }
 
@@ -367,6 +354,7 @@ export function TerminalView({
       onKeyDownCapture={(event) => {
         if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
           event.preventDefault();
+          event.stopPropagation();
           if (searchOpen) {
             searchInputRef.current?.focus();
             searchInputRef.current?.select();
@@ -379,7 +367,7 @@ export function TerminalView({
       <button type="button" hidden data-context-zoom-reset onClick={() => zoomRef.current(0)} />
       <button type="button" hidden data-terminal-scroll-bottom onClick={() => terminalRef.current?.scrollToBottom()} />
       {searchOpen ? (
-        <div className="absolute top-2 right-2 z-10 w-80 max-w-[calc(100%-1rem)] rounded-lg bg-background shadow-lg">
+        <div className="absolute top-2 right-[6.5rem] z-10 w-72 max-w-[calc(100%-7rem)] rounded-lg bg-background shadow-lg">
           <InputGroup>
             <InputGroupAddon>
               <Search />
@@ -403,10 +391,7 @@ export function TerminalView({
                 }
               }}
             />
-            <InputGroupAddon align="inline-end" className="gap-0 pr-1 text-xs tabular-nums">
-              <span className="px-1">
-                {searchResult.resultCount ? `${searchResult.resultIndex + 1}/${searchResult.resultCount}` : "0/0"}
-              </span>
+            <InputGroupAddon align="inline-end" className="gap-0 pr-1">
               <InputGroupButton
                 size="icon-xs"
                 aria-label="Previous match"

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface Session {
   provider?: ModelProvider;
   // Provider model chosen when the session was created; absent for providers that own model choice.
   model?: string;
+  reasoningEffort?: string;
   // A sign-in session runs the provider's own login command; it is never stored or resumed.
   mode?: "login";
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface Session {
   createdAt?: number;
   agent: Agent;
   provider?: ModelProvider;
+  // Provider model chosen when the session was created; absent for providers that own model choice.
+  model?: string;
   // A sign-in session runs the provider's own login command; it is never stored or resumed.
   mode?: "login";
   name: string;

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -3,11 +3,38 @@
 import { describe, expect, test } from "bun:test";
 
 import { githubItemReferences, likelyGitHubItems } from "../src/github-items";
-import { clearOutput, readTerminalInput, recordTerminalInput } from "../src/output-store";
+import { appendOutput, clearOutput, readTerminalInput, recordTerminalInput } from "../src/output-store";
 
 const references = (output: string, remote = "", terminalStream = "", prose = output) =>
   githubItemReferences(output, remote, terminalStream, prose);
 const explicit = (output: string) => references(output).explicit;
+
+describe("output activity", () => {
+  test("keeps Claude background activity authoritative across output chunks", () => {
+    const bytes = (value: string) => [...new TextEncoder().encode(value)];
+    expect(appendOutput("activity", bytes("\x1b]6973;lite-work"))).toMatchObject({
+      activityChanged: false,
+      backgroundActivity: undefined,
+    });
+    expect(appendOutput("activity", bytes("ing\x07Lite"))).toMatchObject({
+      activity: true,
+      activityChanged: true,
+      backgroundActivity: true,
+    });
+    expect(appendOutput("activity", bytes("\x07"))).toMatchObject({
+      activity: undefined,
+      activityChanged: false,
+      backgroundActivity: true,
+      notification: true,
+    });
+    expect(appendOutput("activity", bytes("\x1b]6973;lite-idle\x07Lite"))).toMatchObject({
+      activity: false,
+      activityChanged: true,
+      backgroundActivity: false,
+    });
+    clearOutput("activity");
+  });
+});
 
 describe("githubItemReferences", () => {
   test("keeps user prose separate from terminal output for the session lifetime", () => {


### PR DESCRIPTION
## Summary
- add Cmd/Ctrl+F terminal search with highlighted matches and next/previous navigation
- route Cmd/Ctrl+F to the existing session, file, and Git filters when those sidebars are focused
- preserve editor-native search and terminal Cmd+K behavior

## Validation
- `bun run check`
- `bun test`
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `bun run local`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Added contextual Cmd/Ctrl+F search for terminals and focused workspace filters, while also adding DeepSeek model controls and improving session activity and loading-state handling.

### 📊 Key Changes

- Added terminal search using `@xterm/addon-search`, with highlighted matches, match counts, previous/next navigation, live-output refreshes, Escape-to-close, and F3/Cmd/Ctrl+G navigation.
- Routed Cmd/Ctrl+F to the session, Files, and Git search inputs when those surfaces are focused, while preserving editor-native search and terminal Cmd/Ctrl+K behavior.
- Added DeepSeek-specific new-session options for Flash or Pro models and low, high, or max thinking effort; these values are stored on sessions and passed to the backend when launching or resuming them.
- Updated activity tracking to preserve Claude background activity across output chunks, clear attention when activity resumes, and avoid notifications for background activity.
- Added loading indicators and disabled controls while sessions restart or inspector panels refresh, and incremented the Tauri package version to `0.0.34`.

### 🎯 Purpose & Impact

- Users can search terminal output without leaving the workspace and use the same shortcut to search whichever sidebar or filter currently has focus.
- DeepSeek sessions can be launched with the selected model and reasoning effort instead of always using the provider default.
- Background agent activity remains marked as active across streamed output, while related notifications and attention indicators are handled according to the reported activity state.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `bun.lock`
- `src-tauri/Cargo.lock`
</details>
