### PR TITLE
Persist Git records and resume Claude after restart

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.34"
+version = "0.0.35"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1360,8 +1360,7 @@ struct Lookup {
     url: String,
 }
 
-// A session prints as many references as it prints, and all of them are asked about in one request;
-// the cap is what one request comfortably carries rather than how long the panel is allowed to wait.
+// The number of references one GitHub GraphQL request comfortably carries.
 const CHECKED_GITHUB_ITEMS: usize = 100;
 
 // gh carries the user's sign-in without Lite reading it. References share bounded GraphQL requests,
@@ -1395,7 +1394,7 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
     }
     let answer = resolve_executable("gh").and_then(|gh| {
         let mut query = String::from("query {\n");
-        for (index, lookup) in lookups.iter().take(CHECKED_GITHUB_ITEMS).enumerate() {
+        for (index, lookup) in lookups.iter().enumerate() {
             let Lookup {
                 owner,
                 repository,
@@ -1434,10 +1433,7 @@ fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
     let mut found = Vec::new();
     for (index, lookup) in lookups.iter().enumerate() {
         let alias = format!("q{index}");
-        let repository = answer
-            .as_ref()
-            .filter(|_| index < CHECKED_GITHUB_ITEMS)
-            .map(|body| &body["data"][alias.as_str()]);
+        let repository = answer.as_ref().map(|body| &body["data"][alias.as_str()]);
         match repository {
             Some(repository) if repository["issueOrPullRequest"].is_object() => {
                 let item = &repository["issueOrPullRequest"];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3201,6 +3201,7 @@ async fn spawn_session(
     model: Option<String>,
     reasoning_effort: Option<String>,
     mode: Option<String>,
+    initial_prompt: Option<String>,
     theme: Option<String>,
     resume: bool,
     cols: u16,
@@ -3331,6 +3332,9 @@ async fn spawn_session(
     if !signing_in && agent == "claude" {
         let settings = claude_settings(&app, &session_id, &run_id)?;
         command.args(["--settings", &path_text(&settings)]);
+        if let Some(prompt) = initial_prompt {
+            command.arg(prompt);
+        }
     }
     configure_session_command(&mut command, &cwd, theme.as_deref());
     // Codex records a new thread per launch, so its discovery watches for one the tab did not start with.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1364,10 +1364,10 @@ struct Lookup {
 // the cap is what one request comfortably carries rather than how long the panel is allowed to wait.
 const CHECKED_GITHUB_ITEMS: usize = 100;
 
-// gh carries the user's sign-in without Lite reading it. Every explicit reference goes into one
-// GraphQL request, because a process and network round trip per item would make the panel wait. A
-// reference is dropped only when GitHub confirms the repository exists and the item does not;
-// otherwise an unavailable or private item remains visible as the command or link named it.
+// gh carries the user's sign-in without Lite reading it. References share bounded GraphQL requests,
+// because a process and network round trip per item would make the panel wait. A reference is dropped
+// only when GitHub confirms the repository exists and the item does not; otherwise an unavailable or
+// private item remains visible as the command or link named it.
 fn check_github_items(urls: Vec<String>) -> Vec<GitHubItem> {
     let mut lookups: Vec<Lookup> = Vec::new();
     let mut seen = HashSet::new();
@@ -1503,9 +1503,13 @@ async fn github_items(urls: Vec<String>) -> Vec<GitHubItem> {
             deletions: None,
         })
         .collect();
-    tauri::async_runtime::spawn_blocking(move || check_github_items(urls))
-        .await
-        .unwrap_or(unanswered)
+    tauri::async_runtime::spawn_blocking(move || {
+        urls.chunks(CHECKED_GITHUB_ITEMS)
+            .flat_map(|batch| check_github_items(batch.to_vec()))
+            .collect()
+    })
+    .await
+    .unwrap_or(unanswered)
 }
 
 #[tauri::command]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1146,16 +1146,14 @@ function SessionRow({
   onRestart: () => void;
   onClose: () => void;
 }) {
-  const [name, setName] = useState(session.name);
   const drag = useRef<{ id: number; x: number; y: number; row: HTMLElement } | undefined>(undefined);
   const drop = useRef<{ row: HTMLElement; after: boolean } | undefined>(undefined);
   const shifted = useRef<HTMLElement[]>([]);
   const dragging = useRef(false);
 
-  function saveName() {
-    const next = name.trim();
-    if (next) onRename(next);
-    else setName(session.name);
+  function saveName(value: string) {
+    const next = value.trim();
+    if (next && next !== session.name) onRename(next);
     onRenamingChange(false);
   }
 
@@ -1303,16 +1301,15 @@ function SessionRow({
       {renaming ? (
         <Input
           autoFocus
-          value={name}
+          defaultValue={session.name}
           className="min-w-0 flex-1"
           aria-label="Session name"
-          onChange={(event) => setName(event.target.value)}
-          onBlur={saveName}
+          onBlur={(event) => saveName(event.currentTarget.value)}
           onKeyDown={(event) => {
-            if (event.key === "Enter") saveName();
+            if (event.key === "Enter") event.currentTarget.blur();
             if (event.key === "Escape") {
-              setName(session.name);
-              onRenamingChange(false);
+              event.currentTarget.value = session.name;
+              event.currentTarget.blur();
             }
           }}
         />
@@ -2034,7 +2031,7 @@ function App() {
     setKeepAwake(enabled);
   }, []);
 
-  const launch = useCallback(async (session: Session, resume: boolean) => {
+  const launch = useCallback(async (session: Session, resume: boolean, initialPrompt?: string) => {
     if (runs.current.has(session.id)) return true;
     recoveryFailures.current.delete(session.id);
     const runId = crypto.randomUUID();
@@ -2064,6 +2061,7 @@ function App() {
         model: session.model,
         reasoningEffort: session.reasoningEffort,
         mode: session.mode,
+        initialPrompt: initialPrompt ?? null,
         theme: themeRef.current,
         resume,
         cols: 100,
@@ -2097,10 +2095,11 @@ function App() {
       // Taking the marker before launch makes this caller the sole owner of the continuation even
       // when another mount effect or click reaches the same in-flight process.
       const shouldContinue = session.agent !== "shell" && interrupted.current.delete(session.id);
-      const launched = await launch(session, true);
+      const prompt = "Lite restarted while you were working. Continue the previous task.";
+      const launched = await launch(session, true, shouldContinue && session.agent === "claude" ? prompt : undefined);
       if (shouldContinue) {
-        if (launched) runOnStart(session.id, "Lite restarted while you were working. Continue the previous task.");
-        else interrupted.current.add(session.id);
+        if (!launched) interrupted.current.add(session.id);
+        else if (session.agent !== "claude") runOnStart(session.id, prompt);
       }
       return launched;
     },

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -141,7 +141,7 @@ export function mergeGitHubItems<T extends { url: string }>(current: T[], update
   return [...items.values()];
 }
 
-function itemKey(url: string) {
+export function itemKey(url: string) {
   const [, , , owner, repository, , number] = url.split("/");
   return `${owner}/${repository}#${number}`.toLowerCase();
 }

--- a/src/github-items.ts
+++ b/src/github-items.ts
@@ -135,6 +135,12 @@ export function likelyGitHubItems<T extends { updatedAt: string | null; url: str
   });
 }
 
+export function mergeGitHubItems<T extends { url: string }>(current: T[], updates: T[]): T[] {
+  const items = new Map(current.map((item) => [itemKey(item.url), item]));
+  for (const item of updates) items.set(itemKey(item.url), item);
+  return [...items.values()];
+}
+
 function itemKey(url: string) {
   const [, , , owner, repository, , number] = url.split("/");
   return `${owner}/${repository}#${number}`.toLowerCase();

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -74,7 +74,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { githubItemReferences, likelyGitHubItems } from "@/github-items";
+import { githubItemReferences, likelyGitHubItems, mergeGitHubItems } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { including, without } from "@/lib/utils";
 import { readTerminalInput, readTerminalOutput, readTerminalStream, subscribeTerminalOutput } from "@/output-store";
@@ -130,6 +130,21 @@ interface GitHubItem {
   updatedAt: string | null;
   additions: number | null;
   deletions: number | null;
+}
+
+const GITHUB_ITEMS_KEY = "lite.github-items";
+
+function sessionGitHubItems(sessionId: string) {
+  const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
+  return sessions[sessionId] ?? [];
+}
+
+function retainGitHubItems(sessionId: string, updates: GitHubItem[]) {
+  const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
+  const items = mergeGitHubItems(sessions[sessionId] ?? [], updates);
+  sessions[sessionId] = items;
+  localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
+  return items;
 }
 
 // The colors GitHub itself answers in, so a glance here reads the same as a glance there.
@@ -1315,6 +1330,9 @@ const usageCache = new Map<string, UsageSnapshot | null>();
 export function clearInspectorCache(sessionId: string) {
   usageCache.delete(sessionId);
   fileEditorsBySession.delete(sessionId);
+  const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
+  delete sessions[sessionId];
+  localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
 }
 
 function GitPanel({
@@ -1336,7 +1354,7 @@ function GitPanel({
 }) {
   const [references, setReferences] = useState(() => namedInSession(sessionId, remote));
   const [status, setStatus] = useState<GitStatus | null>();
-  const [items, setItems] = useState<GitHubItem[]>();
+  const [items, setItems] = useState<GitHubItem[]>(() => sessionGitHubItems(sessionId));
   const [error, setError] = useState("");
   const [query, setQuery] = useState("");
   const [diffPath, setDiffPath] = useState("");
@@ -1373,39 +1391,49 @@ function GitPanel({
     };
   }, [active, remote, sessionId]);
 
-  // Explicit references always survive the lookup. User prose or an unqualified command inferred from
-  // the session folder survives only when GitHub confirms activity in the last 30 days.
+  // A named item belongs to the session once. Later checks update its GitHub state, but never remove it.
+  // User prose or an unqualified command first has to be confirmed as recent activity.
   useEffect(() => {
     const { explicit, inferred } = references;
-    const urls = [...explicit, ...inferred];
+    const retained = sessionGitHubItems(sessionId);
+    const placeholders = explicit.map((url) => ({
+      url,
+      title: null,
+      state: null,
+      occurredAt: null,
+      updatedAt: null,
+      additions: null,
+      deletions: null,
+    }));
+    const visible = retainGitHubItems(sessionId, mergeGitHubItems(placeholders, retained));
+    const urls = mergeGitHubItems(
+      visible,
+      [...explicit, ...inferred].map((url) => ({ url })),
+    ).map((item) => item.url);
     if (!urls.length) return setItems([]);
     let disposed = false;
-    // A remote that arrives after an empty first pass starts a real check, so the panel goes back to
-    // checking rather than staying empty without a word.
-    setItems(undefined);
+    setItems(visible);
     void invoke<GitHubItem[]>("github_items", { urls })
       .then((checked) => {
-        if (!disposed) setItems(likelyGitHubItems(checked, inferred));
-      })
-      // An explicit link survives an unavailable GitHub; an inference cannot be verified and does not.
-      .catch(() => {
-        if (!disposed)
-          setItems(
-            explicit.map((url) => ({
-              url,
-              title: null,
-              state: null,
-              occurredAt: null,
-              updatedAt: null,
-              additions: null,
-              deletions: null,
-            })),
+        if (!disposed) {
+          const known = new Set(
+            visible.map((item) =>
+              `${githubReference(item.url).repository}#${githubReference(item.url).number}`.toLowerCase(),
+            ),
           );
-      });
+          const unconfirmed = inferred.filter((url) => {
+            const reference = githubReference(url);
+            return !known.has(`${reference.repository}#${reference.number}`.toLowerCase());
+          });
+          const updates = likelyGitHubItems(checked, unconfirmed).filter((item) => item.title !== null);
+          setItems(retainGitHubItems(sessionId, updates));
+        }
+      })
+      .catch(() => {});
     return () => {
       disposed = true;
     };
-  }, [references]);
+  }, [references, sessionId]);
 
   const refresh = useCallback(async () => {
     setError("");

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -74,7 +74,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { githubItemReferences, likelyGitHubItems, mergeGitHubItems } from "@/github-items";
+import { githubItemReferences, itemKey, likelyGitHubItems, mergeGitHubItems } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
 import { including, without } from "@/lib/utils";
 import { readTerminalInput, readTerminalOutput, readTerminalStream, subscribeTerminalOutput } from "@/output-store";
@@ -1395,17 +1395,7 @@ function GitPanel({
   // User prose or an unqualified command first has to be confirmed as recent activity.
   useEffect(() => {
     const { explicit, inferred } = references;
-    const retained = sessionGitHubItems(sessionId);
-    const placeholders = explicit.map((url) => ({
-      url,
-      title: null,
-      state: null,
-      occurredAt: null,
-      updatedAt: null,
-      additions: null,
-      deletions: null,
-    }));
-    const visible = retainGitHubItems(sessionId, mergeGitHubItems(placeholders, retained));
+    const visible = sessionGitHubItems(sessionId);
     const urls = mergeGitHubItems(
       visible,
       [...explicit, ...inferred].map((url) => ({ url })),
@@ -1416,16 +1406,11 @@ function GitPanel({
     void invoke<GitHubItem[]>("github_items", { urls })
       .then((checked) => {
         if (!disposed) {
-          const known = new Set(
-            visible.map((item) =>
-              `${githubReference(item.url).repository}#${githubReference(item.url).number}`.toLowerCase(),
-            ),
+          const known = new Set(visible.map((item) => itemKey(item.url)));
+          const unconfirmed = inferred.filter((url) => !known.has(itemKey(url)));
+          const updates = likelyGitHubItems(checked, unconfirmed).filter(
+            (item) => item.title !== null || !known.has(itemKey(item.url)),
           );
-          const unconfirmed = inferred.filter((url) => {
-            const reference = githubReference(url);
-            return !known.has(`${reference.repository}#${reference.number}`.toLowerCase());
-          });
-          const updates = likelyGitHubItems(checked, unconfirmed).filter((item) => item.title !== null);
           setItems(retainGitHubItems(sessionId, updates));
         }
       })
@@ -1470,10 +1455,10 @@ function GitPanel({
   }, [refresh]);
 
   useEffect(() => {
-    if ((status !== undefined || error) && items !== undefined) onLoad("git");
-  }, [error, items, onLoad, status]);
+    if (status !== undefined || error) onLoad("git");
+  }, [error, onLoad, status]);
 
-  const repositories = repositoryGroups(remote, status ?? null, items ?? []);
+  const repositories = repositoryGroups(remote, status ?? null, items);
   // Searching narrows each card to what matches — a changed path, an item's title or number, or the
   // repository's own name — and drops the cards left holding nothing.
   const lowered = query.trim().toLowerCase();
@@ -1517,13 +1502,10 @@ function GitPanel({
                 onOpenDiff={(path) => void openDiff(path)}
               />
             ))}
-            {lowered && status !== undefined && items && repositories.length && !shown.length ? (
+            {lowered && status !== undefined && repositories.length && !shown.length ? (
               <p className="text-sm text-muted-foreground">No matches</p>
             ) : null}
-            {items === undefined && (references.explicit.length || references.inferred.length) ? (
-              <Loading label="Checking GitHub links…" />
-            ) : null}
-            {status === null && items && !repositories.length ? (
+            {status === null && !repositories.length ? (
               <Empty>
                 <EmptyHeader>
                   <EmptyDescription>

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -212,7 +212,7 @@ The agent also discussed ultralytics/portal PR #3612.`,
 
   test("keeps session items while refreshing mutable GitHub fields", () => {
     const current = [
-      { url: "https://github.com/ultralytics/lite/pull/107", title: "Old", state: "open" },
+      { url: "https://github.com/ultralytics/lite/issues/107", title: "Old", state: "open" },
       { url: "https://github.com/ultralytics/lite/issues/99", title: "Kept", state: "open" },
     ];
     const updates = [

--- a/tests/github-items.test.ts
+++ b/tests/github-items.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { githubItemReferences, likelyGitHubItems } from "../src/github-items";
+import { githubItemReferences, likelyGitHubItems, mergeGitHubItems } from "../src/github-items";
 import { appendOutput, clearOutput, readTerminalInput, recordTerminalInput } from "../src/output-store";
 
 const references = (output: string, remote = "", terminalStream = "", prose = output) =>
@@ -208,6 +208,19 @@ The agent also discussed ultralytics/portal PR #3612.`,
     ];
 
     expect(likelyGitHubItems(items, inferred, now)).toEqual([items[1], items[2]]);
+  });
+
+  test("keeps session items while refreshing mutable GitHub fields", () => {
+    const current = [
+      { url: "https://github.com/ultralytics/lite/pull/107", title: "Old", state: "open" },
+      { url: "https://github.com/ultralytics/lite/issues/99", title: "Kept", state: "open" },
+    ];
+    const updates = [
+      { url: "https://github.com/ultralytics/lite/pull/107", title: "Updated", state: "merged" },
+      { url: "https://github.com/ultralytics/lite/issues/108", title: "Added", state: "open" },
+    ];
+
+    expect(mergeGitHubItems(current, updates)).toEqual([updates[0], current[1], updates[1]]);
   });
 
   test("removes the cross-worktree duplicates from the reported transcript", () => {


### PR DESCRIPTION
## Summary

- retain every confirmed PR and issue for the lifetime of its Lite session while refreshing mutable GitHub metadata
- submit Lite restart continuation through Claude Code's resume launch instead of terminal timing
- preserve the original Claude session name when rename is cancelled
- bump the desktop app patch version to 0.0.35

## Validation

- `bun run check`
- `bun test` (15 passing)
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` (6 passing)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite now retains GitHub items throughout a session, resumes Claude sessions through Claude’s launch arguments, preserves cancelled renames, and updates the desktop version to 0.0.35.

### 📊 Key Changes

- Added session-scoped GitHub item storage in local storage, merging new references with existing items while refreshing mutable metadata without removing previously confirmed issues or pull requests.
- Changed GitHub lookups to process all references in batches of up to 100 items instead of checking only the first 100.
- Added an optional initial prompt to session startup; Claude receives the restart continuation prompt during launch, while other agents continue receiving it through terminal input.
- Updated session renaming to use the input’s current value and leave the original name unchanged when renaming is cancelled or the value is blank.
- Bumped the Tauri desktop application version from 0.0.34 to 0.0.35.

### 🎯 Purpose & Impact

- GitHub references confirmed during a Lite session remain visible across later refreshes and can be restored when the inspector is reopened; clearing the inspector cache removes the stored items for that session.
- Restarted Claude sessions receive the continuation message as part of the resumed launch rather than through terminal timing.
- GitHub references beyond the first 100 are now checked through additional batches.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
