### PR TITLE
Fix `copy path` on macOS

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "block2",
  "dbus",
  "objc2",
+ "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
  "objc2-io-kit",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ tauri-plugin-updater = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "0.6.2"
 objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSPasteboard"] }
 objc2-core-foundation = { version = "0.3.2", features = ["CFString"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
 objc2-io-kit = { version = "0.3.2", features = ["pwr_mgt"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,9 @@ use tauri_plugin_updater::UpdaterExt;
 use tungstenite::Message;
 
 #[cfg(target_os = "macos")]
-use objc2_foundation::{NSObject, NSObjectProtocol};
+use objc2_app_kit::{NSPasteboard, NSPasteboardTypeString};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSObject, NSObjectProtocol, NSString};
 #[cfg(target_os = "macos")]
 use objc2_user_notifications::{
     UNNotificationDefaultActionIdentifier, UNNotificationResponse, UNUserNotificationCenter,
@@ -5144,6 +5146,20 @@ fn startup_ready(app: AppHandle) {
     }
 }
 
+// Clipboard writes stay synchronous because AppKit pasteboard access belongs on the main thread.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+fn write_clipboard(text: String) -> Result<(), String> {
+    let pasteboard = NSPasteboard::generalPasteboard();
+    // SAFETY: AppKit owns this immutable process-lifetime constant.
+    let text_type = unsafe { NSPasteboardTypeString };
+    pasteboard.clearContents();
+    pasteboard
+        .setString_forType(&NSString::from_str(&text), text_type)
+        .then_some(())
+        .ok_or("Could not write to the clipboard".into())
+}
+
 // Tauri fills the About panel from the bundle config, which reaches it with only a name and version,
 // so the panel read as bare. macOS only: it is the one platform Tauri gives an application menu, and
 // setting one on Windows or Linux would put a native menu bar on a window that draws its own chrome.
@@ -5198,6 +5214,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            #[cfg(target_os = "macos")]
+            write_clipboard,
             choose_directory,
             follow_directory,
             github_items,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -439,7 +439,10 @@ function hasMenuItems(context: AppMenuContext): boolean {
 }
 
 function writeClipboard(text: string) {
-  void navigator.clipboard.writeText(text).catch(() => undefined);
+  const write = navigator.platform.includes("Mac")
+    ? invoke("write_clipboard", { text })
+    : navigator.clipboard.writeText(text);
+  void write.catch((error) => toast.add({ title: "Could not copy", description: String(error), type: "error" }));
 }
 
 function edit(context: AppMenuContext, command: "cut" | "paste" | "selectAll") {


### PR DESCRIPTION
Copy path silently leaves the macOS clipboard unchanged because the webview rejects its write.

```diff
- navigator.clipboard.writeText(text)
+ invoke("write_clipboard", { text })
```

- writes through AppKit on the main thread
- keeps Windows and Linux behavior unchanged
- surfaces copy failures instead of discarding them

Fixes #116. Related: [PR #44](https://github.com/ultralytics/lite/pull/44), [introducing commit](https://github.com/ultralytics/lite/commit/a264e80c558d180205e2639871333fb965af2461), [Tauri #12007](https://github.com/tauri-apps/tauri/issues/12007), [plugin #3205](https://github.com/tauri-apps/plugins-workspace/issues/3205).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixed macOS Copy path handling by routing clipboard writes through a native AppKit pasteboard command instead of the webview clipboard API.

### 📊 Key Changes
- Added the macOS `objc2-app-kit` dependency with `NSPasteboard` support.
- Implemented the synchronous `write_clipboard` Tauri command to clear and write the general macOS pasteboard.
- Updated `src/App.tsx` to use the native command on macOS while retaining the existing browser clipboard path on Windows and Linux.
- Copy failures now produce an error toast instead of being silently discarded.

### 🎯 Purpose & Impact
The macOS Copy path now writes to the system clipboard through AppKit, addressing the webview write rejection while preserving existing behavior on other platforms and surfacing failures to users.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
