### PR TITLE
Add Remote SSH workspaces

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -645,7 +645,11 @@ fn ssh_command(host: &str) -> Result<Command, String> {
     Ok(command)
 }
 
-fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
+fn ssh_stream(
+    root: &SshRoot,
+    script: &str,
+    mut receive: impl FnMut(&[u8]) -> Result<(), String>,
+) -> Result<(), String> {
     let mut child = ssh_command(&root.host)?
         .arg(script)
         .stdout(Stdio::piped())
@@ -654,22 +658,23 @@ fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
         .map_err(|error| error.to_string())?;
     let mut stdout = child.stdout.take().ok_or("Could not read SSH output")?;
     let mut stderr = child.stderr.take().ok_or("Could not read SSH errors")?;
-    let oversized = Arc::new(AtomicBool::new(false));
-    let output_oversized = Arc::clone(&oversized);
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
     let output = thread::spawn(move || {
-        let mut output = Vec::new();
         let mut buffer = [0_u8; 8192];
-        while let Ok(count) = stdout.read(&mut buffer) {
-            if count == 0 {
-                break;
-            }
-            let remaining = MAX_SSH_OUTPUT_BYTES as usize - output.len();
-            output.extend_from_slice(&buffer[..count.min(remaining)]);
-            if count > remaining {
-                output_oversized.store(true, Ordering::Relaxed);
+        loop {
+            match stdout.read(&mut buffer) {
+                Ok(0) => return,
+                Ok(count) => {
+                    if sender.send(Ok(buffer[..count].to_vec())).is_err() {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    let _ = sender.send(Err(error.to_string()));
+                    return;
+                }
             }
         }
-        output
     });
     let errors = thread::spawn(move || {
         let mut output = Vec::new();
@@ -686,41 +691,66 @@ fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
         output
     });
     let started = Instant::now();
-    let status = loop {
-        if oversized.load(Ordering::Relaxed) {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = output.join();
-            let _ = errors.join();
-            return Err("SSH output is too large; inspect it in the terminal".into());
-        }
+    let mut status = None;
+    let mut output_open = true;
+    loop {
         if started.elapsed() >= SSH_COMMAND_TIMEOUT {
             let _ = child.kill();
             let _ = child.wait();
+            drop(receiver);
             let _ = output.join();
             let _ = errors.join();
             return Err("SSH command timed out after 30 seconds".into());
         }
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {}
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = output.join();
-                let _ = errors.join();
-                return Err(error.to_string());
+        if output_open {
+            match receiver.recv_timeout(Duration::from_millis(25)) {
+                Ok(Ok(chunk)) => {
+                    if let Err(error) = receive(&chunk) {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        drop(receiver);
+                        let _ = output.join();
+                        let _ = errors.join();
+                        return Err(error);
+                    }
+                }
+                Ok(Err(error)) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    drop(receiver);
+                    let _ = output.join();
+                    let _ = errors.join();
+                    return Err(error);
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => output_open = false,
+            }
+        } else {
+            thread::sleep(Duration::from_millis(25));
+        }
+        if status.is_none() {
+            match child.try_wait() {
+                Ok(Some(exit)) => status = Some(exit),
+                Ok(None) => {}
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    drop(receiver);
+                    let _ = output.join();
+                    let _ = errors.join();
+                    return Err(error.to_string());
+                }
             }
         }
-        thread::sleep(Duration::from_millis(25));
-    };
-    let output = output.join().unwrap_or_default();
-    let errors = errors.join().unwrap_or_default();
-    if oversized.load(Ordering::Relaxed) {
-        return Err("SSH output is too large; inspect it in the terminal".into());
+        if !output_open && status.is_some() {
+            break;
+        }
     }
+    let _ = output.join();
+    let errors = errors.join().unwrap_or_default();
+    let status = status.expect("SSH status is set before the loop exits");
     if status.success() {
-        Ok(output)
+        Ok(())
     } else {
         let detail = String::from_utf8_lossy(&errors).trim().to_owned();
         Err(if detail.is_empty() {
@@ -729,6 +759,18 @@ fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
             detail
         })
     }
+}
+
+fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
+    let mut output = Vec::new();
+    ssh_stream(root, script, |chunk| {
+        if output.len() + chunk.len() > MAX_SSH_OUTPUT_BYTES as usize {
+            return Err("SSH output is too large; inspect it in the terminal".into());
+        }
+        output.extend_from_slice(chunk);
+        Ok(())
+    })?;
+    Ok(output)
 }
 
 fn ssh_text(root: &SshRoot, script: &str) -> Result<String, String> {
@@ -1139,6 +1181,11 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
             posix_quote(r"s/.*-\([0-9a-fA-F-]\{36\}\)\.jsonl$/\1/p"),
         ),
         "kimi" => format!(
+            "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; test -f \"$home/session_index.jsonl\" || exit 0; grep -F -- {} \"$home/session_index.jsonl\" | sed -n {}",
+            posix_quote(&cwd),
+            posix_quote(r#"s/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p"#),
+        ),
+        "kimi-current" => format!(
             "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; test -f \"$home/session_index.jsonl\" || exit 0; grep -F -- {} \"$home/session_index.jsonl\" | tail -n 1 | sed -n {}",
             posix_quote(&cwd),
             posix_quote(r#"s/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p"#),
@@ -1150,6 +1197,24 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
         .filter(|id| is_provider_session_id(id))
         .map(str::to_owned)
         .collect())
+}
+
+fn ssh_provider_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bool, String> {
+    if !is_provider_session_id(id) {
+        return Ok(false);
+    }
+    let script = match agent {
+        "codex" => format!(
+            "home=${{CODEX_HOME:-$HOME/.codex}}; find \"$home/sessions\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            posix_quote(&format!("rollout-*-{id}.jsonl")),
+        ),
+        "kimi" => format!(
+            "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; grep -F -- {} \"$home/session_index.jsonl\" 2>/dev/null | grep -q '\"sessionId\"' && printf 1 || printf 0",
+            posix_quote(id),
+        ),
+        _ => return Ok(false),
+    };
+    Ok(ssh_text(root, &script)? == "1")
 }
 
 fn load_codex_server(app: &AppHandle) -> Result<CodexServer, String> {
@@ -3637,7 +3702,7 @@ async fn spawn_session(
     cols: u16,
     rows: u16,
 ) -> Result<Option<String>, String> {
-    let ssh = ssh_root(&roots, &root_id)?;
+    let mut ssh = ssh_root(&roots, &root_id)?;
     match (ssh.as_ref(), host.as_deref()) {
         (Some(root), Some(host)) if root.host == host => {}
         (None, None) => {}
@@ -3651,15 +3716,22 @@ async fn spawn_session(
             .contains_key(&root_id)
     {
         uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
-        let path = fs::canonicalize(cwd).map_err(|_| MISSING_DIRECTORY)?;
+        let path = fs::canonicalize(&cwd).map_err(|_| MISSING_DIRECTORY)?;
         update_roots(&app, &roots, |roots| {
             roots
                 .entry(root_id.clone())
                 .or_insert(WorkspaceRoot::Local(path));
         })?;
     }
-    let cwd = if let Some(root) = ssh.as_ref() {
-        PathBuf::from(&root.path)
+    let cwd = if let Some(root) = ssh.as_mut() {
+        let boundary = root.clone();
+        let target = cwd.clone();
+        let path =
+            tauri::async_runtime::spawn_blocking(move || scoped_ssh_path(&boundary, &target))
+                .await
+                .map_err(|error| error.to_string())??;
+        root.path = path.clone();
+        PathBuf::from(path)
     } else {
         root_path(&roots, &root_id)?
     };
@@ -3736,12 +3808,25 @@ async fn spawn_session(
         stop_pty(&mut session)?;
     }
 
-    let ssh_known_sessions =
-        if !signing_in && provider_session_id.is_none() && (agent == "codex" || agent == "kimi") {
-            if let Some(root) = ssh.clone() {
-                if agent == "kimi" {
-                    Some(HashSet::new())
-                } else {
+    if !signing_in
+        && (agent == "codex" || agent == "kimi")
+        && let (Some(root), Some(known)) = (ssh.clone(), provider_session_id.clone())
+    {
+        let discovery_agent = agent.clone();
+        let exists = tauri::async_runtime::spawn_blocking(move || {
+            ssh_provider_session_exists(&root, &discovery_agent, &known)
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        if !exists {
+            update_provider_session(&app, &provider_sessions, &session_id, None)?;
+            provider_session_id = None;
+        }
+    }
+    let ssh_known_sessions = if provider_session_id.is_none() {
+        match agent.as_str() {
+            "codex" => {
+                if let Some(root) = ssh.clone() {
                     let discovery_agent = agent.clone();
                     Some(
                         tauri::async_runtime::spawn_blocking(move || {
@@ -3750,13 +3835,16 @@ async fn spawn_session(
                         .await
                         .map_err(|error| error.to_string())??,
                     )
+                } else {
+                    None
                 }
-            } else {
-                None
             }
-        } else {
-            None
-        };
+            "kimi" if ssh.is_some() => Some(HashSet::new()),
+            _ => None,
+        }
+    } else {
+        None
+    };
 
     let output = Arc::new(Mutex::new(output));
     let alive = Arc::new(AtomicBool::new(true));
@@ -3948,7 +4036,12 @@ async fn spawn_session(
             let mut wait = Duration::from_secs(1);
             loop {
                 let candidates = if let Some(root) = discovery_ssh.as_ref() {
-                    ssh_provider_session_ids(root, &discovery_agent).map(|current| {
+                    let remote_agent = if discovery_agent == "kimi" {
+                        "kimi-current"
+                    } else {
+                        discovery_agent.as_str()
+                    };
+                    ssh_provider_session_ids(root, remote_agent).map(|current| {
                         if discovery_agent == "kimi" {
                             current
                         } else {
@@ -4232,38 +4325,55 @@ async fn list_directory(
         let hide_hidden = settings.hide_hidden.load(Ordering::Relaxed);
         return tauri::async_runtime::spawn_blocking(move || {
             let path = scoped_ssh_path(&root, &path)?;
-            let output = ssh_output(
+            let after =
+                after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
+            let mut page = BTreeMap::new();
+            let mut has_more = false;
+            let mut pending = Vec::new();
+            let mut fields = Vec::new();
+            ssh_stream(
                 &root,
                 &format!(
                     "find {} -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
                     posix_quote(&path)
                 ),
+                |chunk| {
+                    pending.extend_from_slice(chunk);
+                    let mut consumed = 0;
+                    while let Some(end) = pending[consumed..].iter().position(|byte| *byte == 0) {
+                        let end = consumed + end;
+                        fields.push(pending[consumed..end].to_vec());
+                        consumed = end + 1;
+                        if fields.len() != 3 {
+                            continue;
+                        }
+                        let record = std::mem::take(&mut fields);
+                        let name = String::from_utf8_lossy(&record[0]).into_owned();
+                        if hide_hidden && name.starts_with('.') {
+                            continue;
+                        }
+                        let entry = FileEntry {
+                            name,
+                            path: String::from_utf8_lossy(&record[1]).into_owned(),
+                            is_directory: record[2] == b"d",
+                            is_symlink: record[2] == b"l",
+                        };
+                        let key = directory_key(&entry.name, &entry.path, entry.is_directory);
+                        if after.as_ref().is_some_and(|after| key <= *after) {
+                            continue;
+                        }
+                        page.insert(key, entry);
+                        if page.len() > DIRECTORY_PAGE_SIZE {
+                            page.pop_last();
+                            has_more = true;
+                        }
+                    }
+                    pending.drain(..consumed);
+                    Ok(())
+                },
             )?;
-            let fields = output.split(|byte| *byte == 0).collect::<Vec<_>>();
-            let after =
-                after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
-            let mut page = BTreeMap::new();
-            let mut has_more = false;
-            for record in fields.chunks_exact(3) {
-                let name = String::from_utf8_lossy(record[0]).into_owned();
-                if hide_hidden && name.starts_with('.') {
-                    continue;
-                }
-                let entry = FileEntry {
-                    name,
-                    path: String::from_utf8_lossy(record[1]).into_owned(),
-                    is_directory: record[2] == b"d",
-                    is_symlink: record[2] == b"l",
-                };
-                let key = directory_key(&entry.name, &entry.path, entry.is_directory);
-                if after.as_ref().is_some_and(|after| key <= *after) {
-                    continue;
-                }
-                page.insert(key, entry);
-                if page.len() > DIRECTORY_PAGE_SIZE {
-                    page.pop_last();
-                    has_more = true;
-                }
+            if !pending.is_empty() || !fields.is_empty() {
+                return Err("Could not read remote directory".into());
             }
             let entries = page.into_values().collect::<Vec<_>>();
             let next_cursor = has_more.then(|| {
@@ -4855,11 +4965,19 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     scope_text,
                 ],
             );
-            let diffs = ssh_bounded_git_output(
+            let mut diffs = ssh_bounded_git_output(
                 &root,
                 &diff_command,
                 &format!("head -c {}", MAX_GIT_DIFF_BYTES),
             )?;
+            if !diffs.is_empty() && !diffs.ends_with(&[0]) {
+                diffs.truncate(
+                    diffs
+                        .iter()
+                        .rposition(|byte| *byte == 0)
+                        .map_or(0, |end| end + 1),
+                );
+            }
             let mut line_diffs = BTreeMap::new();
             for record in diffs
                 .split(|byte| *byte == 0)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4925,7 +4925,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
             let output = ssh_bounded_git_output(
                 &root,
                 &status_command,
-                &format!("head -z -n {}", MAX_GIT_CHANGES + 1),
+                &format!("head -z -n {}", 2 * (MAX_GIT_CHANGES + 1)),
             )?;
             let mut changes = Vec::new();
             let mut records = output.split(|byte| *byte == 0);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1218,7 +1218,7 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
             format!(
                 "home=${{{variable}:-$HOME/{fallback}}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g; s/\"root\"[[:space:]]*:[[:space:]]*/\"root\":/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
                 posix_quote(&format!("\"root\":{cwd}")),
-                posix_quote(r#"s/.*"\(wd_[^"]*\)"[[:space:]]*:[[:space:]]*{.*/\1/p"#),
+                posix_quote(r#"s/.*"\([A-Za-z0-9_-]*\)"[[:space:]]*:[[:space:]]*{.*/\1/p"#),
             )
         }
         _ => return Ok(HashSet::new()),
@@ -4487,7 +4487,7 @@ async fn write_text_file(
             let script = scoped_ssh_script(
                 &root,
                 &path,
-                "set -e; test -f \"$path\"; parent=${path%/*}; test -n \"$parent\" || parent=/; tmp=$(mktemp \"$parent\"/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference=\"$path\" \"$tmp\"; mv -- \"$tmp\" \"$path\"; trap - EXIT",
+                "set -e; test -f \"$path\" || { printf '%s\\n' 'Only files can be edited' >&2; exit 1; }; parent=${path%/*}; test -n \"$parent\" || parent=/; tmp=$(mktemp \"$parent\"/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference=\"$path\" \"$tmp\"; mv -- \"$tmp\" \"$path\"; trap - EXIT",
             )?;
             ssh_stream(&root, &script, Some(contents.as_bytes()), |_| Ok(()))
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3649,7 +3649,7 @@ fn configure_session_command(
     );
 }
 
-fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<String>, String> {
+fn ssh_agent_args(launch: &SessionCommand<'_>) -> Result<Vec<String>, String> {
     let agent = launch.agent;
     let provider = launch.provider;
     let resume = launch.resume;
@@ -3657,10 +3657,6 @@ fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<S
     let provider_session_id = launch.provider_session_id;
     let executable = agent_executable(agent).ok_or("Unknown session type")?;
     let mut args = vec![executable.to_owned()];
-    if signing_in {
-        args.extend(login_arguments(agent)?);
-        return Ok(args);
-    }
     if agent != "codex" {
         args.extend(session_arguments(
             agent,
@@ -3688,7 +3684,6 @@ fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<S
 fn ssh_session_command(
     root: &SshRoot,
     launch: &SessionCommand<'_>,
-    signing_in: bool,
     initial_prompt: Option<&str>,
 ) -> Result<CommandBuilder, String> {
     if launch.agent == "shell" {
@@ -3701,9 +3696,8 @@ fn ssh_session_command(
         builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);
         return Ok(builder);
     }
-    let mut args = ssh_agent_args(launch, signing_in)?;
-    if !signing_in
-        && launch.agent == "claude"
+    let mut args = ssh_agent_args(launch)?;
+    if launch.agent == "claude"
         && let Some(prompt) = initial_prompt
     {
         args.push(prompt.into());
@@ -3800,7 +3794,6 @@ async fn spawn_session(
             _ => true,
         };
     if resume
-        && !signing_in
         && let Some(root) = ssh.clone()
         && matches!(agent.as_str(), "claude" | "gemini" | "qwen")
     {
@@ -3877,8 +3870,7 @@ async fn spawn_session(
         stop_pty(&mut session)?;
     }
 
-    let ssh_known_sessions = if !signing_in
-        && (agent == "codex" || agent == "kimi")
+    let ssh_known_sessions = if (agent == "codex" || agent == "kimi")
         && let Some(root) = ssh.clone()
     {
         let discovery_agent = agent.clone();
@@ -3944,7 +3936,7 @@ async fn spawn_session(
         provider_session_id: provider_session_id.as_deref(),
     };
     let mut command = if let Some(root) = ssh.as_ref() {
-        ssh_session_command(root, &launch, signing_in, initial_prompt.as_deref())?
+        ssh_session_command(root, &launch, initial_prompt.as_deref())?
     } else if signing_in {
         login_command(&agent)?
     } else {
@@ -4933,12 +4925,14 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         return tauri::async_runtime::spawn_blocking(move || {
             let marker = format!("lite-git-{}", uuid::Uuid::new_v4());
             let separator = format!("\0{marker}\0");
+            let status_limit = 900_000;
             let output = ssh_output(
                 &root,
                 &format!(
-                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\" || exit; printf '\\0%s\\0' {}; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\"",
+                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; code=$(mktemp) || exit; trap 'rm -f -- \"$code\"' EXIT; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; {{ git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\"; printf '%s' $? > \"$code\"; }} | head -z -n {} | head -c {status_limit}; result=$(cat \"$code\"); test \"$result\" = 0 || test \"$result\" = 141 || exit \"$result\"; printf '\\0%s\\0' {}; {{ git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\"; printf '%s' $? > \"$code\"; }} | head -c {MAX_GIT_DIFF_BYTES}; result=$(cat \"$code\"); test \"$result\" = 0 || test \"$result\" = 141 || exit \"$result\"; rm -f -- \"$code\"; trap - EXIT",
                     posix_quote(&root.path),
                     posix_quote(&marker),
+                    MAX_GIT_CHANGES + 1,
                     posix_quote(&marker),
                     posix_quote(&marker),
                 ),
@@ -4960,7 +4954,16 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                 .windows(separator.len())
                 .position(|window| window == separator)
                 .ok_or("Could not read remote Git status")?;
-            let status = &body[..split];
+            let mut status = body[..split].to_vec();
+            let byte_truncated = status.len() == status_limit;
+            if byte_truncated && !status.ends_with(&[0]) {
+                status.truncate(
+                    status
+                        .iter()
+                        .rposition(|byte| *byte == 0)
+                        .map_or(0, |position| position + 1),
+                );
+            }
             let mut changes = Vec::new();
             let mut records = status.split(|byte| *byte == 0);
             while let Some(record) = records.next() {
@@ -4979,7 +4982,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     break;
                 }
             }
-            let changes_truncated = changes.len() > MAX_GIT_CHANGES;
+            let changes_truncated = byte_truncated || changes.len() > MAX_GIT_CHANGES;
             changes.truncate(MAX_GIT_CHANGES);
             let scope = root
                 .path

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1648,6 +1648,8 @@ async fn use_ssh_directory(
         "\"$HOME\"".to_owned()
     } else if let Some(path) = path.strip_prefix("~/") {
         format!("\"$HOME\"/{}", posix_quote(path))
+    } else if path.starts_with('-') {
+        posix_quote(&format!("./{path}"))
     } else {
         posix_quote(path)
     };
@@ -1658,7 +1660,7 @@ async fn use_ssh_directory(
     let resolved = tauri::async_runtime::spawn_blocking(move || {
         ssh_text(
             &probe,
-            &format!("mkdir -p -- {requested} && cd -- {requested} && pwd -P"),
+            &format!("mkdir -p -- {requested} && cd {requested} && pwd -P"),
         )
     })
     .await
@@ -3666,7 +3668,7 @@ fn ssh_session_command(
         .collect::<Vec<_>>()
         .join(" ");
     let remote = format!(
-        "cd -- {} && exec ${{SHELL:-/bin/sh}} -lc {}",
+        "cd {} && exec ${{SHELL:-/bin/sh}} -lc {}",
         posix_quote(&root.path),
         posix_quote(&format!("exec {command}"))
     );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -645,13 +645,18 @@ fn ssh_command(host: &str) -> Result<Command, String> {
     Ok(command)
 }
 
+fn ssh_script(script: &str) -> String {
+    format!("exec sh -c {}", posix_quote(script))
+}
+
 fn ssh_stream(
     root: &SshRoot,
     script: &str,
     mut receive: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<(), String> {
     let mut child = ssh_command(&root.host)?
-        .arg(script)
+        .arg(ssh_script(script))
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -781,10 +786,10 @@ fn ssh_text(root: &SshRoot, script: &str) -> Result<String, String> {
 
 fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
     let mut child = ssh_command(&root.host)?
-        .arg(script)
+        .arg(ssh_script(script))
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| error.to_string())?;
     let stdin = child
@@ -796,12 +801,19 @@ fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
         let mut stdin = stdin;
         stdin.write_all(&input).map_err(|error| error.to_string())
     });
+    let stderr = child.stderr.take().ok_or("Could not read SSH errors")?;
+    let errors = thread::spawn(move || {
+        let mut output = Vec::new();
+        let _ = stderr.take(16_385).read_to_end(&mut output);
+        output
+    });
     let started = Instant::now();
     let status = loop {
         if started.elapsed() >= SSH_COMMAND_TIMEOUT {
             let _ = child.kill();
             let _ = child.wait();
             let _ = write.join();
+            let _ = errors.join();
             return Err("SSH command timed out after 30 seconds".into());
         }
         match child.try_wait() {
@@ -811,19 +823,26 @@ fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
                 let _ = child.kill();
                 let _ = child.wait();
                 let _ = write.join();
+                let _ = errors.join();
                 return Err(error.to_string());
             }
         }
         thread::sleep(Duration::from_millis(25));
     };
-    write
+    let write = write
         .join()
-        .map_err(|_| "Could not write to SSH".to_owned())??;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!("SSH command exited with {status}"))
+        .map_err(|_| "Could not write to SSH".to_owned());
+    let errors = errors.join().unwrap_or_default();
+    if !status.success() {
+        let detail = String::from_utf8_lossy(&errors).trim().to_owned();
+        return Err(if detail.is_empty() {
+            format!("SSH command exited with {status}")
+        } else {
+            detail
+        });
     }
+    write??;
+    Ok(())
 }
 
 fn remote_path(root: &SshRoot, path: &str) -> Result<String, String> {
@@ -847,22 +866,20 @@ fn remote_path(root: &SshRoot, path: &str) -> Result<String, String> {
     }
 }
 
-fn scoped_ssh_path(root: &SshRoot, path: &str) -> Result<String, String> {
-    remote_path(root, path)?;
-    let path = ssh_text(root, &format!("realpath -- {}", posix_quote(path)))?;
-    remote_path(root, &path)
-}
-
-fn scoped_ssh_entry(root: &SshRoot, path: &str) -> Result<String, String> {
+fn scoped_ssh_script(root: &SshRoot, path: &str, command: &str) -> Result<String, String> {
     let path = remote_path(root, path)?;
-    let (parent, name) = path
-        .rsplit_once('/')
-        .ok_or("Path is outside the selected folder")?;
-    if name.is_empty() || matches!(name, "." | "..") {
-        return Err("Path is outside the selected folder".into());
-    }
-    let parent = scoped_ssh_path(root, if parent.is_empty() { "/" } else { parent })?;
-    Ok(format!("{parent}/{name}"))
+    let scope = if root.path == "/" {
+        String::new()
+    } else {
+        let root = posix_quote(root.path.trim_end_matches('/'));
+        format!(
+            "case \"$path\" in {root}|{root}/*) ;; *) printf '%s\\n' 'Path is outside the selected folder' >&2; exit 1;; esac; "
+        )
+    };
+    Ok(format!(
+        "path=$(realpath -- {}) || exit; {scope}{command}",
+        posix_quote(&path)
+    ))
 }
 
 fn scoped_path(root: &Path, path: &str) -> Result<PathBuf, String> {
@@ -1180,16 +1197,18 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
             posix_quote(&cwd),
             posix_quote(r"s/.*-\([0-9a-fA-F-]\{36\}\)\.jsonl$/\1/p"),
         ),
-        "kimi" => format!(
-            "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; test -f \"$home/session_index.jsonl\" || exit 0; grep -F -- {} \"$home/session_index.jsonl\" | sed -n {}",
-            posix_quote(&cwd),
-            posix_quote(r#"s/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p"#),
-        ),
-        "kimi-current" => format!(
-            "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; test -f \"$home/session_index.jsonl\" || exit 0; grep -F -- {} \"$home/session_index.jsonl\" | tail -n 1 | sed -n {}",
-            posix_quote(&cwd),
-            posix_quote(r#"s/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p"#),
-        ),
+        "kimi" | "kimi-current" => {
+            let newest = if agent == "kimi-current" {
+                "-printf '%T@ %f\\n' | sort -n | tail -n 1 | sed 's/^[^ ]* //'"
+            } else {
+                "-printf '%f\\n'"
+            };
+            format!(
+                "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
+                posix_quote(&format!("\"root\":{cwd}")),
+                posix_quote(r#"s/.*"\(wd_[^"]*\)":{.*/\1/p"#),
+            )
+        }
         _ => return Ok(HashSet::new()),
     };
     Ok(ssh_text(root, &script)?
@@ -1199,17 +1218,26 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
         .collect())
 }
 
-fn ssh_provider_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bool, String> {
+fn ssh_native_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bool, String> {
     if !is_provider_session_id(id) {
         return Ok(false);
     }
-    if agent == "kimi" {
-        return ssh_provider_session_ids(root, agent).map(|ids| ids.contains(id));
-    }
     let script = match agent {
-        "codex" => format!(
-            "home=${{CODEX_HOME:-$HOME/.codex}}; find \"$home/sessions\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
-            posix_quote(&format!("rollout-*-{id}.jsonl")),
+        "claude" => format!(
+            "home=${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}; find \"$home/projects\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            posix_quote(&format!("{id}.jsonl")),
+        ),
+        "gemini" => format!(
+            "home=${{GEMINI_CLI_HOME:-$HOME/.gemini}}; find \"$home/tmp\" -type f -path {} -exec grep -m 1 -F -q -- {} {{}} \\; -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            posix_quote(&format!(
+                "*/chats/*-{}.jsonl",
+                id.chars().take(8).collect::<String>()
+            )),
+            posix_quote(&serde_json::to_string(id).map_err(|error| error.to_string())?),
+        ),
+        "qwen" => format!(
+            "home=${{QWEN_HOME:-$HOME/.qwen}}; find \"$home/projects\" -type f -path {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            posix_quote(&format!("*/chats/{id}.jsonl")),
         ),
         _ => return Ok(false),
     };
@@ -1640,10 +1668,13 @@ async fn use_ssh_directory(
     path: String,
 ) -> Result<DirectoryGrant, String> {
     let host = host.trim().to_owned();
-    if path.trim().is_empty() {
+    let path = path.trim();
+    if path.is_empty() {
         return Err("Enter a folder on the SSH host".into());
     }
-    let path = path.as_str();
+    if path.starts_with('~') && path != "~" && !path.starts_with("~/") {
+        return Err("Use ~ or ~/ for your home folder".into());
+    }
     let requested = if path == "~" {
         "\"$HOME\"".to_owned()
     } else if let Some(path) = path.strip_prefix("~/") {
@@ -1691,16 +1722,30 @@ async fn follow_directory(
     path: String,
 ) -> Result<DirectoryGrant, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let target = path;
-        let resolved = root.clone();
-        let path =
-            tauri::async_runtime::spawn_blocking(move || scoped_ssh_path(&resolved, &target))
-                .await
-                .map_err(|error| error.to_string())??;
+        let probe = root.clone();
+        let requested = posix_quote(&path);
+        let path = tauri::async_runtime::spawn_blocking(move || {
+            ssh_text(&probe, &format!("realpath -- {requested}"))
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        if !path.starts_with('/') {
+            return Err("The SSH server did not return an absolute folder path".into());
+        }
+        let host = root.host;
+        update_roots(&app, &roots, |roots| {
+            roots.insert(
+                root_id.clone(),
+                WorkspaceRoot::Ssh(SshRoot {
+                    host: host.clone(),
+                    path: path.clone(),
+                }),
+            );
+        })?;
         return Ok(DirectoryGrant {
             id: root_id,
             path,
-            host: Some(root.host),
+            host: Some(host),
         });
     }
     root_path(&roots, &root_id)?;
@@ -3610,9 +3655,6 @@ fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<S
     let resume = launch.resume;
     let session_id = launch.session_id;
     let provider_session_id = launch.provider_session_id;
-    if agent == "shell" {
-        return Ok(vec!["${SHELL:-/bin/sh}".into(), "-l".into()]);
-    }
     let executable = agent_executable(agent).ok_or("Unknown session type")?;
     let mut args = vec![executable.to_owned()];
     if signing_in {
@@ -3649,6 +3691,16 @@ fn ssh_session_command(
     signing_in: bool,
     initial_prompt: Option<&str>,
 ) -> Result<CommandBuilder, String> {
+    if launch.agent == "shell" {
+        let remote = ssh_script(&format!(
+            "cd {} && exec \"${{SHELL:-/bin/sh}}\" -l",
+            posix_quote(&root.path)
+        ));
+        let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
+        let mut builder = CommandBuilder::new(ssh);
+        builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);
+        return Ok(builder);
+    }
     let mut args = ssh_agent_args(launch, signing_in)?;
     if !signing_in
         && launch.agent == "claude"
@@ -3658,20 +3710,14 @@ fn ssh_session_command(
     }
     let command = args
         .iter()
-        .map(|argument| {
-            if argument == "${SHELL:-/bin/sh}" {
-                argument.clone()
-            } else {
-                posix_quote(argument)
-            }
-        })
+        .map(|argument| posix_quote(argument))
         .collect::<Vec<_>>()
         .join(" ");
-    let remote = format!(
+    let remote = ssh_script(&format!(
         "cd {} && exec ${{SHELL:-/bin/sh}} -lc {}",
         posix_quote(&root.path),
         posix_quote(&format!("exec {command}"))
-    );
+    ));
     let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
     let mut builder = CommandBuilder::new(ssh);
     builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);
@@ -3704,18 +3750,29 @@ async fn spawn_session(
     rows: u16,
 ) -> Result<Option<String>, String> {
     let mut ssh = ssh_root(&roots, &root_id)?;
-    match (ssh.as_ref(), host.as_deref()) {
-        (Some(root), Some(host)) if root.host == host => {}
-        (None, None) => {}
+    let root_exists = roots
+        .0
+        .lock()
+        .map_err(|error| error.to_string())?
+        .contains_key(&root_id);
+    match (ssh.as_ref(), host.as_deref(), root_exists) {
+        (Some(root), Some(host), _) if root.host == host => {}
+        (None, None, _) => {}
+        (None, Some(host), false) if cwd.starts_with('/') => {
+            uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
+            let _ = ssh_command(host)?;
+            let root = SshRoot {
+                host: host.to_owned(),
+                path: cwd.clone(),
+            };
+            update_roots(&app, &roots, |roots| {
+                roots.insert(root_id.clone(), WorkspaceRoot::Ssh(root.clone()));
+            })?;
+            ssh = Some(root);
+        }
         _ => return Err("The remote workspace permission is no longer available".into()),
     }
-    if ssh.is_none()
-        && !roots
-            .0
-            .lock()
-            .map_err(|error| error.to_string())?
-            .contains_key(&root_id)
-    {
+    if ssh.is_none() && !root_exists {
         uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
         let path = fs::canonicalize(&cwd).map_err(|_| MISSING_DIRECTORY)?;
         update_roots(&app, &roots, |roots| {
@@ -3724,15 +3781,8 @@ async fn spawn_session(
                 .or_insert(WorkspaceRoot::Local(path));
         })?;
     }
-    let cwd = if let Some(root) = ssh.as_mut() {
-        let boundary = root.clone();
-        let target = cwd.clone();
-        let path =
-            tauri::async_runtime::spawn_blocking(move || scoped_ssh_path(&boundary, &target))
-                .await
-                .map_err(|error| error.to_string())??;
-        root.path = path.clone();
-        PathBuf::from(path)
+    let cwd = if let Some(root) = ssh.as_ref() {
+        PathBuf::from(&root.path)
     } else {
         root_path(&roots, &root_id)?
     };
@@ -3749,6 +3799,24 @@ async fn spawn_session(
             }
             _ => true,
         };
+    if resume
+        && !signing_in
+        && let Some(root) = ssh.clone()
+        && matches!(agent.as_str(), "claude" | "gemini" | "qwen")
+    {
+        let remote_agent = agent.clone();
+        let remote_id = provider_session_id
+            .as_deref()
+            .unwrap_or(&session_id)
+            .to_owned();
+        if let Ok(Ok(exists)) = tauri::async_runtime::spawn_blocking(move || {
+            ssh_native_session_exists(&root, &remote_agent, &remote_id)
+        })
+        .await
+        {
+            resume = exists;
+        }
+    }
     // The tab keeps the id it was given so the next launch reopens the same conversation, and a
     // conversation another tab already owns is left to it rather than written by both.
     if let Some((claude_id, _)) = claude_launch.filter(|(id, _)| id != &session_id) {
@@ -3809,39 +3877,27 @@ async fn spawn_session(
         stop_pty(&mut session)?;
     }
 
-    if !signing_in
+    let ssh_known_sessions = if !signing_in
         && (agent == "codex" || agent == "kimi")
-        && let (Some(root), Some(known)) = (ssh.clone(), provider_session_id.clone())
+        && let Some(root) = ssh.clone()
     {
         let discovery_agent = agent.clone();
-        let exists = tauri::async_runtime::spawn_blocking(move || {
-            ssh_provider_session_exists(&root, &discovery_agent, &known)
+        let sessions = tauri::async_runtime::spawn_blocking(move || {
+            ssh_provider_session_ids(&root, &discovery_agent)
         })
-        .await
-        .map_err(|error| error.to_string())??;
-        if !exists {
-            update_provider_session(&app, &provider_sessions, &session_id, None)?;
-            provider_session_id = None;
-        }
-    }
-    let ssh_known_sessions = if provider_session_id.is_none() {
-        match agent.as_str() {
-            "codex" => {
-                if let Some(root) = ssh.clone() {
-                    let discovery_agent = agent.clone();
-                    Some(
-                        tauri::async_runtime::spawn_blocking(move || {
-                            ssh_provider_session_ids(&root, &discovery_agent)
-                        })
-                        .await
-                        .map_err(|error| error.to_string())??,
-                    )
-                } else {
-                    None
+        .await;
+        match sessions {
+            Ok(Ok(sessions)) => {
+                if provider_session_id
+                    .as_ref()
+                    .is_some_and(|known| !sessions.contains(known))
+                {
+                    update_provider_session(&app, &provider_sessions, &session_id, None)?;
+                    provider_session_id = None;
                 }
+                provider_session_id.is_none().then_some(sessions)
             }
-            "kimi" if ssh.is_some() => Some(HashSet::new()),
-            _ => None,
+            _ => (agent == "kimi" && provider_session_id.is_none()).then(HashSet::new),
         }
     } else {
         None
@@ -4080,7 +4136,8 @@ async fn spawn_session(
                     break;
                 }
                 thread::sleep(wait);
-                wait = (wait * 2).min(Duration::from_secs(10));
+                let maximum = if discovery_ssh.is_some() { 60 } else { 10 };
+                wait = (wait * 2).min(Duration::from_secs(maximum));
             }
         });
     }
@@ -4325,7 +4382,6 @@ async fn list_directory(
     if let Some(root) = ssh_root(&roots, &root_id)? {
         let hide_hidden = settings.hide_hidden.load(Ordering::Relaxed);
         return tauri::async_runtime::spawn_blocking(move || {
-            let path = scoped_ssh_path(&root, &path)?;
             let after =
                 after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
             let mut page = BTreeMap::new();
@@ -4334,10 +4390,11 @@ async fn list_directory(
             let mut fields = Vec::new();
             ssh_stream(
                 &root,
-                &format!(
-                    "find {} -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
-                    posix_quote(&path)
-                ),
+                &scoped_ssh_script(
+                    &root,
+                    &path,
+                    "find \"$path\" -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
+                )?,
                 |chunk| {
                     pending.extend_from_slice(chunk);
                     let mut consumed = 0;
@@ -4446,15 +4503,17 @@ async fn read_text_file(
 ) -> Result<String, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
-            let path = scoped_ssh_path(&root, &path)?;
-            let size = ssh_text(&root, &format!("wc -c < {}", posix_quote(&path)))?
-                .trim()
-                .parse::<u64>()
-                .map_err(|_| "Could not read remote file size")?;
-            if size > MAX_FILE_BYTES {
+            let bytes = ssh_output(
+                &root,
+                &scoped_ssh_script(
+                    &root,
+                    &path,
+                    &format!("head -c {} -- \"$path\"", MAX_FILE_BYTES + 1),
+                )?,
+            )?;
+            if bytes.len() > MAX_FILE_BYTES as usize {
                 return Err("File is larger than 500 KB".into());
             }
-            let bytes = ssh_output(&root, &format!("cat -- {}", posix_quote(&path)))?;
             if bytes.contains(&0) {
                 return Err("Binary files cannot be previewed".into());
             }
@@ -4488,15 +4547,11 @@ async fn write_text_file(
     }
     if let Some(root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
-            let path = scoped_ssh_path(&root, &path)?;
-            let parent = path
-                .rsplit_once('/')
-                .map_or("/", |(parent, _)| if parent.is_empty() { "/" } else { parent });
-            let script = format!(
-                "set -e; test -f {file}; tmp=$(mktemp {parent}/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference={file} \"$tmp\"; mv -- \"$tmp\" {file}; trap - EXIT",
-                file = posix_quote(&path),
-                parent = posix_quote(parent),
-            );
+            let script = scoped_ssh_script(
+                &root,
+                &path,
+                "set -e; test -f \"$path\"; parent=${path%/*}; test -n \"$parent\" || parent=/; tmp=$(mktemp \"$parent\"/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference=\"$path\" \"$tmp\"; mv -- \"$tmp\" \"$path\"; trap - EXIT",
+            )?;
             ssh_input(&root, &script, contents.as_bytes())
         })
         .await
@@ -4522,11 +4577,22 @@ async fn delete_entry(
 ) -> Result<(), String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
-            let path = scoped_ssh_entry(&root, &path)?;
-            if path == root.path.trim_end_matches('/') {
+            let path = remote_path(&root, &path)?;
+            if path.trim_end_matches('/') == root.path.trim_end_matches('/') {
                 return Err("The selected folder cannot be deleted".into());
             }
-            ssh_text(&root, &format!("rm -rf -- {}", posix_quote(&path))).map(|_| ())
+            let (parent, name) = path
+                .rsplit_once('/')
+                .ok_or("Path is outside the selected folder")?;
+            if name.is_empty() || matches!(name, "." | "..") {
+                return Err("Path is outside the selected folder".into());
+            }
+            let script = scoped_ssh_script(
+                &root,
+                if parent.is_empty() { "/" } else { parent },
+                &format!("rm -rf -- \"$path\"/{}", posix_quote(name)),
+            )?;
+            ssh_text(&root, &script).map(|_| ())
         })
         .await
         .map_err(|error| error.to_string())?;
@@ -4557,6 +4623,36 @@ fn set_hide_hidden_files(
     Ok(())
 }
 
+fn git_change(record: &[u8]) -> Result<Option<GitChange>, String> {
+    if record.len() < 4 || record[2] != b' ' {
+        return Ok(None);
+    }
+    Ok(Some(GitChange {
+        status: String::from_utf8_lossy(&record[..2]).into_owned(),
+        path: String::from_utf8(record[3..].to_vec())
+            .map_err(|_| "Git status contains a non-UTF-8 path")?,
+    }))
+}
+
+fn git_line_diffs(output: &[u8]) -> BTreeMap<String, LineDiff> {
+    output
+        .split(|byte| *byte == 0)
+        .filter_map(|record| {
+            let mut fields = record.splitn(3, |byte| *byte == b'\t');
+            let additions = String::from_utf8_lossy(fields.next()?).parse().ok()?;
+            let deletions = String::from_utf8_lossy(fields.next()?).parse().ok()?;
+            let path = fields.next().filter(|path| !path.is_empty())?;
+            Some((
+                String::from_utf8_lossy(path).into_owned(),
+                LineDiff {
+                    additions,
+                    deletions,
+                },
+            ))
+        })
+        .collect()
+}
+
 fn bounded_git_changes(
     git: &Path,
     path: &Path,
@@ -4583,26 +4679,29 @@ fn bounded_git_changes(
             break;
         }
         record.pop();
-        if record.len() < 4 || record[2] != b' ' {
+        let change = match git_change(&record) {
+            Ok(change) => change,
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+        };
+        let Some(change) = change else {
             continue;
-        }
-        let status = String::from_utf8_lossy(&record[..2]).into_owned();
+        };
         // Porcelain v1 -z puts a rename's destination first and its source in the next record.
-        if status.bytes().any(|byte| matches!(byte, b'R' | b'C')) {
+        if change
+            .status
+            .bytes()
+            .any(|byte| matches!(byte, b'R' | b'C'))
+        {
             let mut source = Vec::new();
             reader
                 .read_until(0, &mut source)
                 .map_err(|error| error.to_string())?;
         }
-        let path = match String::from_utf8(record[3..].to_vec()) {
-            Ok(path) => path,
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err("Git status contains a non-UTF-8 path".into());
-            }
-        };
-        changes.push(GitChange { status, path });
+        changes.push(change);
         if changes.len() > MAX_GIT_CHANGES {
             break;
         }
@@ -4668,44 +4767,10 @@ fn ssh_git_output(root: &SshRoot, directory: &str, args: &[&str]) -> Result<Vec<
     ssh_output(root, &ssh_git_command(directory, args))
 }
 
-fn ssh_bounded_git_output(root: &SshRoot, command: &str, limit: &str) -> Result<Vec<u8>, String> {
-    let marker = format!("lite-git-{}:", uuid::Uuid::new_v4());
-    let mut output = ssh_output(
-        root,
-        &format!(
-            "{{ {command}; code=$?; printf '%s%s\\0' {} \"$code\"; }} | {limit}",
-            posix_quote(&marker)
-        ),
-    )?;
-    let Some(position) = output
-        .windows(marker.len())
-        .rposition(|window| window == marker.as_bytes())
-    else {
-        return Ok(output);
-    };
-    let status = output[position + marker.len()..]
-        .split(|byte| *byte == 0)
-        .next()
-        .unwrap_or_default();
-    if status != b"0" {
-        return Err("Could not read Git status; refresh Git and try again".into());
-    }
-    output.truncate(position);
-    Ok(output)
-}
-
 fn ssh_git_text(root: &SshRoot, directory: &str, args: &[&str]) -> Result<String, String> {
     String::from_utf8(ssh_git_output(root, directory, args)?)
         .map(|output| output.strip_suffix('\n').unwrap_or(&output).to_owned())
         .map_err(|_| "Git returned non-UTF-8 text".into())
-}
-
-fn ssh_git_base(root: &SshRoot, repository: &str) -> Result<String, String> {
-    if ssh_git_output(root, repository, &["rev-parse", "--verify", "HEAD"]).is_ok() {
-        Ok("HEAD".into())
-    } else {
-        ssh_text(root, "git hash-object -t tree /dev/null")
-    }
 }
 
 fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
@@ -4717,60 +4782,24 @@ fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
     {
         return Err("This change is outside the selected folder".into());
     }
-    let repository = ssh_git_text(root, &root.path, &["rev-parse", "--show-toplevel"])?;
     let pathspec = path_text(relative);
-    let file = format!("{}/{}", repository.trim_end_matches('/'), pathspec);
-    let ancestor = ssh_text(
+    let scope = if root.path == "/" {
+        String::new()
+    } else {
+        let boundary = posix_quote(root.path.trim_end_matches('/'));
+        format!(
+            "case \"$ancestor\" in {boundary}|{boundary}/*) ;; *) printf '%s\\n' 'This change is outside the selected folder; start a session from the repository root to view it' >&2; exit 1;; esac; "
+        )
+    };
+    let output = ssh_output(
         root,
         &format!(
-            "path={}; while ! test -e \"$path\" && ! test -L \"$path\"; do parent=${{path%/*}}; path=${{parent:-/}}; done; realpath -- \"$path\"",
-            posix_quote(&file)
+            "root={}; pathspec={}; repository=$(git -C \"$root\" rev-parse --show-toplevel) || exit; file=\"${{repository%/}}/$pathspec\"; ancestor=\"$file\"; while ! test -e \"$ancestor\" && ! test -L \"$ancestor\"; do parent=${{ancestor%/*}}; ancestor=${{parent:-/}}; done; ancestor=$(realpath -- \"$ancestor\") || exit; {scope}if git -C \"$repository\" --literal-pathspecs ls-files --others --exclude-standard -- \"$pathspec\" | grep -q .; then git -C \"$repository\" diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null \"$file\" || test $? -eq 1; else if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --no-color \"$base\" -- \"$pathspec\"; fi | head -c {}",
+            posix_quote(&root.path),
+            posix_quote(&pathspec),
+            MAX_GIT_DIFF_BYTES + 1,
         ),
     )?;
-    remote_path(root, &ancestor).map_err(|_| {
-        "This change is outside the selected folder; start a session from the repository root to view it"
-    })?;
-    let untracked = !ssh_git_output(
-        root,
-        &repository,
-        &[
-            "--literal-pathspecs",
-            "ls-files",
-            "--others",
-            "--exclude-standard",
-            "-z",
-            "--",
-            &pathspec,
-        ],
-    )?
-    .is_empty();
-    let output = if untracked {
-        ssh_output(
-            root,
-            &format!(
-                "git -C {} diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null {} || test $? -eq 1",
-                posix_quote(&repository),
-                posix_quote(&file)
-            ),
-        )?
-    } else {
-        let base = ssh_git_base(root, &repository)?;
-        ssh_git_output(
-            root,
-            &repository,
-            &[
-                "--literal-pathspecs",
-                "diff",
-                "--no-ext-diff",
-                "--no-textconv",
-                "--no-renames",
-                "--no-color",
-                &base,
-                "--",
-                &pathspec,
-            ],
-        )?
-    };
     if output.len() > MAX_GIT_DIFF_BYTES as usize {
         return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
     }
@@ -4797,16 +4826,12 @@ fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
 async fn git_diff(
     roots: State<'_, Roots>,
     root_id: String,
-    directory: String,
     path: String,
 ) -> Result<String, String> {
-    if let Some(mut root) = ssh_root(&roots, &root_id)? {
-        return tauri::async_runtime::spawn_blocking(move || {
-            root.path = scoped_ssh_path(&root, &directory)?;
-            ssh_git_diff(&root, &path)
-        })
-        .await
-        .map_err(|error| error.to_string())?;
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        return tauri::async_runtime::spawn_blocking(move || ssh_git_diff(&root, &path))
+            .await
+            .map_err(|error| error.to_string())?;
     }
     let granted = root_path(&roots, &root_id)?;
     let relative = Path::new(&path);
@@ -4899,102 +4924,77 @@ async fn git_diff(
 }
 
 #[tauri::command]
-async fn git_status(
-    roots: State<'_, Roots>,
-    root_id: String,
-    directory: String,
-) -> Result<Option<GitStatus>, String> {
-    if let Some(mut root) = ssh_root(&roots, &root_id)? {
+async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<GitStatus>, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
-            root.path = scoped_ssh_path(&root, &directory)?;
-            let repository =
-                match ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"]) {
-                    Ok(repository) => repository,
-                    Err(_) => return Ok(None),
-                };
-            let scope = root
-                .path
-                .strip_prefix(&repository)
-                .ok_or("The selected folder is outside the Git repository")?
-                .trim_start_matches('/');
-            let scope_text = if scope.is_empty() { "." } else { scope };
-            let branch = ssh_git_text(&root, &root.path, &["branch", "--show-current"])?;
-            let status_command = ssh_git_command(
-                &repository,
-                &[
-                    "--literal-pathspecs",
-                    "status",
-                    "--porcelain=v1",
-                    "-z",
-                    "--no-renames",
-                    "--untracked-files=all",
-                    "--",
-                    scope_text,
-                ],
-            );
-            let mut output = ssh_bounded_git_output(
+            let marker = format!("lite-git-{}", uuid::Uuid::new_v4());
+            let separator = format!("\0{marker}\0");
+            let status_limit = MAX_SSH_OUTPUT_BYTES - MAX_GIT_DIFF_BYTES - 8192;
+            let output = ssh_output(
                 &root,
-                &status_command,
                 &format!(
-                    "head -z -n {} | head -c {MAX_SSH_OUTPUT_BYTES}",
-                    2 * (MAX_GIT_CHANGES + 1)
+                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\" | head -c {status_limit}; printf '\\0%s\\0' {}; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\" | head -c {MAX_GIT_DIFF_BYTES}",
+                    posix_quote(&root.path),
+                    posix_quote(&marker),
+                    posix_quote(&marker),
+                    posix_quote(&marker),
                 ),
             )?;
-            let byte_truncated = output.len() == MAX_SSH_OUTPUT_BYTES as usize;
+            let mut header = output.splitn(4, |byte| *byte == 0);
+            if header.next() != Some(marker.as_bytes()) {
+                return Err("Could not read remote Git status".into());
+            }
+            let repository = String::from_utf8(header.next().unwrap_or_default().to_vec())
+                .map_err(|_| "Git returned a non-UTF-8 repository path")?;
+            if repository.is_empty() {
+                return Ok(None);
+            }
+            let branch = String::from_utf8(header.next().unwrap_or_default().to_vec())
+                .map_err(|_| "Git returned a non-UTF-8 branch")?;
+            let body = header.next().ok_or("Could not read remote Git status")?;
+            let separator = separator.as_bytes();
+            let split = body
+                .windows(separator.len())
+                .position(|window| window == separator)
+                .ok_or("Could not read remote Git status")?;
+            let mut status = body[..split].to_vec();
+            let byte_truncated = status.len() == status_limit as usize;
             if byte_truncated {
-                output.truncate(
-                    output
+                status.truncate(
+                    status
                         .iter()
                         .rposition(|byte| *byte == 0)
                         .map_or(0, |position| position + 1),
                 );
             }
             let mut changes = Vec::new();
-            let mut records = output.split(|byte| *byte == 0);
+            let mut records = status.split(|byte| *byte == 0);
             while let Some(record) = records.next() {
-                if record.len() < 4 || record[2] != b' ' {
+                let Some(change) = git_change(record)? else {
                     continue;
-                }
-                let status = String::from_utf8_lossy(&record[..2]).into_owned();
-                if status.bytes().any(|byte| matches!(byte, b'R' | b'C')) {
+                };
+                if change
+                    .status
+                    .bytes()
+                    .any(|byte| matches!(byte, b'R' | b'C'))
+                {
                     let _ = records.next();
                 }
-                changes.push(GitChange {
-                    status,
-                    path: String::from_utf8(record[3..].to_vec())
-                        .map_err(|_| "Git status contains a non-UTF-8 path")?,
-                });
+                changes.push(change);
                 if changes.len() > MAX_GIT_CHANGES {
                     break;
                 }
             }
             let changes_truncated = byte_truncated || changes.len() > MAX_GIT_CHANGES;
             changes.truncate(MAX_GIT_CHANGES);
+            let scope = root
+                .path
+                .strip_prefix(&repository)
+                .ok_or("The selected folder is outside the Git repository")?
+                .trim_start_matches('/');
             changes.retain(|change| Path::new(&change.path).starts_with(scope));
-            let base = ssh_git_base(&root, &repository)?;
-            let diff_command = ssh_git_command(
-                &repository,
-                &[
-                    "--literal-pathspecs",
-                    "diff",
-                    "--no-ext-diff",
-                    "--no-textconv",
-                    "--no-renames",
-                    "--numstat",
-                    "-z",
-                    &base,
-                    "--",
-                    scope_text,
-                ],
-            );
-            let mut diffs = ssh_bounded_git_output(
-                &root,
-                &diff_command,
-                &format!("head -c {}", MAX_GIT_DIFF_BYTES),
-            )?;
-            if diffs.len() == MAX_GIT_DIFF_BYTES as usize {
-                diffs.clear();
-            } else if !diffs.is_empty() && !diffs.ends_with(&[0]) {
+            let mut diffs = body[split + separator.len()..].to_vec();
+            if !diffs.is_empty() && !diffs.ends_with(&[0]) {
                 diffs.truncate(
                     diffs
                         .iter()
@@ -5002,31 +5002,7 @@ async fn git_status(
                         .map_or(0, |end| end + 1),
                 );
             }
-            let mut line_diffs = BTreeMap::new();
-            for record in diffs
-                .split(|byte| *byte == 0)
-                .filter(|record| !record.is_empty())
-            {
-                let mut fields = record.splitn(3, |byte| *byte == b'\t');
-                let (Some(additions), Some(deletions), Some(path)) = (
-                    fields
-                        .next()
-                        .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
-                    fields
-                        .next()
-                        .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
-                    fields.next(),
-                ) else {
-                    continue;
-                };
-                line_diffs.insert(
-                    String::from_utf8_lossy(path).into_owned(),
-                    LineDiff {
-                        additions,
-                        deletions,
-                    },
-                );
-            }
+            let mut line_diffs = git_line_diffs(&diffs);
             line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
             Ok(Some(GitStatus {
                 branch: if branch.is_empty() {
@@ -5124,39 +5100,7 @@ async fn git_status(
             }
             Some(output)
         })
-        .map(|output| {
-            let mut diffs = BTreeMap::<String, LineDiff>::new();
-            for header in output
-                .split(|byte| *byte == 0)
-                .filter(|record| !record.is_empty())
-            {
-                let mut fields = header.splitn(3, |byte| *byte == b'\t');
-                let Some(additions) = fields
-                    .next()
-                    .and_then(|value| String::from_utf8_lossy(value).parse::<u64>().ok())
-                else {
-                    continue;
-                };
-                let Some(deletions) = fields
-                    .next()
-                    .and_then(|value| String::from_utf8_lossy(value).parse::<u64>().ok())
-                else {
-                    continue;
-                };
-                let Some(path) = fields.next() else { continue };
-                if path.is_empty() {
-                    continue;
-                }
-                diffs.insert(
-                    String::from_utf8_lossy(path).into_owned(),
-                    LineDiff {
-                        additions,
-                        deletions,
-                    },
-                );
-            }
-            diffs
-        })
+        .map(|output| git_line_diffs(&output))
         .unwrap_or_default();
     line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
     Ok(Some(GitStatus {
@@ -5203,14 +5147,9 @@ fn browse_url(remote: &str) -> Option<String> {
 // The repository a folder was cloned from, asked for on its own: naming it costs one git call, where
 // the full status reads the whole worktree.
 #[tauri::command]
-async fn git_remote(
-    roots: State<'_, Roots>,
-    root_id: String,
-    directory: String,
-) -> Result<Option<String>, String> {
-    if let Some(mut root) = ssh_root(&roots, &root_id)? {
+async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<String>, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
-            root.path = scoped_ssh_path(&root, &directory)?;
             Ok(
                 ssh_git_text(&root, &root.path, &["remote", "get-url", "origin"])
                     .ok()
@@ -5918,7 +5857,11 @@ async fn read_usage(
     agent: String,
     provider: Option<String>,
     session_id: String,
+    host: Option<String>,
 ) -> Result<Option<UsageSnapshot>, String> {
+    if host.is_some() {
+        return Ok(None);
+    }
     let provider_session_id = if agent == "codex" || agent == "kimi" {
         provider_sessions
             .0

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1203,14 +1203,13 @@ fn ssh_provider_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<
     if !is_provider_session_id(id) {
         return Ok(false);
     }
+    if agent == "kimi" {
+        return ssh_provider_session_ids(root, agent).map(|ids| ids.contains(id));
+    }
     let script = match agent {
         "codex" => format!(
             "home=${{CODEX_HOME:-$HOME/.codex}}; find \"$home/sessions\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
             posix_quote(&format!("rollout-*-{id}.jsonl")),
-        ),
-        "kimi" => format!(
-            "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; grep -F -- {} \"$home/session_index.jsonl\" 2>/dev/null | grep -q '\"sessionId\"' && printf 1 || printf 0",
-            posix_quote(id),
         ),
         _ => return Ok(false),
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1216,9 +1216,9 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
                 "-printf '%f\\n'"
             };
             format!(
-                "home=${{{variable}:-$HOME/{fallback}}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g; s/\"root\"[[:space:]]*:[[:space:]]*/\"root\":/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
+                "home=${{{variable}:-$HOME/{fallback}}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/\"\\(wd_[a-z0-9._-]*_[0-9a-f]\\{{12\\}}\\)\"[[:space:]]*:/\\n\"\\1\":/g; s/\"root\"[[:space:]]*:[[:space:]]*/\"root\":/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
                 posix_quote(&format!("\"root\":{cwd}")),
-                posix_quote(r#"s/.*"\([A-Za-z0-9_-]*\)"[[:space:]]*:[[:space:]]*{.*/\1/p"#),
+                posix_quote(r#"s/^"\(wd_[a-z0-9._-]*_[0-9a-f]\{12\}\)"[[:space:]]*:.*/\1/p"#),
             )
         }
         _ => return Ok(HashSet::new()),
@@ -1237,7 +1237,7 @@ fn ssh_native_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bo
     let (variable, fallback) = provider_home_parts(agent).ok_or("Unknown session type")?;
     let script = match agent {
         "claude" => format!(
-            "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/projects\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/projects\" -type f -name {} -exec grep -m 1 -E -q -- '\"type\"[[:space:]]*:[[:space:]]*\"(user|assistant|system)\"' {{}} \\; -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
             posix_quote(&format!("{id}.jsonl")),
         ),
         "gemini" => format!(
@@ -4705,8 +4705,6 @@ fn bounded_git_output(
 }
 
 fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
-    let relative = Path::new(path);
-    let pathspec = path_text(relative);
     let scope = ssh_scope_guard(
         &root.path,
         "ancestor",
@@ -4718,7 +4716,7 @@ fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
         &format!(
             "root={}; pathspec={}; repository=$(git -C \"$root\" rev-parse --show-toplevel) || exit; file=\"${{repository%/}}/$pathspec\"; ancestor=\"$file\"; while ! test -e \"$ancestor\" && ! test -L \"$ancestor\"; do parent=${{ancestor%/*}}; ancestor=${{parent:-/}}; done; ancestor=$(realpath -- \"$ancestor\") || exit; {scope}if git -C \"$repository\" --literal-pathspecs ls-files --others --exclude-standard -- \"$pathspec\" | grep -q .; then git -C \"$repository\" diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null \"$file\" || test $? -eq 1; else {SSH_GIT_BASE} git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --no-color \"$base\" -- \"$pathspec\"; fi",
             posix_quote(&root.path),
-            posix_quote(&pathspec),
+            posix_quote(path),
         ),
         None,
         |chunk| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     thread,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 use tauri::ipc::{Channel, InvokeResponseBody};
@@ -38,6 +38,7 @@ const DIRECTORY_PAGE_SIZE: usize = 250;
 const MAX_GIT_CHANGES: usize = 500;
 const MAX_GIT_DIFF_BYTES: u64 = 1_000_000;
 const MAX_SSH_OUTPUT_BYTES: u64 = 2_000_000;
+const SSH_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const MISSING_DIRECTORY: &str = "The selected folder no longer exists";
 const CODEX_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 // Requests stay bounded so an app server that never answers surfaces an error instead of a stuck tab.
@@ -651,8 +652,25 @@ fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| error.to_string())?;
-    let stdout = child.stdout.take().ok_or("Could not read SSH output")?;
+    let mut stdout = child.stdout.take().ok_or("Could not read SSH output")?;
     let mut stderr = child.stderr.take().ok_or("Could not read SSH errors")?;
+    let oversized = Arc::new(AtomicBool::new(false));
+    let output_oversized = Arc::clone(&oversized);
+    let output = thread::spawn(move || {
+        let mut output = Vec::new();
+        let mut buffer = [0_u8; 8192];
+        while let Ok(count) = stdout.read(&mut buffer) {
+            if count == 0 {
+                break;
+            }
+            let remaining = MAX_SSH_OUTPUT_BYTES as usize - output.len();
+            output.extend_from_slice(&buffer[..count.min(remaining)]);
+            if count > remaining {
+                output_oversized.store(true, Ordering::Relaxed);
+            }
+        }
+        output
+    });
     let errors = thread::spawn(move || {
         let mut output = Vec::new();
         let mut buffer = [0_u8; 4096];
@@ -667,24 +685,40 @@ fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
         }
         output
     });
-    let mut output = Vec::new();
-    if let Err(error) = stdout
-        .take(MAX_SSH_OUTPUT_BYTES + 1)
-        .read_to_end(&mut output)
-    {
-        let _ = child.kill();
-        let _ = child.wait();
-        let _ = errors.join();
-        return Err(error.to_string());
-    }
-    if output.len() > MAX_SSH_OUTPUT_BYTES as usize {
-        let _ = child.kill();
-        let _ = child.wait();
-        let _ = errors.join();
+    let started = Instant::now();
+    let status = loop {
+        if oversized.load(Ordering::Relaxed) {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = output.join();
+            let _ = errors.join();
+            return Err("SSH output is too large; inspect it in the terminal".into());
+        }
+        if started.elapsed() >= SSH_COMMAND_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = output.join();
+            let _ = errors.join();
+            return Err("SSH command timed out after 30 seconds".into());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = output.join();
+                let _ = errors.join();
+                return Err(error.to_string());
+            }
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    let output = output.join().unwrap_or_default();
+    let errors = errors.join().unwrap_or_default();
+    if oversized.load(Ordering::Relaxed) {
         return Err("SSH output is too large; inspect it in the terminal".into());
     }
-    let status = child.wait().map_err(|error| error.to_string())?;
-    let errors = errors.join().unwrap_or_default();
     if status.success() {
         Ok(output)
     } else {
@@ -711,17 +745,38 @@ fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
         .stderr(Stdio::null())
         .spawn()
         .map_err(|error| error.to_string())?;
-    let write = child
+    let stdin = child
         .stdin
         .take()
-        .ok_or_else(|| "Could not write to SSH".to_owned())
-        .and_then(|mut stdin| stdin.write_all(input).map_err(|error| error.to_string()));
-    if let Err(error) = write {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(error);
-    }
-    let status = child.wait().map_err(|error| error.to_string())?;
+        .ok_or_else(|| "Could not write to SSH".to_owned())?;
+    let input = input.to_vec();
+    let write = thread::spawn(move || {
+        let mut stdin = stdin;
+        stdin.write_all(&input).map_err(|error| error.to_string())
+    });
+    let started = Instant::now();
+    let status = loop {
+        if started.elapsed() >= SSH_COMMAND_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = write.join();
+            return Err("SSH command timed out after 30 seconds".into());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = write.join();
+                return Err(error.to_string());
+            }
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    write
+        .join()
+        .map_err(|_| "Could not write to SSH".to_owned())??;
     if status.success() {
         Ok(())
     } else {
@@ -730,8 +785,19 @@ fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
 }
 
 fn remote_path(root: &SshRoot, path: &str) -> Result<String, String> {
-    let root_path = root.path.trim_end_matches('/');
-    let path = path.trim_end_matches('/');
+    let root_path = if root.path == "/" {
+        "/"
+    } else {
+        root.path.trim_end_matches('/')
+    };
+    let path = if path == "/" {
+        "/"
+    } else {
+        path.trim_end_matches('/')
+    };
+    if root_path == "/" && path.starts_with('/') {
+        return Ok(path.to_owned());
+    }
     if path == root_path || path.starts_with(&format!("{root_path}/")) {
         Ok(path.to_owned())
     } else {
@@ -753,7 +819,7 @@ fn scoped_ssh_entry(root: &SshRoot, path: &str) -> Result<String, String> {
     if name.is_empty() || matches!(name, "." | "..") {
         return Err("Path is outside the selected folder".into());
     }
-    let parent = scoped_ssh_path(root, parent)?;
+    let parent = scoped_ssh_path(root, if parent.is_empty() { "/" } else { parent })?;
     Ok(format!("{parent}/{name}"))
 }
 
@@ -1062,6 +1128,28 @@ fn load_provider_sessions(app: &AppHandle) -> ProviderSessions {
         }
     }
     ProviderSessions(Mutex::new(sessions))
+}
+
+fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<String>, String> {
+    let cwd = serde_json::to_string(&root.path).map_err(|error| error.to_string())?;
+    let script = match agent {
+        "codex" => format!(
+            "home=${{CODEX_HOME:-$HOME/.codex}}; test -d \"$home/sessions\" || exit 0; find \"$home/sessions\" -type f -name 'rollout-*.jsonl' -exec sh -c 'pattern=$1; shift; for file do IFS= read -r line < \"$file\"; case $line in *\"$pattern\"*) printf \"%s\\n\" \"$file\";; esac; done' sh {} {{}} + | sed -n {}",
+            posix_quote(&cwd),
+            posix_quote(r"s/.*-\([0-9a-fA-F-]\{36\}\)\.jsonl$/\1/p"),
+        ),
+        "kimi" => format!(
+            "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; test -f \"$home/session_index.jsonl\" || exit 0; grep -F -- {} \"$home/session_index.jsonl\" | tail -n 1 | sed -n {}",
+            posix_quote(&cwd),
+            posix_quote(r#"s/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p"#),
+        ),
+        _ => return Ok(HashSet::new()),
+    };
+    Ok(ssh_text(root, &script)?
+        .lines()
+        .filter(|id| is_provider_session_id(id))
+        .map(str::to_owned)
+        .collect())
 }
 
 fn load_codex_server(app: &AppHandle) -> Result<CodexServer, String> {
@@ -1503,10 +1591,14 @@ async fn use_ssh_directory(
         host: host.clone(),
         path: String::new(),
     };
-    let resolved = ssh_text(
-        &probe,
-        &format!("mkdir -p -- {requested} && cd -- {requested} && pwd -P"),
-    )?;
+    let resolved = tauri::async_runtime::spawn_blocking(move || {
+        ssh_text(
+            &probe,
+            &format!("mkdir -p -- {requested} && cd -- {requested} && pwd -P"),
+        )
+    })
+    .await
+    .map_err(|error| error.to_string())??;
     if !resolved.starts_with('/') {
         return Err("The SSH server did not return an absolute folder path".into());
     }
@@ -1533,7 +1625,16 @@ async fn follow_directory(
     path: String,
 ) -> Result<DirectoryGrant, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let path = ssh_text(&root, &format!("cd -- {} && pwd -P", posix_quote(&path)))?;
+        let target = path;
+        let resolved = root.clone();
+        let path = tauri::async_runtime::spawn_blocking(move || {
+            ssh_text(
+                &resolved,
+                &format!("cd -- {} && pwd -P", posix_quote(&target)),
+            )
+        })
+        .await
+        .map_err(|error| error.to_string())??;
         let next = SshRoot {
             host: root.host.clone(),
             path: path.clone(),
@@ -2971,15 +3072,13 @@ struct SessionCommand<'a> {
 }
 
 fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<CommandBuilder, String> {
-    let SessionCommand {
-        agent,
-        provider,
-        model,
-        reasoning_effort,
-        resume,
-        session_id,
-        provider_session_id,
-    } = *launch;
+    let agent = launch.agent;
+    let provider = launch.provider;
+    let model = launch.model;
+    let reasoning_effort = launch.reasoning_effort;
+    let resume = launch.resume;
+    let session_id = launch.session_id;
+    let provider_session_id = launch.provider_session_id;
     let mut command = match agent {
         "claude" => {
             let mut command = agent_builder(agent)?;
@@ -3451,15 +3550,11 @@ fn configure_session_command(
 }
 
 fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<String>, String> {
-    let SessionCommand {
-        agent,
-        provider,
-        model,
-        reasoning_effort,
-        resume,
-        session_id,
-        provider_session_id,
-    } = *launch;
+    let agent = launch.agent;
+    let provider = launch.provider;
+    let resume = launch.resume;
+    let session_id = launch.session_id;
+    let provider_session_id = launch.provider_session_id;
     if agent == "shell" {
         return Ok(vec!["${SHELL:-/bin/sh}".into(), "-l".into()]);
     }
@@ -3484,16 +3579,8 @@ fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<S
         "-c".into(),
         r#"tui.notification_condition="always""#.into(),
     ]);
-    if let Some(provider) = codex_provider(provider) {
-        args.extend(["--profile".into(), provider.id.into()]);
-        if provider.id == "deepseek" {
-            if let Some(model) = model {
-                args.extend(["-c".into(), format!("model=\"{model}\"")]);
-            }
-            if let Some(effort) = reasoning_effort {
-                args.extend(["-c".into(), format!("model_reasoning_effort=\"{effort}\"")]);
-            }
-        }
+    if codex_provider(provider).is_some() {
+        return Err("Lite-managed Codex providers are available in local workspaces only".into());
     }
     if let Some(id) = provider_session_id {
         args.extend(["resume".into(), id.into()]);
@@ -3610,8 +3697,7 @@ async fn spawn_session(
             uuid::Uuid::new_v4().to_string()
         });
     }
-    if ssh.is_none()
-        && !signing_in
+    if !signing_in
         && (agent == "codex" || agent == "kimi")
         && let Some(saved_provider_session_id) = provider_sessions
             .0
@@ -3654,6 +3740,27 @@ async fn spawn_session(
     if let Some(mut session) = stale {
         stop_pty(&mut session)?;
     }
+
+    let ssh_known_sessions =
+        if !signing_in && provider_session_id.is_none() && (agent == "codex" || agent == "kimi") {
+            if let Some(root) = ssh.clone() {
+                if agent == "kimi" {
+                    Some(HashSet::new())
+                } else {
+                    let discovery_agent = agent.clone();
+                    tauri::async_runtime::spawn_blocking(move || {
+                        ssh_provider_session_ids(&root, &discovery_agent)
+                    })
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
     let output = Arc::new(Mutex::new(output));
     let alive = Arc::new(AtomicBool::new(true));
@@ -3716,7 +3823,9 @@ async fn spawn_session(
     );
     // Codex records a new thread per launch, so its discovery watches for one the tab did not start with.
     // Kimi attaches to the directory's session instead, so its discovery reads that session directly.
-    let known_sessions = if ssh.is_none()
+    let known_sessions = if let Some(existing) = ssh_known_sessions {
+        Some(existing)
+    } else if ssh.is_none()
         && !signing_in
         && provider_session_id.is_none()
         && (agent == "codex" || agent == "kimi")
@@ -3836,12 +3945,21 @@ async fn spawn_session(
         let discovery_app = app.clone();
         let discovery_session_id = session_id.clone();
         let discovery_agent = agent.clone();
+        let discovery_ssh = ssh.clone();
         thread::spawn(move || {
             // The id appears with the first turn, which may be minutes away, so an idle tab is asked
             // less and less often rather than every second for as long as it stays open.
             let mut wait = Duration::from_secs(1);
             loop {
-                let candidates = if discovery_agent == "kimi" {
+                let candidates = if let Some(root) = discovery_ssh.as_ref() {
+                    ssh_provider_session_ids(root, &discovery_agent).map(|current| {
+                        if discovery_agent == "kimi" {
+                            current
+                        } else {
+                            current.difference(&existing).cloned().collect()
+                        }
+                    })
+                } else if discovery_agent == "kimi" {
                     Ok(kimi_current_session(&discovery_app, &cwd)
                         .into_iter()
                         .collect::<HashSet<_>>())
@@ -4115,53 +4233,58 @@ async fn list_directory(
     after: Option<DirectoryCursor>,
 ) -> Result<DirectoryListing, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let path = scoped_ssh_path(&root, &path)?;
-        let output = ssh_output(
-            &root,
-            &format!(
-                "find {} -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
-                posix_quote(&path)
-            ),
-        )?;
-        let fields = output.split(|byte| *byte == 0).collect::<Vec<_>>();
-        let after =
-            after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
-        let mut page = BTreeMap::new();
-        let mut has_more = false;
-        for record in fields.chunks_exact(3) {
-            let name = String::from_utf8_lossy(record[0]).into_owned();
-            if settings.hide_hidden.load(Ordering::Relaxed) && name.starts_with('.') {
-                continue;
+        let hide_hidden = settings.hide_hidden.load(Ordering::Relaxed);
+        return tauri::async_runtime::spawn_blocking(move || {
+            let path = scoped_ssh_path(&root, &path)?;
+            let output = ssh_output(
+                &root,
+                &format!(
+                    "find {} -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
+                    posix_quote(&path)
+                ),
+            )?;
+            let fields = output.split(|byte| *byte == 0).collect::<Vec<_>>();
+            let after =
+                after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
+            let mut page = BTreeMap::new();
+            let mut has_more = false;
+            for record in fields.chunks_exact(3) {
+                let name = String::from_utf8_lossy(record[0]).into_owned();
+                if hide_hidden && name.starts_with('.') {
+                    continue;
+                }
+                let entry = FileEntry {
+                    name,
+                    path: String::from_utf8_lossy(record[1]).into_owned(),
+                    is_directory: record[2] == b"d",
+                    is_symlink: record[2] == b"l",
+                };
+                let key = directory_key(&entry.name, &entry.path, entry.is_directory);
+                if after.as_ref().is_some_and(|after| key <= *after) {
+                    continue;
+                }
+                page.insert(key, entry);
+                if page.len() > DIRECTORY_PAGE_SIZE {
+                    page.pop_last();
+                    has_more = true;
+                }
             }
-            let entry = FileEntry {
-                name,
-                path: String::from_utf8_lossy(record[1]).into_owned(),
-                is_directory: record[2] == b"d",
-                is_symlink: record[2] == b"l",
-            };
-            let key = directory_key(&entry.name, &entry.path, entry.is_directory);
-            if after.as_ref().is_some_and(|after| key <= *after) {
-                continue;
-            }
-            page.insert(key, entry);
-            if page.len() > DIRECTORY_PAGE_SIZE {
-                page.pop_last();
-                has_more = true;
-            }
-        }
-        let entries = page.into_values().collect::<Vec<_>>();
-        let next_cursor = has_more.then(|| {
-            let entry = entries.last().expect("a truncated page is not empty");
-            DirectoryCursor {
-                name: entry.name.clone(),
-                path: entry.path.clone(),
-                is_directory: entry.is_directory,
-            }
-        });
-        return Ok(DirectoryListing {
-            entries,
-            next_cursor,
-        });
+            let entries = page.into_values().collect::<Vec<_>>();
+            let next_cursor = has_more.then(|| {
+                let entry = entries.last().expect("a truncated page is not empty");
+                DirectoryCursor {
+                    name: entry.name.clone(),
+                    path: entry.path.clone(),
+                    is_directory: entry.is_directory,
+                }
+            });
+            Ok(DirectoryListing {
+                entries,
+                next_cursor,
+            })
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
@@ -4215,18 +4338,22 @@ async fn read_text_file(
     path: String,
 ) -> Result<String, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let path = scoped_ssh_path(&root, &path)?;
-        let size = ssh_text(&root, &format!("wc -c < {}", posix_quote(&path)))?
-            .parse::<u64>()
-            .map_err(|_| "Could not read remote file size")?;
-        if size > MAX_FILE_BYTES {
-            return Err("File is larger than 500 KB".into());
-        }
-        let bytes = ssh_output(&root, &format!("cat -- {}", posix_quote(&path)))?;
-        if bytes.contains(&0) {
-            return Err("Binary files cannot be previewed".into());
-        }
-        return String::from_utf8(bytes).map_err(|_| "File is not UTF-8 text".into());
+        return tauri::async_runtime::spawn_blocking(move || {
+            let path = scoped_ssh_path(&root, &path)?;
+            let size = ssh_text(&root, &format!("wc -c < {}", posix_quote(&path)))?
+                .parse::<u64>()
+                .map_err(|_| "Could not read remote file size")?;
+            if size > MAX_FILE_BYTES {
+                return Err("File is larger than 500 KB".into());
+            }
+            let bytes = ssh_output(&root, &format!("cat -- {}", posix_quote(&path)))?;
+            if bytes.contains(&0) {
+                return Err("Binary files cannot be previewed".into());
+            }
+            String::from_utf8(bytes).map_err(|_| "File is not UTF-8 text".into())
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
@@ -4252,14 +4379,20 @@ async fn write_text_file(
         return Err("File is larger than 500 KB".into());
     }
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let path = scoped_ssh_path(&root, &path)?;
-        let parent = path.rsplit_once('/').map_or("/", |(parent, _)| parent);
-        let script = format!(
-            "set -e; test -f {file}; tmp=$(mktemp {parent}/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference={file} \"$tmp\"; mv -- \"$tmp\" {file}; trap - EXIT",
-            file = posix_quote(&path),
-            parent = posix_quote(parent),
-        );
-        return ssh_input(&root, &script, contents.as_bytes());
+        return tauri::async_runtime::spawn_blocking(move || {
+            let path = scoped_ssh_path(&root, &path)?;
+            let parent = path
+                .rsplit_once('/')
+                .map_or("/", |(parent, _)| if parent.is_empty() { "/" } else { parent });
+            let script = format!(
+                "set -e; test -f {file}; tmp=$(mktemp {parent}/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference={file} \"$tmp\"; mv -- \"$tmp\" {file}; trap - EXIT",
+                file = posix_quote(&path),
+                parent = posix_quote(parent),
+            );
+            ssh_input(&root, &script, contents.as_bytes())
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
@@ -4280,11 +4413,15 @@ async fn delete_entry(
     path: String,
 ) -> Result<(), String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let path = scoped_ssh_entry(&root, &path)?;
-        if path == root.path.trim_end_matches('/') {
-            return Err("The selected folder cannot be deleted".into());
-        }
-        return ssh_text(&root, &format!("rm -rf -- {}", posix_quote(&path))).map(|_| ());
+        return tauri::async_runtime::spawn_blocking(move || {
+            let path = scoped_ssh_entry(&root, &path)?;
+            if path == root.path.trim_end_matches('/') {
+                return Err("The selected folder cannot be deleted".into());
+            }
+            ssh_text(&root, &format!("rm -rf -- {}", posix_quote(&path))).map(|_| ())
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_entry(&root, &path)?;
@@ -4409,15 +4546,18 @@ fn bounded_git_output(
     Ok(String::from_utf8_lossy(&output).into_owned())
 }
 
-fn ssh_git_output(root: &SshRoot, directory: &str, args: &[&str]) -> Result<Vec<u8>, String> {
-    let command = std::iter::once("git".to_owned())
+fn ssh_git_command(directory: &str, args: &[&str]) -> String {
+    std::iter::once("git".to_owned())
         .chain(std::iter::once("-C".to_owned()))
         .chain(std::iter::once(directory.to_owned()))
         .chain(args.iter().map(|argument| (*argument).to_owned()))
         .map(|argument| posix_quote(&argument))
         .collect::<Vec<_>>()
-        .join(" ");
-    ssh_output(root, &command)
+        .join(" ")
+}
+
+fn ssh_git_output(root: &SshRoot, directory: &str, args: &[&str]) -> Result<Vec<u8>, String> {
+    ssh_output(root, &ssh_git_command(directory, args))
 }
 
 fn ssh_git_text(root: &SshRoot, directory: &str, args: &[&str]) -> Result<String, String> {
@@ -4432,6 +4572,68 @@ fn ssh_git_base(root: &SshRoot, repository: &str) -> Result<String, String> {
     } else {
         ssh_text(root, "git hash-object -t tree /dev/null")
     }
+}
+
+fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
+    let relative = Path::new(path);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err("This change is outside the selected folder".into());
+    }
+    let repository = ssh_git_text(root, &root.path, &["rev-parse", "--show-toplevel"])?;
+    let pathspec = path_text(relative);
+    let file = format!("{}/{}", repository.trim_end_matches('/'), pathspec);
+    remote_path(root, &file).map_err(|_| {
+        "This change is outside the selected folder; start a session from the repository root to view it"
+    })?;
+    let untracked = !ssh_git_output(
+        root,
+        &repository,
+        &[
+            "--literal-pathspecs",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            &pathspec,
+        ],
+    )?
+    .is_empty();
+    let output = if untracked {
+        ssh_output(
+            root,
+            &format!(
+                "git -C {} diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null {} || test $? -eq 1",
+                posix_quote(&repository),
+                posix_quote(&file)
+            ),
+        )?
+    } else {
+        let base = ssh_git_base(root, &repository)?;
+        ssh_git_output(
+            root,
+            &repository,
+            &[
+                "--literal-pathspecs",
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-renames",
+                "--no-color",
+                &base,
+                "--",
+                &pathspec,
+            ],
+        )?
+    };
+    if output.len() > MAX_GIT_DIFF_BYTES as usize {
+        return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
+    }
+    Ok(String::from_utf8_lossy(&output).into_owned())
 }
 
 fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
@@ -4457,65 +4659,9 @@ async fn git_diff(
     path: String,
 ) -> Result<String, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let relative = Path::new(&path);
-        if relative.is_absolute()
-            || relative
-                .components()
-                .any(|component| !matches!(component, Component::Normal(_)))
-        {
-            return Err("This change is outside the selected folder".into());
-        }
-        let repository = ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"])?;
-        let pathspec = path_text(relative);
-        let file = format!("{}/{}", repository.trim_end_matches('/'), pathspec);
-        remote_path(&root, &file).map_err(|_| {
-            "This change is outside the selected folder; start a session from the repository root to view it"
-        })?;
-        let untracked = !ssh_git_output(
-            &root,
-            &repository,
-            &[
-                "--literal-pathspecs",
-                "ls-files",
-                "--others",
-                "--exclude-standard",
-                "-z",
-                "--",
-                &pathspec,
-            ],
-        )?
-        .is_empty();
-        let output = if untracked {
-            ssh_output(
-                &root,
-                &format!(
-                    "git -C {} diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null {} || test $? -eq 1",
-                    posix_quote(&repository),
-                    posix_quote(&file)
-                ),
-            )?
-        } else {
-            let base = ssh_git_base(&root, &repository)?;
-            ssh_git_output(
-                &root,
-                &repository,
-                &[
-                    "--literal-pathspecs",
-                    "diff",
-                    "--no-ext-diff",
-                    "--no-textconv",
-                    "--no-renames",
-                    "--no-color",
-                    &base,
-                    "--",
-                    &pathspec,
-                ],
-            )?
-        };
-        if output.len() > MAX_GIT_DIFF_BYTES as usize {
-            return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
-        }
-        return Ok(String::from_utf8_lossy(&output).into_owned());
+        return tauri::async_runtime::spawn_blocking(move || ssh_git_diff(&root, &path))
+            .await
+            .map_err(|error| error.to_string())?;
     }
     let granted = root_path(&roots, &root_id)?;
     let relative = Path::new(&path);
@@ -4610,107 +4756,118 @@ async fn git_diff(
 #[tauri::command]
 async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<GitStatus>, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let repository = match ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"]) {
-            Ok(repository) => repository,
-            Err(_) => return Ok(None),
-        };
-        let scope = root
-            .path
-            .strip_prefix(&repository)
-            .ok_or("The selected folder is outside the Git repository")?
-            .trim_start_matches('/');
-        let scope_text = if scope.is_empty() { "." } else { scope };
-        let branch = ssh_git_text(&root, &root.path, &["branch", "--show-current"])?;
-        let output = ssh_git_output(
-            &root,
-            &repository,
-            &[
-                "--literal-pathspecs",
-                "status",
-                "--porcelain=v1",
-                "-z",
-                "--no-renames",
-                "--untracked-files=all",
-                "--",
-                scope_text,
-            ],
-        )?;
-        let mut changes = Vec::new();
-        let mut records = output.split(|byte| *byte == 0);
-        while let Some(record) = records.next() {
-            if record.len() < 4 || record[2] != b' ' {
-                continue;
-            }
-            let status = String::from_utf8_lossy(&record[..2]).into_owned();
-            if status.bytes().any(|byte| matches!(byte, b'R' | b'C')) {
-                let _ = records.next();
-            }
-            changes.push(GitChange {
-                status,
-                path: String::from_utf8(record[3..].to_vec())
-                    .map_err(|_| "Git status contains a non-UTF-8 path")?,
-            });
-            if changes.len() > MAX_GIT_CHANGES {
-                break;
-            }
-        }
-        let changes_truncated = changes.len() > MAX_GIT_CHANGES;
-        changes.truncate(MAX_GIT_CHANGES);
-        changes.retain(|change| Path::new(&change.path).starts_with(scope));
-        let base = ssh_git_base(&root, &repository)?;
-        let diffs = ssh_git_output(
-            &root,
-            &repository,
-            &[
-                "--literal-pathspecs",
-                "diff",
-                "--no-ext-diff",
-                "--no-textconv",
-                "--no-renames",
-                "--numstat",
-                "-z",
-                &base,
-                "--",
-                scope_text,
-            ],
-        )?;
-        let mut line_diffs = BTreeMap::new();
-        for record in diffs
-            .split(|byte| *byte == 0)
-            .filter(|record| !record.is_empty())
-        {
-            let mut fields = record.splitn(3, |byte| *byte == b'\t');
-            let (Some(additions), Some(deletions), Some(path)) = (
-                fields
-                    .next()
-                    .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
-                fields
-                    .next()
-                    .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
-                fields.next(),
-            ) else {
-                continue;
-            };
-            line_diffs.insert(
-                String::from_utf8_lossy(path).into_owned(),
-                LineDiff {
-                    additions,
-                    deletions,
-                },
+        return tauri::async_runtime::spawn_blocking(move || {
+            let repository =
+                match ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"]) {
+                    Ok(repository) => repository,
+                    Err(_) => return Ok(None),
+                };
+            let scope = root
+                .path
+                .strip_prefix(&repository)
+                .ok_or("The selected folder is outside the Git repository")?
+                .trim_start_matches('/');
+            let scope_text = if scope.is_empty() { "." } else { scope };
+            let branch = ssh_git_text(&root, &root.path, &["branch", "--show-current"])?;
+            let status_command = ssh_git_command(
+                &repository,
+                &[
+                    "--literal-pathspecs",
+                    "status",
+                    "--porcelain=v1",
+                    "-z",
+                    "--no-renames",
+                    "--untracked-files=all",
+                    "--",
+                    scope_text,
+                ],
             );
-        }
-        line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
-        return Ok(Some(GitStatus {
-            branch: if branch.is_empty() {
-                "Detached HEAD".into()
-            } else {
-                branch
-            },
-            worktree: repository,
-            changes,
-            line_diffs,
-            changes_truncated,
-        }));
+            let output = ssh_output(
+                &root,
+                &format!("{status_command} | head -z -n {}", MAX_GIT_CHANGES + 1),
+            )?;
+            let mut changes = Vec::new();
+            let mut records = output.split(|byte| *byte == 0);
+            while let Some(record) = records.next() {
+                if record.len() < 4 || record[2] != b' ' {
+                    continue;
+                }
+                let status = String::from_utf8_lossy(&record[..2]).into_owned();
+                if status.bytes().any(|byte| matches!(byte, b'R' | b'C')) {
+                    let _ = records.next();
+                }
+                changes.push(GitChange {
+                    status,
+                    path: String::from_utf8(record[3..].to_vec())
+                        .map_err(|_| "Git status contains a non-UTF-8 path")?,
+                });
+                if changes.len() > MAX_GIT_CHANGES {
+                    break;
+                }
+            }
+            let changes_truncated = changes.len() > MAX_GIT_CHANGES;
+            changes.truncate(MAX_GIT_CHANGES);
+            changes.retain(|change| Path::new(&change.path).starts_with(scope));
+            let base = ssh_git_base(&root, &repository)?;
+            let diff_command = ssh_git_command(
+                &repository,
+                &[
+                    "--literal-pathspecs",
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--no-renames",
+                    "--numstat",
+                    "-z",
+                    &base,
+                    "--",
+                    scope_text,
+                ],
+            );
+            let diffs = ssh_output(
+                &root,
+                &format!("{diff_command} | head -c {}", MAX_GIT_DIFF_BYTES),
+            )?;
+            let mut line_diffs = BTreeMap::new();
+            for record in diffs
+                .split(|byte| *byte == 0)
+                .filter(|record| !record.is_empty())
+            {
+                let mut fields = record.splitn(3, |byte| *byte == b'\t');
+                let (Some(additions), Some(deletions), Some(path)) = (
+                    fields
+                        .next()
+                        .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
+                    fields
+                        .next()
+                        .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
+                    fields.next(),
+                ) else {
+                    continue;
+                };
+                line_diffs.insert(
+                    String::from_utf8_lossy(path).into_owned(),
+                    LineDiff {
+                        additions,
+                        deletions,
+                    },
+                );
+            }
+            line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
+            Ok(Some(GitStatus {
+                branch: if branch.is_empty() {
+                    "Detached HEAD".into()
+                } else {
+                    branch
+                },
+                worktree: repository,
+                changes,
+                line_diffs,
+                changes_truncated,
+            }))
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let path = root_path(&roots, &root_id)?;
     // Locating Git runs a login shell, so one refresh resolves it once rather than once per command.
@@ -4874,11 +5031,15 @@ fn browse_url(remote: &str) -> Option<String> {
 #[tauri::command]
 async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<String>, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        return Ok(
-            ssh_git_text(&root, &root.path, &["remote", "get-url", "origin"])
-                .ok()
-                .and_then(|remote| browse_url(&remote)),
-        );
+        return tauri::async_runtime::spawn_blocking(move || {
+            Ok(
+                ssh_git_text(&root, &root.path, &["remote", "get-url", "origin"])
+                    .ok()
+                    .and_then(|remote| browse_url(&remote)),
+            )
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let path = root_path(&roots, &root_id)?;
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
@@ -5978,6 +6139,17 @@ mod tests {
             command.get_env("LC_CTYPE"),
             cfg!(target_os = "macos").then_some(OsStr::new("UTF-8"))
         );
+    }
+
+    #[test]
+    fn ssh_root_keeps_filesystem_root() {
+        let root = SshRoot {
+            host: "server".into(),
+            path: "/".into(),
+        };
+
+        assert_eq!(remote_path(&root, "/").unwrap(), "/");
+        assert_eq!(remote_path(&root, "/project").unwrap(), "/project");
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -733,7 +733,7 @@ fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
 
 fn ssh_text(root: &SshRoot, script: &str) -> Result<String, String> {
     String::from_utf8(ssh_output(root, script)?)
-        .map(|output| output.trim().to_owned())
+        .map(|output| output.strip_suffix('\n').unwrap_or(&output).to_owned())
         .map_err(|_| "SSH command returned non-UTF-8 text".into())
 }
 
@@ -3743,12 +3743,13 @@ async fn spawn_session(
                     Some(HashSet::new())
                 } else {
                     let discovery_agent = agent.clone();
-                    tauri::async_runtime::spawn_blocking(move || {
-                        ssh_provider_session_ids(&root, &discovery_agent)
-                    })
-                    .await
-                    .ok()
-                    .and_then(Result::ok)
+                    Some(
+                        tauri::async_runtime::spawn_blocking(move || {
+                            ssh_provider_session_ids(&root, &discovery_agent)
+                        })
+                        .await
+                        .map_err(|error| error.to_string())??,
+                    )
                 }
             } else {
                 None
@@ -4336,6 +4337,7 @@ async fn read_text_file(
         return tauri::async_runtime::spawn_blocking(move || {
             let path = scoped_ssh_path(&root, &path)?;
             let size = ssh_text(&root, &format!("wc -c < {}", posix_quote(&path)))?
+                .trim()
                 .parse::<u64>()
                 .map_err(|_| "Could not read remote file size")?;
             if size > MAX_FILE_BYTES {
@@ -4555,9 +4557,35 @@ fn ssh_git_output(root: &SshRoot, directory: &str, args: &[&str]) -> Result<Vec<
     ssh_output(root, &ssh_git_command(directory, args))
 }
 
+fn ssh_bounded_git_output(root: &SshRoot, command: &str, limit: &str) -> Result<Vec<u8>, String> {
+    let marker = format!("lite-git-{}:", uuid::Uuid::new_v4());
+    let mut output = ssh_output(
+        root,
+        &format!(
+            "{{ {command}; code=$?; printf '%s%s\\0' {} \"$code\"; }} | {limit}",
+            posix_quote(&marker)
+        ),
+    )?;
+    let Some(position) = output
+        .windows(marker.len())
+        .rposition(|window| window == marker.as_bytes())
+    else {
+        return Ok(output);
+    };
+    let status = output[position + marker.len()..]
+        .split(|byte| *byte == 0)
+        .next()
+        .unwrap_or_default();
+    if status != b"0" {
+        return Err("Could not read Git status; refresh Git and try again".into());
+    }
+    output.truncate(position);
+    Ok(output)
+}
+
 fn ssh_git_text(root: &SshRoot, directory: &str, args: &[&str]) -> Result<String, String> {
     String::from_utf8(ssh_git_output(root, directory, args)?)
-        .map(|output| output.trim().to_owned())
+        .map(|output| output.strip_suffix('\n').unwrap_or(&output).to_owned())
         .map_err(|_| "Git returned non-UTF-8 text".into())
 }
 
@@ -4784,9 +4812,10 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     scope_text,
                 ],
             );
-            let output = ssh_output(
+            let output = ssh_bounded_git_output(
                 &root,
-                &format!("{status_command} | head -z -n {}", MAX_GIT_CHANGES + 1),
+                &status_command,
+                &format!("head -z -n {}", MAX_GIT_CHANGES + 1),
             )?;
             let mut changes = Vec::new();
             let mut records = output.split(|byte| *byte == 0);
@@ -4826,9 +4855,10 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     scope_text,
                 ],
             );
-            let diffs = ssh_output(
+            let diffs = ssh_bounded_git_output(
                 &root,
-                &format!("{diff_command} | head -c {}", MAX_GIT_DIFF_BYTES),
+                &diff_command,
+                &format!("head -c {}", MAX_GIT_DIFF_BYTES),
             )?;
             let mut line_diffs = BTreeMap::new();
             for record in diffs

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -547,6 +547,42 @@ fn directory_key(name: &str, path: &str, is_directory: bool) -> (u8, String, Str
     )
 }
 
+fn page_directory_entry(
+    page: &mut BTreeMap<(u8, String, String), FileEntry>,
+    has_more: &mut bool,
+    after: &Option<(u8, String, String)>,
+    entry: FileEntry,
+) {
+    let key = directory_key(&entry.name, &entry.path, entry.is_directory);
+    if after.as_ref().is_some_and(|after| key <= *after) {
+        return;
+    }
+    page.insert(key, entry);
+    if page.len() > DIRECTORY_PAGE_SIZE {
+        page.pop_last();
+        *has_more = true;
+    }
+}
+
+fn directory_listing(
+    page: BTreeMap<(u8, String, String), FileEntry>,
+    has_more: bool,
+) -> DirectoryListing {
+    let entries = page.into_values().collect::<Vec<_>>();
+    let next_cursor = has_more.then(|| {
+        let entry = entries.last().expect("a truncated page is not empty");
+        DirectoryCursor {
+            name: entry.name.clone(),
+            path: entry.path.clone(),
+            is_directory: entry.is_directory,
+        }
+    });
+    DirectoryListing {
+        entries,
+        next_cursor,
+    }
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GitStatus {
@@ -3645,6 +3681,12 @@ fn ssh_agent_args(launch: &SessionCommand<'_>) -> Result<Vec<String>, String> {
             session_id,
             provider_session_id,
         )?);
+        if agent == "claude" {
+            args.extend([
+                "--settings".into(),
+                r#"{"preferredNotifChannel":"iterm2"}"#.into(),
+            ]);
+        }
         return Ok(args);
     }
     args.extend([
@@ -3721,12 +3763,17 @@ async fn spawn_session(
     cols: u16,
     rows: u16,
 ) -> Result<Option<String>, String> {
-    let mut ssh = ssh_root(&roots, &root_id)?;
-    let root_exists = roots
+    let root = roots
         .0
         .lock()
         .map_err(|error| error.to_string())?
-        .contains_key(&root_id);
+        .get(&root_id)
+        .cloned();
+    let root_exists = root.is_some();
+    let mut ssh = match root {
+        Some(WorkspaceRoot::Ssh(root)) => Some(root),
+        _ => None,
+    };
     match (ssh.as_ref(), host.as_deref(), root_exists) {
         (Some(root), Some(host), _) if root.host == host => {}
         (None, None, _) => {}
@@ -4386,15 +4433,7 @@ async fn list_directory(
                             is_directory: record[2] == b"d",
                             is_symlink: record[2] == b"l",
                         };
-                        let key = directory_key(&entry.name, &entry.path, entry.is_directory);
-                        if after.as_ref().is_some_and(|after| key <= *after) {
-                            continue;
-                        }
-                        page.insert(key, entry);
-                        if page.len() > DIRECTORY_PAGE_SIZE {
-                            page.pop_last();
-                            has_more = true;
-                        }
+                        page_directory_entry(&mut page, &mut has_more, &after, entry);
                     }
                     pending.drain(..consumed);
                     Ok(())
@@ -4403,19 +4442,7 @@ async fn list_directory(
             if !pending.is_empty() || !fields.is_empty() {
                 return Err("Could not read remote directory".into());
             }
-            let entries = page.into_values().collect::<Vec<_>>();
-            let next_cursor = has_more.then(|| {
-                let entry = entries.last().expect("a truncated page is not empty");
-                DirectoryCursor {
-                    name: entry.name.clone(),
-                    path: entry.path.clone(),
-                    is_directory: entry.is_directory,
-                }
-            });
-            Ok(DirectoryListing {
-                entries,
-                next_cursor,
-            })
+            Ok(directory_listing(page, has_more))
         })
         .await
         .map_err(|error| error.to_string())?;
@@ -4440,29 +4467,9 @@ async fn list_directory(
             is_directory: file_type.is_dir(),
             is_symlink: file_type.is_symlink(),
         };
-        let key = directory_key(&entry.name, &entry.path, entry.is_directory);
-        if after.as_ref().is_some_and(|after| key <= *after) {
-            continue;
-        }
-        page.insert(key, entry);
-        if page.len() > DIRECTORY_PAGE_SIZE {
-            page.pop_last();
-            has_more = true;
-        }
+        page_directory_entry(&mut page, &mut has_more, &after, entry);
     }
-    let entries = page.into_values().collect::<Vec<_>>();
-    let next_cursor = has_more.then(|| {
-        let entry = entries.last().expect("a truncated page is not empty");
-        DirectoryCursor {
-            name: entry.name.clone(),
-            path: entry.path.clone(),
-            is_directory: entry.is_directory,
-        }
-    });
-    Ok(DirectoryListing {
-        entries,
-        next_cursor,
-    })
+    Ok(directory_listing(page, has_more))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,11 +39,18 @@ const MAX_GIT_CHANGES: usize = 500;
 const MAX_GIT_DIFF_BYTES: u64 = 1_000_000;
 const MAX_SSH_OUTPUT_BYTES: u64 = 2_000_000;
 const SSH_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const SSH_GIT_BASE: &str = "if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi;";
 const MISSING_DIRECTORY: &str = "The selected folder no longer exists";
 const CODEX_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 // Requests stay bounded so an app server that never answers surfaces an error instead of a stuck tab.
 const CODEX_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 const DEEPSEEK_MODEL: &str = "deepseek-v4-flash";
+const CODEX_NOTIFICATION_ARGS: [&str; 4] = [
+    "-c",
+    r#"tui.notification_method="osc9""#,
+    "-c",
+    r#"tui.notification_condition="always""#,
+];
 const SUPPORTED_KEYS: [&str; 6] = [
     "claude",
     "codex",
@@ -593,6 +600,29 @@ struct GitStatus {
     changes_truncated: bool,
 }
 
+fn git_status_result(
+    worktree: String,
+    branch: String,
+    mut changes: Vec<GitChange>,
+    mut line_diffs: BTreeMap<String, LineDiff>,
+    changes_truncated: bool,
+    scope: &Path,
+) -> GitStatus {
+    changes.retain(|change| Path::new(&change.path).starts_with(scope));
+    line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
+    GitStatus {
+        branch: if branch.is_empty() {
+            "Detached HEAD".into()
+        } else {
+            branch
+        },
+        worktree,
+        changes,
+        line_diffs,
+        changes_truncated,
+    }
+}
+
 #[derive(Serialize)]
 struct GitChange {
     status: String,
@@ -677,7 +707,7 @@ fn ssh_command(host: &str) -> Result<Command, String> {
     }
     let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
     let mut command = Command::new(ssh);
-    command.args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "--", host]);
+    command.args(["-o", "ConnectTimeout=10"]);
     Ok(command)
 }
 
@@ -688,15 +718,26 @@ fn ssh_script(script: &str) -> String {
 fn ssh_stream(
     root: &SshRoot,
     script: &str,
+    input: Option<&[u8]>,
     mut receive: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<(), String> {
-    let mut child = ssh_command(&root.host)?
+    let mut command = ssh_command(&root.host)?;
+    command
+        .args(["-o", "BatchMode=yes", "--", &root.host])
         .arg(ssh_script(script))
-        .stdin(Stdio::null())
+        .stdin(if input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| error.to_string())?;
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(|error| error.to_string())?;
+    let write = input.map(|input| {
+        let mut stdin = child.stdin.take().expect("SSH input requested a pipe");
+        let input = input.to_vec();
+        thread::spawn(move || stdin.write_all(&input).map_err(|error| error.to_string()))
+    });
     let mut stdout = child.stdout.take().ok_or("Could not read SSH output")?;
     let mut stderr = child.stderr.take().ok_or("Could not read SSH errors")?;
     let (sender, receiver) = std::sync::mpsc::sync_channel(1);
@@ -769,9 +810,18 @@ fn ssh_stream(
     }
     drop(receiver);
     let _ = output.join();
+    let write = write.map(|write| {
+        write
+            .join()
+            .map_err(|_| "Could not write to SSH".to_owned())
+            .and_then(|result| result)
+    });
     let errors = errors.join().unwrap_or_default();
     let status = status?;
     if status.success() {
+        if let Some(write) = write {
+            write?;
+        }
         Ok(())
     } else {
         let detail = String::from_utf8_lossy(&errors).trim().to_owned();
@@ -785,7 +835,7 @@ fn ssh_stream(
 
 fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
     let mut output = Vec::new();
-    ssh_stream(root, script, |chunk| {
+    ssh_stream(root, script, None, |chunk| {
         if output.len() + chunk.len() > MAX_SSH_OUTPUT_BYTES as usize {
             return Err("SSH output is too large; inspect it in the terminal".into());
         }
@@ -799,67 +849,6 @@ fn ssh_text(root: &SshRoot, script: &str) -> Result<String, String> {
     String::from_utf8(ssh_output(root, script)?)
         .map(|output| output.strip_suffix('\n').unwrap_or(&output).to_owned())
         .map_err(|_| "SSH command returned non-UTF-8 text".into())
-}
-
-fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
-    let mut child = ssh_command(&root.host)?
-        .arg(ssh_script(script))
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| error.to_string())?;
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| "Could not write to SSH".to_owned())?;
-    let input = input.to_vec();
-    let write = thread::spawn(move || {
-        let mut stdin = stdin;
-        stdin.write_all(&input).map_err(|error| error.to_string())
-    });
-    let stderr = child.stderr.take().ok_or("Could not read SSH errors")?;
-    let errors = thread::spawn(move || {
-        let mut output = Vec::new();
-        let _ = stderr.take(16_385).read_to_end(&mut output);
-        output
-    });
-    let started = Instant::now();
-    let status = loop {
-        if started.elapsed() >= SSH_COMMAND_TIMEOUT {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = write.join();
-            let _ = errors.join();
-            return Err("SSH command timed out after 30 seconds".into());
-        }
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {}
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = write.join();
-                let _ = errors.join();
-                return Err(error.to_string());
-            }
-        }
-        thread::sleep(Duration::from_millis(25));
-    };
-    let write = write
-        .join()
-        .map_err(|_| "Could not write to SSH".to_owned());
-    let errors = errors.join().unwrap_or_default();
-    if !status.success() {
-        let detail = String::from_utf8_lossy(&errors).trim().to_owned();
-        return Err(if detail.is_empty() {
-            format!("SSH command exited with {status}")
-        } else {
-            detail
-        });
-    }
-    write??;
-    Ok(())
 }
 
 fn remote_path(root: &SshRoot, path: &str) -> Result<String, String> {
@@ -883,16 +872,20 @@ fn remote_path(root: &SshRoot, path: &str) -> Result<String, String> {
     }
 }
 
+fn ssh_scope_guard(root: &str, variable: &str, message: &str) -> String {
+    if root == "/" {
+        return String::new();
+    }
+    let root = posix_quote(root.trim_end_matches('/'));
+    format!(
+        "case \"${variable}\" in {root}|{root}/*) ;; *) printf '%s\\n' {} >&2; exit 1;; esac; ",
+        posix_quote(message)
+    )
+}
+
 fn scoped_ssh_script(root: &SshRoot, path: &str, command: &str) -> Result<String, String> {
     let path = remote_path(root, path)?;
-    let scope = if root.path == "/" {
-        String::new()
-    } else {
-        let root = posix_quote(root.path.trim_end_matches('/'));
-        format!(
-            "case \"$path\" in {root}|{root}/*) ;; *) printf '%s\\n' 'Path is outside the selected folder' >&2; exit 1;; esac; "
-        )
-    };
+    let scope = ssh_scope_guard(&root.path, "path", "Path is outside the selected folder");
     Ok(format!(
         "path=$(realpath -- {}) || exit; {scope}{command}",
         posix_quote(&path)
@@ -1208,9 +1201,11 @@ fn load_provider_sessions(app: &AppHandle) -> ProviderSessions {
 
 fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<String>, String> {
     let cwd = serde_json::to_string(&root.path).map_err(|error| error.to_string())?;
+    let home_agent = agent.strip_suffix("-current").unwrap_or(agent);
+    let (variable, fallback) = provider_home_parts(home_agent).ok_or("Unknown session type")?;
     let script = match agent {
         "codex" => format!(
-            "home=${{CODEX_HOME:-$HOME/.codex}}; test -d \"$home/sessions\" || exit 0; find \"$home/sessions\" -type f -name 'rollout-*.jsonl' -exec sh -c 'pattern=$1; shift; for file do IFS= read -r line < \"$file\"; case $line in *\"$pattern\"*) printf \"%s\\n\" \"$file\";; esac; done' sh {} {{}} + | sed -n {}",
+            "home=${{{variable}:-$HOME/{fallback}}}; test -d \"$home/sessions\" || exit 0; find \"$home/sessions\" -type f -name 'rollout-*.jsonl' -exec sh -c 'pattern=$1; shift; for file do IFS= read -r line < \"$file\"; case $line in *\"$pattern\"*) printf \"%s\\n\" \"$file\";; esac; done' sh {} {{}} + | sed -n {}",
             posix_quote(&cwd),
             posix_quote(r"s/.*-\([0-9a-fA-F-]\{36\}\)\.jsonl$/\1/p"),
         ),
@@ -1221,7 +1216,7 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
                 "-printf '%f\\n'"
             };
             format!(
-                "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g; s/\"root\"[[:space:]]*:[[:space:]]*/\"root\":/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
+                "home=${{{variable}:-$HOME/{fallback}}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g; s/\"root\"[[:space:]]*:[[:space:]]*/\"root\":/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
                 posix_quote(&format!("\"root\":{cwd}")),
                 posix_quote(r#"s/.*"\(wd_[^"]*\)"[[:space:]]*:[[:space:]]*{.*/\1/p"#),
             )
@@ -1239,13 +1234,14 @@ fn ssh_native_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bo
     if !is_provider_session_id(id) {
         return Ok(false);
     }
+    let (variable, fallback) = provider_home_parts(agent).ok_or("Unknown session type")?;
     let script = match agent {
         "claude" => format!(
-            "home=${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}; find \"$home/projects\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/projects\" -type f -name {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
             posix_quote(&format!("{id}.jsonl")),
         ),
         "gemini" => format!(
-            "home=${{GEMINI_CLI_HOME:-$HOME/.gemini}}; find \"$home/tmp\" -type f -path {} -exec grep -m 1 -F -q -- {} {{}} \\; -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/tmp\" -type f -path {} -exec grep -m 1 -F -q -- {} {{}} \\; -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
             posix_quote(&format!(
                 "*/chats/*-{}.jsonl",
                 id.chars().take(8).collect::<String>()
@@ -1253,7 +1249,7 @@ fn ssh_native_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bo
             posix_quote(&serde_json::to_string(id).map_err(|error| error.to_string())?),
         ),
         "qwen" => format!(
-            "home=${{QWEN_HOME:-$HOME/.qwen}}; find \"$home/projects\" -type f -path {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/projects\" -type f -path {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
             posix_quote(&format!("*/chats/{id}.jsonl")),
         ),
         _ => return Ok(false),
@@ -1376,6 +1372,40 @@ fn grant_directory(
     })
 }
 
+async fn grant_ssh_directory(
+    app: &AppHandle,
+    roots: &Roots,
+    host: String,
+    script: String,
+    root_id: Option<String>,
+) -> Result<DirectoryGrant, String> {
+    let probe = SshRoot {
+        host: host.clone(),
+        path: String::new(),
+    };
+    let path = tauri::async_runtime::spawn_blocking(move || ssh_text(&probe, &script))
+        .await
+        .map_err(|error| error.to_string())??;
+    if !path.starts_with('/') {
+        return Err("The SSH server did not return an absolute folder path".into());
+    }
+    let id = root_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    update_roots(app, roots, |roots| {
+        roots.insert(
+            id.clone(),
+            WorkspaceRoot::Ssh(SshRoot {
+                host: host.clone(),
+                path: path.clone(),
+            }),
+        );
+    })?;
+    Ok(DirectoryGrant {
+        id,
+        path,
+        host: Some(host),
+    })
+}
+
 fn default_directory_path(app: &AppHandle) -> Option<PathBuf> {
     let path = last_directory_path(app)
         .and_then(|path| fs::read_to_string(path).map_err(|error| error.to_string()))
@@ -1412,7 +1442,19 @@ fn shell_quote(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\\\""))
 }
 
-fn provider_home(app: &AppHandle, variable: &str, fallback: &str) -> Result<PathBuf, String> {
+fn provider_home_parts(agent: &str) -> Option<(&'static str, &'static str)> {
+    match agent {
+        "claude" => Some(("CLAUDE_CONFIG_DIR", ".claude")),
+        "codex" => Some(("CODEX_HOME", ".codex")),
+        "gemini" => Some(("GEMINI_CLI_HOME", ".gemini")),
+        "kimi" => Some(("KIMI_CODE_HOME", ".kimi-code")),
+        "qwen" => Some(("QWEN_HOME", ".qwen")),
+        _ => None,
+    }
+}
+
+fn provider_home(app: &AppHandle, agent: &str) -> Result<PathBuf, String> {
+    let (variable, fallback) = provider_home_parts(agent).ok_or("Unknown session type")?;
     std::env::var_os(variable)
         .filter(|home| !home.is_empty())
         .map(PathBuf::from)
@@ -1459,7 +1501,7 @@ fn claude_transcript_has_messages(path: &Path) -> bool {
 // the conversation it moved to. Returns the id to launch and whether it names one to resume.
 fn claude_launch_id(app: &AppHandle, session_id: &str) -> (String, bool) {
     let transcript = format!("{session_id}.jsonl");
-    let Some(project) = provider_home(app, "CLAUDE_CONFIG_DIR", ".claude")
+    let Some(project) = provider_home(app, "claude")
         .ok()
         .and_then(|home| fs::read_dir(home.join("projects")).ok())
         .and_then(|projects| {
@@ -1701,34 +1743,14 @@ async fn use_ssh_directory(
     } else {
         posix_quote(path)
     };
-    let probe = SshRoot {
-        host: host.clone(),
-        path: String::new(),
-    };
-    let resolved = tauri::async_runtime::spawn_blocking(move || {
-        ssh_text(
-            &probe,
-            &format!("mkdir -p -- {requested} && cd {requested} && pwd -P"),
-        )
-    })
+    grant_ssh_directory(
+        &app,
+        &roots,
+        host,
+        format!("mkdir -p -- {requested} && cd {requested} && pwd -P"),
+        None,
+    )
     .await
-    .map_err(|error| error.to_string())??;
-    if !resolved.starts_with('/') {
-        return Err("The SSH server did not return an absolute folder path".into());
-    }
-    let id = uuid::Uuid::new_v4().to_string();
-    let root = SshRoot {
-        host: host.clone(),
-        path: resolved.clone(),
-    };
-    update_roots(&app, &roots, |roots| {
-        roots.insert(id.clone(), WorkspaceRoot::Ssh(root));
-    })?;
-    Ok(DirectoryGrant {
-        id,
-        path: resolved,
-        host: Some(host),
-    })
 }
 
 #[tauri::command]
@@ -1739,31 +1761,14 @@ async fn follow_directory(
     path: String,
 ) -> Result<DirectoryGrant, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
-        let probe = root.clone();
-        let requested = posix_quote(&path);
-        let path = tauri::async_runtime::spawn_blocking(move || {
-            ssh_text(&probe, &format!("realpath -- {requested}"))
-        })
-        .await
-        .map_err(|error| error.to_string())??;
-        if !path.starts_with('/') {
-            return Err("The SSH server did not return an absolute folder path".into());
-        }
-        let host = root.host;
-        update_roots(&app, &roots, |roots| {
-            roots.insert(
-                root_id.clone(),
-                WorkspaceRoot::Ssh(SshRoot {
-                    host: host.clone(),
-                    path: path.clone(),
-                }),
-            );
-        })?;
-        return Ok(DirectoryGrant {
-            id: root_id,
-            path,
-            host: Some(host),
-        });
+        return grant_ssh_directory(
+            &app,
+            &roots,
+            root.host,
+            format!("realpath -- {}", posix_quote(&path)),
+            Some(root_id),
+        )
+        .await;
     }
     root_path(&roots, &root_id)?;
     grant_directory(&app, &roots, PathBuf::from(path), Some(root_id))
@@ -2968,17 +2973,14 @@ fn session_arguments(
     }
 }
 
-fn login_arguments(agent: &str) -> Result<Vec<String>, String> {
-    match agent {
-        "claude" => Ok(vec!["auth".into(), "login".into()]),
-        "codex" | "kimi" => Ok(vec!["login".into()]),
-        "gemini" | "qwen" => Ok(Vec::new()),
-        _ => Err("This provider signs in with an API key".into()),
-    }
+fn codex_resume_arguments(provider_session_id: Option<&str>) -> Vec<String> {
+    provider_session_id
+        .map(|id| vec!["resume".into(), id.into()])
+        .unwrap_or_default()
 }
 
 fn codex_home(app: &AppHandle) -> Result<PathBuf, String> {
-    provider_home(app, "CODEX_HOME", ".codex")
+    provider_home(app, "codex")
 }
 
 // Whether Codex's own configuration states something, asked line by line so the file is never parsed
@@ -3014,11 +3016,11 @@ fn codex_profile_exists(app: &AppHandle, provider: &str) -> bool {
 }
 
 fn gemini_home(app: &AppHandle) -> Result<PathBuf, String> {
-    provider_home(app, "GEMINI_CLI_HOME", ".gemini")
+    provider_home(app, "gemini")
 }
 
 fn qwen_home(app: &AppHandle) -> Result<PathBuf, String> {
-    provider_home(app, "QWEN_HOME", ".qwen")
+    provider_home(app, "qwen")
 }
 
 fn native_session_path(app: &AppHandle, agent: &str, session_id: &str) -> Option<PathBuf> {
@@ -3072,7 +3074,7 @@ fn native_session_path(app: &AppHandle, agent: &str, session_id: &str) -> Option
 }
 
 fn kimi_home(app: &AppHandle) -> Result<PathBuf, String> {
-    provider_home(app, "KIMI_CODE_HOME", ".kimi-code")
+    provider_home(app, "kimi")
 }
 
 fn kimi_context(app: &AppHandle, session_id: &str) -> Option<UsageSnapshot> {
@@ -3213,8 +3215,7 @@ fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<Command
             let mut command = agent_builder(agent)?;
             // Codex otherwise suppresses notifications while its terminal is focused and its automatic
             // method falls back to BEL for Lite's generic TERM. Keep the override local to this launch.
-            command.args(["-c", r#"tui.notification_method="osc9""#]);
-            command.args(["-c", r#"tui.notification_condition="always""#]);
+            command.args(CODEX_NOTIFICATION_ARGS);
             // Providers are selected per launch so the user's default Codex provider stays untouched.
             if let Some(provider) = codex_provider(provider) {
                 let key = saved_api_key(app, agent, Some(provider.id)).is_some();
@@ -3284,9 +3285,7 @@ fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<Command
                     ]);
                 }
             }
-            if let Some(provider_session_id) = provider_session_id {
-                command.args(["resume", provider_session_id]);
-            }
+            command.args(codex_resume_arguments(provider_session_id));
             command
         }
         "shell" => {
@@ -3317,7 +3316,12 @@ fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<Command
 // Each CLI owns its sign-in and opens the browser itself, so Lite only runs the command and shows it.
 fn login_command(agent: &str) -> Result<CommandBuilder, String> {
     let mut command = agent_builder(agent)?;
-    command.args(login_arguments(agent)?);
+    command.args(match agent {
+        "claude" => vec!["auth", "login"],
+        "codex" | "kimi" => vec!["login"],
+        "gemini" | "qwen" => Vec::new(),
+        _ => return Err("This provider signs in with an API key".into()),
+    });
     if let Some(path) = user_path() {
         command.env("PATH", path);
     }
@@ -3645,44 +3649,6 @@ fn configure_session_command(
     );
 }
 
-fn ssh_agent_args(launch: &SessionCommand<'_>) -> Result<Vec<String>, String> {
-    let agent = launch.agent;
-    let provider = launch.provider;
-    let resume = launch.resume;
-    let session_id = launch.session_id;
-    let provider_session_id = launch.provider_session_id;
-    let executable = agent_executable(agent).ok_or("Unknown session type")?;
-    let mut args = vec![executable.to_owned()];
-    if agent != "codex" {
-        args.extend(session_arguments(
-            agent,
-            resume,
-            session_id,
-            provider_session_id,
-        )?);
-        if agent == "claude" {
-            args.extend([
-                "--settings".into(),
-                r#"{"preferredNotifChannel":"iterm2"}"#.into(),
-            ]);
-        }
-        return Ok(args);
-    }
-    args.extend([
-        "-c".into(),
-        r#"tui.notification_method="osc9""#.into(),
-        "-c".into(),
-        r#"tui.notification_condition="always""#.into(),
-    ]);
-    if codex_provider(provider).is_some() {
-        return Err("Lite-managed Codex providers are available in local workspaces only".into());
-    }
-    if let Some(id) = provider_session_id {
-        args.extend(["resume".into(), id.into()]);
-    }
-    Ok(args)
-}
-
 fn ssh_session_command(
     root: &SshRoot,
     launch: &SessionCommand<'_>,
@@ -3694,11 +3660,32 @@ fn ssh_session_command(
             posix_quote(&root.path)
         ))
     } else {
-        let mut args = ssh_agent_args(launch)?;
-        if launch.agent == "claude"
-            && let Some(prompt) = initial_prompt
-        {
-            args.push(prompt.into());
+        let executable = agent_executable(launch.agent).ok_or("Unknown session type")?;
+        let mut args = vec![executable.to_owned()];
+        if launch.agent == "codex" {
+            if codex_provider(launch.provider).is_some() {
+                return Err(
+                    "Lite-managed Codex providers are available in local workspaces only".into(),
+                );
+            }
+            args.extend(CODEX_NOTIFICATION_ARGS.map(str::to_owned));
+            args.extend(codex_resume_arguments(launch.provider_session_id));
+        } else {
+            args.extend(session_arguments(
+                launch.agent,
+                launch.resume,
+                launch.session_id,
+                launch.provider_session_id,
+            )?);
+            if launch.agent == "claude" {
+                args.extend([
+                    "--settings".into(),
+                    r#"{"preferredNotifChannel":"iterm2"}"#.into(),
+                ]);
+                if let Some(prompt) = initial_prompt {
+                    args.push(prompt.into());
+                }
+            }
         }
         let command = args
             .iter()
@@ -3711,9 +3698,12 @@ fn ssh_session_command(
             posix_quote(&format!("exec {command}"))
         ))
     };
-    let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
-    let mut builder = CommandBuilder::new(ssh);
-    builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);
+    let command = ssh_command(&root.host)?;
+    let argv = std::iter::once(command.get_program().to_os_string())
+        .chain(command.get_args().map(ToOwned::to_owned))
+        .collect();
+    let mut builder = CommandBuilder::from_argv(argv);
+    builder.args(["-tt", "--", &root.host, &remote]);
     Ok(builder)
 }
 
@@ -3749,35 +3739,35 @@ async fn spawn_session(
         .get(&root_id)
         .cloned();
     let root_exists = root.is_some();
-    let mut ssh = match root {
-        Some(WorkspaceRoot::Ssh(root)) => Some(root),
-        _ => None,
-    };
-    match (ssh.as_ref(), host.as_deref(), root_exists) {
-        (Some(root), Some(host), _) if root.host == host => {}
-        (None, None, _) => {}
-        (None, Some(host), false) if cwd.starts_with('/') => {
-            uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
-            let _ = ssh_command(host)?;
-            let root = SshRoot {
-                host: host.to_owned(),
-                path: cwd.clone(),
-            };
-            update_roots(&app, &roots, |roots| {
-                roots.insert(root_id.clone(), WorkspaceRoot::Ssh(root.clone()));
-            })?;
-            ssh = Some(root);
-        }
+    let mut ssh = match (root, host.as_deref()) {
+        (Some(WorkspaceRoot::Ssh(root)), Some(host)) if root.host == host => Some(root),
+        (Some(WorkspaceRoot::Local(_)), None) | (None, _) => None,
         _ => return Err("The remote workspace permission is no longer available".into()),
-    }
-    if ssh.is_none() && !root_exists {
+    };
+    if !root_exists {
         uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
-        let path = fs::canonicalize(&cwd).map_err(|_| MISSING_DIRECTORY)?;
-        update_roots(&app, &roots, |roots| {
-            roots
-                .entry(root_id.clone())
-                .or_insert(WorkspaceRoot::Local(path));
-        })?;
+        if let Some(host) = host {
+            if !cwd.starts_with('/') {
+                return Err("The remote workspace permission is no longer available".into());
+            }
+            let grant = grant_ssh_directory(
+                &app,
+                &roots,
+                host,
+                format!("realpath -- {}", posix_quote(&cwd)),
+                Some(root_id.clone()),
+            )
+            .await?;
+            ssh = Some(SshRoot {
+                host: grant.host.expect("SSH grants have a host"),
+                path: grant.path,
+            });
+        } else {
+            let path = fs::canonicalize(&cwd).map_err(|_| MISSING_DIRECTORY)?;
+            update_roots(&app, &roots, |roots| {
+                roots.insert(root_id.clone(), WorkspaceRoot::Local(path));
+            })?;
+        }
     }
     let cwd = if let Some(root) = ssh.as_ref() {
         PathBuf::from(&root.path)
@@ -3874,30 +3864,27 @@ async fn spawn_session(
         stop_pty(&mut session)?;
     }
 
-    let ssh_known_sessions = if (agent == "codex" || agent == "kimi")
+    let remote_sessions = if (agent == "codex" || agent == "kimi")
         && let Some(root) = ssh.clone()
     {
         let discovery_agent = agent.clone();
-        let sessions = tauri::async_runtime::spawn_blocking(move || {
+        tauri::async_runtime::spawn_blocking(move || {
             ssh_provider_session_ids(&root, &discovery_agent)
         })
-        .await;
-        match sessions {
-            Ok(Ok(sessions)) => {
-                if provider_session_id
-                    .as_ref()
-                    .is_some_and(|known| !sessions.contains(known))
-                {
-                    update_provider_session(&app, &provider_sessions, &session_id, None)?;
-                    provider_session_id = None;
-                }
-                provider_session_id.is_none().then_some(sessions)
-            }
-            _ => (agent == "kimi" && provider_session_id.is_none()).then(HashSet::new),
-        }
+        .await
+        .ok()
+        .and_then(Result::ok)
     } else {
         None
     };
+    if let Some(sessions) = remote_sessions.as_ref()
+        && provider_session_id
+            .as_ref()
+            .is_some_and(|known| !sessions.contains(known))
+    {
+        update_provider_session(&app, &provider_sessions, &session_id, None)?;
+        provider_session_id = None;
+    }
 
     let output = Arc::new(Mutex::new(output));
     let alive = Arc::new(AtomicBool::new(true));
@@ -3960,22 +3947,19 @@ async fn spawn_session(
     );
     // Codex records a new thread per launch, so its discovery watches for one the tab did not start with.
     // Kimi attaches to the directory's session instead, so its discovery reads that session directly.
-    let known_sessions = if let Some(existing) = ssh_known_sessions {
-        Some(existing)
-    } else if ssh.is_none()
-        && !signing_in
-        && provider_session_id.is_none()
-        && (agent == "codex" || agent == "kimi")
-    {
-        if agent == "kimi" {
-            Some(HashSet::new())
+    let known_sessions =
+        if !signing_in && provider_session_id.is_none() && (agent == "codex" || agent == "kimi") {
+            if agent == "kimi" {
+                Some(HashSet::new())
+            } else if ssh.is_some() {
+                remote_sessions
+            } else {
+                // Losing discovery costs exact resume, not the session, so a failure still opens the terminal.
+                codex_thread_ids(&codex_server, &cwd).ok()
+            }
         } else {
-            // Losing discovery costs exact resume, not the session, so a failure still opens the terminal.
-            codex_thread_ids(&codex_server, &cwd).ok()
-        }
-    } else {
-        None
-    };
+            None
+        };
     let mut child = match pair.slave.spawn_command(command) {
         Ok(child) => child,
         Err(error) => {
@@ -4088,27 +4072,26 @@ async fn spawn_session(
             // less and less often rather than every second for as long as it stays open.
             let mut wait = Duration::from_secs(1);
             loop {
-                let candidates = if let Some(root) = discovery_ssh.as_ref() {
+                let current = if let Some(root) = discovery_ssh.as_ref() {
                     let remote_agent = if discovery_agent == "kimi" {
                         "kimi-current"
                     } else {
                         discovery_agent.as_str()
                     };
-                    ssh_provider_session_ids(root, remote_agent).map(|current| {
-                        if discovery_agent == "kimi" {
-                            current
-                        } else {
-                            current.difference(&existing).cloned().collect()
-                        }
-                    })
+                    ssh_provider_session_ids(root, remote_agent)
                 } else if discovery_agent == "kimi" {
                     Ok(kimi_current_session(&discovery_app, &cwd)
                         .into_iter()
                         .collect::<HashSet<_>>())
                 } else {
                     codex_thread_ids(&discovery_app.state::<CodexServer>(), &cwd)
-                        .map(|current| current.difference(&existing).cloned().collect())
                 };
+                let candidates = current.map(|current| {
+                    current
+                        .difference(&existing)
+                        .cloned()
+                        .collect::<HashSet<_>>()
+                });
                 // Whatever another tab already claimed is skipped, so overlapping launches settle apart.
                 if let Ok(candidates) = candidates
                     && candidates.iter().any(|provider_session_id| {
@@ -4391,6 +4374,7 @@ async fn list_directory(
                     &path,
                     "find \"$path\" -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
                 )?,
+                None,
                 |chunk| {
                     pending.extend_from_slice(chunk);
                     let mut consumed = 0;
@@ -4457,34 +4441,31 @@ async fn read_text_file(
     root_id: String,
     path: String,
 ) -> Result<String, String> {
-    if let Some(root) = ssh_root(&roots, &root_id)? {
-        return tauri::async_runtime::spawn_blocking(move || {
-            let bytes = ssh_output(
+    let bytes = if let Some(root) = ssh_root(&roots, &root_id)? {
+        tauri::async_runtime::spawn_blocking(move || {
+            ssh_output(
                 &root,
                 &scoped_ssh_script(
                     &root,
                     &path,
                     &format!("head -c {} -- \"$path\"", MAX_FILE_BYTES + 1),
                 )?,
-            )?;
-            if bytes.len() > MAX_FILE_BYTES as usize {
-                return Err("File is larger than 500 KB".into());
-            }
-            if bytes.contains(&0) {
-                return Err("Binary files cannot be previewed".into());
-            }
-            String::from_utf8(bytes).map_err(|_| "File is not UTF-8 text".into())
+            )
         })
         .await
-        .map_err(|error| error.to_string())?;
-    }
-    let root = root_path(&roots, &root_id)?;
-    let path = scoped_path(&root, &path)?;
-    let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
-    if metadata.len() > MAX_FILE_BYTES {
+        .map_err(|error| error.to_string())??
+    } else {
+        let root = root_path(&roots, &root_id)?;
+        let path = scoped_path(&root, &path)?;
+        let mut bytes = Vec::new();
+        fs::File::open(path)
+            .and_then(|file| file.take(MAX_FILE_BYTES + 1).read_to_end(&mut bytes))
+            .map_err(|error| error.to_string())?;
+        bytes
+    };
+    if bytes.len() > MAX_FILE_BYTES as usize {
         return Err("File is larger than 500 KB".into());
     }
-    let bytes = fs::read(path).map_err(|error| error.to_string())?;
     if bytes.contains(&0) {
         return Err("Binary files cannot be previewed".into());
     }
@@ -4508,7 +4489,7 @@ async fn write_text_file(
                 &path,
                 "set -e; test -f \"$path\"; parent=${path%/*}; test -n \"$parent\" || parent=/; tmp=$(mktemp \"$parent\"/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference=\"$path\" \"$tmp\"; mv -- \"$tmp\" \"$path\"; trap - EXIT",
             )?;
-            ssh_input(&root, &script, contents.as_bytes())
+            ssh_stream(&root, &script, Some(contents.as_bytes()), |_| Ok(()))
         })
         .await
         .map_err(|error| error.to_string())?;
@@ -4609,21 +4590,7 @@ fn git_line_diffs(output: &[u8]) -> BTreeMap<String, LineDiff> {
         .collect()
 }
 
-fn bounded_git_changes(
-    git: &Path,
-    path: &Path,
-    args: &[&str],
-) -> Result<(Vec<GitChange>, bool), String> {
-    let mut child = Command::new(git)
-        .arg("-C")
-        .arg(path_text(path))
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|error| error.to_string())?;
-    let stdout = child.stdout.take().ok_or("Could not read Git status")?;
-    let mut reader = BufReader::new(stdout);
+fn parse_git_changes(mut reader: impl BufRead) -> Result<(Vec<GitChange>, bool), String> {
     let mut changes = Vec::new();
     loop {
         let mut record = Vec::new();
@@ -4635,15 +4602,7 @@ fn bounded_git_changes(
             break;
         }
         record.pop();
-        let change = match git_change(&record) {
-            Ok(change) => change,
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(error);
-            }
-        };
-        let Some(change) = change else {
+        let Some(change) = git_change(&record)? else {
             continue;
         };
         // Porcelain v1 -z puts a rename's destination first and its source in the next record.
@@ -4663,8 +4622,44 @@ fn bounded_git_changes(
         }
     }
     let truncated = changes.len() > MAX_GIT_CHANGES;
+    changes.truncate(MAX_GIT_CHANGES);
+    Ok((changes, truncated))
+}
+
+fn truncate_to_record(output: &mut Vec<u8>) {
+    if output.last() != Some(&0) {
+        output.truncate(
+            output
+                .iter()
+                .rposition(|byte| *byte == 0)
+                .map_or(0, |position| position + 1),
+        );
+    }
+}
+
+fn bounded_git_changes(
+    git: &Path,
+    path: &Path,
+    args: &[&str],
+) -> Result<(Vec<GitChange>, bool), String> {
+    let mut child = Command::new(git)
+        .arg("-C")
+        .arg(path_text(path))
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let stdout = child.stdout.take().ok_or("Could not read Git status")?;
+    let (changes, truncated) = match parse_git_changes(BufReader::new(stdout)) {
+        Ok(result) => result,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
     if truncated {
-        changes.truncate(MAX_GIT_CHANGES);
         let _ = child.kill();
     }
     let status = child.wait().map_err(|error| error.to_string())?;
@@ -4711,30 +4706,21 @@ fn bounded_git_output(
 
 fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
     let relative = Path::new(path);
-    if relative.is_absolute()
-        || relative
-            .components()
-            .any(|component| !matches!(component, Component::Normal(_)))
-    {
-        return Err("This change is outside the selected folder".into());
-    }
     let pathspec = path_text(relative);
-    let scope = if root.path == "/" {
-        String::new()
-    } else {
-        let boundary = posix_quote(root.path.trim_end_matches('/'));
-        format!(
-            "case \"$ancestor\" in {boundary}|{boundary}/*) ;; *) printf '%s\\n' 'This change is outside the selected folder; start a session from the repository root to view it' >&2; exit 1;; esac; "
-        )
-    };
+    let scope = ssh_scope_guard(
+        &root.path,
+        "ancestor",
+        "This change is outside the selected folder; start a session from the repository root to view it",
+    );
     let mut output = Vec::new();
     ssh_stream(
         root,
         &format!(
-            "root={}; pathspec={}; repository=$(git -C \"$root\" rev-parse --show-toplevel) || exit; file=\"${{repository%/}}/$pathspec\"; ancestor=\"$file\"; while ! test -e \"$ancestor\" && ! test -L \"$ancestor\"; do parent=${{ancestor%/*}}; ancestor=${{parent:-/}}; done; ancestor=$(realpath -- \"$ancestor\") || exit; {scope}if git -C \"$repository\" --literal-pathspecs ls-files --others --exclude-standard -- \"$pathspec\" | grep -q .; then git -C \"$repository\" diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null \"$file\" || test $? -eq 1; else if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --no-color \"$base\" -- \"$pathspec\"; fi",
+            "root={}; pathspec={}; repository=$(git -C \"$root\" rev-parse --show-toplevel) || exit; file=\"${{repository%/}}/$pathspec\"; ancestor=\"$file\"; while ! test -e \"$ancestor\" && ! test -L \"$ancestor\"; do parent=${{ancestor%/*}}; ancestor=${{parent:-/}}; done; ancestor=$(realpath -- \"$ancestor\") || exit; {scope}if git -C \"$repository\" --literal-pathspecs ls-files --others --exclude-standard -- \"$pathspec\" | grep -q .; then git -C \"$repository\" diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null \"$file\" || test $? -eq 1; else {SSH_GIT_BASE} git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --no-color \"$base\" -- \"$pathspec\"; fi",
             posix_quote(&root.path),
             posix_quote(&pathspec),
         ),
+        None,
         |chunk| {
             if output.len() + chunk.len() > MAX_GIT_DIFF_BYTES as usize {
                 return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
@@ -4747,19 +4733,20 @@ fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
 }
 
 fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
-    if command_output(git, repository, &["rev-parse", "--verify", "HEAD"]).is_ok() {
-        return Ok("HEAD".into());
-    }
-    command_output(
-        git,
-        repository,
-        &[
-            "hash-object",
-            "-t",
-            "tree",
-            if cfg!(windows) { "NUL" } else { "/dev/null" },
-        ],
-    )
+    command_output(git, repository, &["rev-parse", "--verify", "HEAD"])
+        .map(|_| "HEAD".into())
+        .or_else(|_| {
+            command_output(
+                git,
+                repository,
+                &[
+                    "hash-object",
+                    "-t",
+                    "tree",
+                    if cfg!(windows) { "NUL" } else { "/dev/null" },
+                ],
+            )
+        })
 }
 
 #[tauri::command]
@@ -4768,12 +4755,6 @@ async fn git_diff(
     root_id: String,
     path: String,
 ) -> Result<String, String> {
-    if let Some(root) = ssh_root(&roots, &root_id)? {
-        return tauri::async_runtime::spawn_blocking(move || ssh_git_diff(&root, &path))
-            .await
-            .map_err(|error| error.to_string())?;
-    }
-    let granted = root_path(&roots, &root_id)?;
     let relative = Path::new(&path);
     if relative.is_absolute()
         || relative
@@ -4785,6 +4766,12 @@ async fn git_diff(
                 .into(),
         );
     }
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        return tauri::async_runtime::spawn_blocking(move || ssh_git_diff(&root, &path))
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+    let granted = root_path(&roots, &root_id)?;
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
     let repository = fs::canonicalize(command_output(
         &git,
@@ -4873,7 +4860,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
             let output = ssh_output(
                 &root,
                 &format!(
-                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; code=$(mktemp) || exit; trap 'rm -f -- \"$code\"' EXIT; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; {{ git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\"; printf '%s' $? > \"$code\"; }} | head -z -n {} | head -c {status_limit}; result=$(cat \"$code\"); test \"$result\" = 0 || test \"$result\" = 141 || exit \"$result\"; printf '\\0%s\\0' {}; {{ git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\"; printf '%s' $? > \"$code\"; }} | head -c {MAX_GIT_DIFF_BYTES}; result=$(cat \"$code\"); test \"$result\" = 0 || test \"$result\" = 141 || exit \"$result\"; rm -f -- \"$code\"; trap - EXIT",
+                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; {SSH_GIT_BASE} code=$(mktemp) || exit; trap 'rm -f -- \"$code\"' EXIT; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; {{ git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\"; printf '%s' $? > \"$code\"; }} | head -z -n {} | head -c {status_limit}; result=$(cat \"$code\"); test \"$result\" = 0 || test \"$result\" = 141 || exit \"$result\"; printf '\\0%s\\0' {}; {{ git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\"; printf '%s' $? > \"$code\"; }} | head -c {MAX_GIT_DIFF_BYTES}; result=$(cat \"$code\"); test \"$result\" = 0 || test \"$result\" = 141 || exit \"$result\"; rm -f -- \"$code\"; trap - EXIT",
                     posix_quote(&root.path),
                     posix_quote(&marker),
                     MAX_GIT_CHANGES + 1,
@@ -4900,62 +4887,26 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                 .ok_or("Could not read remote Git status")?;
             let mut status = body[..split].to_vec();
             let byte_truncated = status.len() == status_limit;
-            if byte_truncated && !status.ends_with(&[0]) {
-                status.truncate(
-                    status
-                        .iter()
-                        .rposition(|byte| *byte == 0)
-                        .map_or(0, |position| position + 1),
-                );
+            if byte_truncated {
+                truncate_to_record(&mut status);
             }
-            let mut changes = Vec::new();
-            let mut records = status.split(|byte| *byte == 0);
-            while let Some(record) = records.next() {
-                let Some(change) = git_change(record)? else {
-                    continue;
-                };
-                if change
-                    .status
-                    .bytes()
-                    .any(|byte| matches!(byte, b'R' | b'C'))
-                {
-                    let _ = records.next();
-                }
-                changes.push(change);
-                if changes.len() > MAX_GIT_CHANGES {
-                    break;
-                }
-            }
-            let changes_truncated = byte_truncated || changes.len() > MAX_GIT_CHANGES;
-            changes.truncate(MAX_GIT_CHANGES);
+            let (changes, record_truncated) = parse_git_changes(std::io::Cursor::new(status))?;
+            let changes_truncated = byte_truncated || record_truncated;
             let scope = root
                 .path
                 .strip_prefix(&repository)
                 .ok_or("The selected folder is outside the Git repository")?
                 .trim_start_matches('/');
-            changes.retain(|change| Path::new(&change.path).starts_with(scope));
             let mut diffs = body[split + separator.len()..].to_vec();
-            if !diffs.is_empty() && !diffs.ends_with(&[0]) {
-                diffs.truncate(
-                    diffs
-                        .iter()
-                        .rposition(|byte| *byte == 0)
-                        .map_or(0, |end| end + 1),
-                );
-            }
-            let mut line_diffs = git_line_diffs(&diffs);
-            line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
-            Ok(Some(GitStatus {
-                branch: if branch.is_empty() {
-                    "Detached HEAD".into()
-                } else {
-                    branch
-                },
-                worktree: repository,
+            truncate_to_record(&mut diffs);
+            Ok(Some(git_status_result(
+                repository,
+                branch,
                 changes,
-                line_diffs,
+                git_line_diffs(&diffs),
                 changes_truncated,
-            }))
+                Path::new(scope),
+            )))
         })
         .await
         .map_err(|error| error.to_string())?;
@@ -4977,7 +4928,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         path_text(scope)
     };
     let branch = command_output(&git, &path, &["branch", "--show-current"])?;
-    let (mut changes, changes_truncated) = bounded_git_changes(
+    let (changes, changes_truncated) = bounded_git_changes(
         &git,
         &repository,
         &[
@@ -4991,9 +4942,8 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
             &scope_text,
         ],
     )?;
-    changes.retain(|change| Path::new(&change.path).starts_with(scope));
     let base = git_diff_base(&git, &repository)?;
-    let mut line_diffs = Command::new(&git)
+    let line_diffs = Command::new(&git)
         .arg("-C")
         .arg(path_text(&repository))
         .args([
@@ -5031,30 +4981,19 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
             } else if !child.wait().ok()?.success() {
                 return None;
             }
-            if output.last() != Some(&0) {
-                output.truncate(
-                    output
-                        .iter()
-                        .rposition(|byte| *byte == 0)
-                        .map_or(0, |i| i + 1),
-                );
-            }
+            truncate_to_record(&mut output);
             Some(output)
         })
         .map(|output| git_line_diffs(&output))
         .unwrap_or_default();
-    line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
-    Ok(Some(GitStatus {
-        branch: if branch.is_empty() {
-            "Detached HEAD".into()
-        } else {
-            branch
-        },
-        worktree: root,
+    Ok(Some(git_status_result(
+        root,
+        branch,
         changes,
         line_diffs,
         changes_truncated,
-    }))
+        scope,
+    )))
 }
 
 // A remote is stored the way the repository was cloned, and only its https form opens in a browser.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3635,6 +3635,7 @@ async fn spawn_session(
     run_id: String,
     root_id: String,
     cwd: String,
+    host: Option<String>,
     mut provider_session_id: Option<String>,
     agent: String,
     provider: Option<String>,
@@ -3648,6 +3649,11 @@ async fn spawn_session(
     rows: u16,
 ) -> Result<Option<String>, String> {
     let ssh = ssh_root(&roots, &root_id)?;
+    match (ssh.as_ref(), host.as_deref()) {
+        (Some(root), Some(host)) if root.host == host => {}
+        (None, None) => {}
+        _ => return Err("The remote workspace permission is no longer available".into()),
+    }
     if ssh.is_none()
         && !roots
             .0

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3197,8 +3197,10 @@ fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<Command
     let session_id = launch.session_id;
     let provider_session_id = launch.provider_session_id;
     let mut command = match agent {
-        "claude" => {
+        "claude" | "gemini" | "kimi" | "qwen" => {
             let mut command = agent_builder(agent)?;
+            // Kimi only resumes an exact id: `--continue` would make two tabs in one directory share
+            // its latest session and leave neither able to discover which session it is showing.
             command.args(session_arguments(
                 agent,
                 resume,
@@ -3285,29 +3287,6 @@ fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<Command
             if let Some(provider_session_id) = provider_session_id {
                 command.args(["resume", provider_session_id]);
             }
-            command
-        }
-        "gemini" => {
-            let mut command = agent_builder(agent)?;
-            command.args(session_arguments(agent, resume, session_id, None)?);
-            command
-        }
-        "kimi" => {
-            // Only an exact id resumes. `--continue` would reopen whatever ran last in the directory,
-            // which two tabs there would both land on, and it creates no entry for discovery to record,
-            // so the tab could never learn which session it is showing.
-            let mut command = agent_builder(agent)?;
-            command.args(session_arguments(
-                agent,
-                resume,
-                session_id,
-                provider_session_id,
-            )?);
-            command
-        }
-        "qwen" => {
-            let mut command = agent_builder(agent)?;
-            command.args(session_arguments(agent, resume, session_id, None)?);
             command
         }
         "shell" => {
@@ -3727,7 +3706,7 @@ fn ssh_session_command(
             .collect::<Vec<_>>()
             .join(" ");
         ssh_script(&format!(
-            "cd {} && exec ${{SHELL:-/bin/sh}} -lc {}",
+            "cd {} && exec \"${{SHELL:-/bin/sh}}\" -lc {}",
             posix_quote(&root.path),
             posix_quote(&format!("exec {command}"))
         ))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5202,9 +5202,14 @@ fn browse_url(remote: &str) -> Option<String> {
 // The repository a folder was cloned from, asked for on its own: naming it costs one git call, where
 // the full status reads the whole worktree.
 #[tauri::command]
-async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<String>, String> {
-    if let Some(root) = ssh_root(&roots, &root_id)? {
+async fn git_remote(
+    roots: State<'_, Roots>,
+    root_id: String,
+    directory: String,
+) -> Result<Option<String>, String> {
+    if let Some(mut root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
+            root.path = scoped_ssh_path(&root, &directory)?;
             Ok(
                 ssh_git_text(&root, &root.path, &["remote", "get-url", "origin"])
                     .ok()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1230,14 +1230,24 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
         .collect())
 }
 
-fn ssh_native_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bool, String> {
+enum RemoteSessionState {
+    Missing,
+    Marker,
+    Ready,
+}
+
+fn ssh_native_session_state(
+    root: &SshRoot,
+    agent: &str,
+    id: &str,
+) -> Result<RemoteSessionState, String> {
     if !is_provider_session_id(id) {
-        return Ok(false);
+        return Ok(RemoteSessionState::Missing);
     }
     let (variable, fallback) = provider_home_parts(agent).ok_or("Unknown session type")?;
     let script = match agent {
         "claude" => format!(
-            "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/projects\" -type f -name {} -exec grep -m 1 -E -q -- '\"type\"[[:space:]]*:[[:space:]]*\"(user|assistant|system)\"' {{}} \\; -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
+            "home=${{{variable}:-$HOME/{fallback}}}; file=$(find \"$home/projects\" -type f -name {} -print -quit 2>/dev/null); if test -z \"$file\"; then printf 0; elif grep -m 1 -E -q -- '\"type\"[[:space:]]*:[[:space:]]*\"(user|assistant|system)\"' \"$file\"; then printf 2; else printf 1; fi",
             posix_quote(&format!("{id}.jsonl")),
         ),
         "gemini" => format!(
@@ -1252,9 +1262,14 @@ fn ssh_native_session_exists(root: &SshRoot, agent: &str, id: &str) -> Result<bo
             "home=${{{variable}:-$HOME/{fallback}}}; find \"$home/projects\" -type f -path {} -print -quit 2>/dev/null | grep -q . && printf 1 || printf 0",
             posix_quote(&format!("*/chats/{id}.jsonl")),
         ),
-        _ => return Ok(false),
+        _ => return Ok(RemoteSessionState::Missing),
     };
-    Ok(ssh_text(root, &script)? == "1")
+    match ssh_text(root, &script)?.as_str() {
+        "0" => Ok(RemoteSessionState::Missing),
+        "1" if agent == "claude" => Ok(RemoteSessionState::Marker),
+        "1" | "2" => Ok(RemoteSessionState::Ready),
+        _ => Err("Could not inspect the remote session".into()),
+    }
 }
 
 fn load_codex_server(app: &AppHandle) -> Result<CodexServer, String> {
@@ -3796,12 +3811,26 @@ async fn spawn_session(
             .as_deref()
             .unwrap_or(&session_id)
             .to_owned();
-        if let Ok(Ok(exists)) = tauri::async_runtime::spawn_blocking(move || {
-            ssh_native_session_exists(&root, &remote_agent, &remote_id)
+        if let Ok(Ok(state)) = tauri::async_runtime::spawn_blocking(move || {
+            ssh_native_session_state(&root, &remote_agent, &remote_id)
         })
         .await
         {
-            resume = exists;
+            match state {
+                RemoteSessionState::Ready => {}
+                RemoteSessionState::Missing => resume = false,
+                RemoteSessionState::Marker => {
+                    resume = false;
+                    let fresh = uuid::Uuid::new_v4().to_string();
+                    update_provider_session(
+                        &app,
+                        &provider_sessions,
+                        &session_id,
+                        Some(fresh.clone()),
+                    )?;
+                    provider_session_id = Some(fresh);
+                }
+            }
         }
     }
     // The tab keeps the id it was given so the next launch reopens the same conversation, and a
@@ -3864,7 +3893,8 @@ async fn spawn_session(
         stop_pty(&mut session)?;
     }
 
-    let remote_sessions = if (agent == "codex" || agent == "kimi")
+    let remote_sessions = if (agent == "codex"
+        || (agent == "kimi" && provider_session_id.is_some()))
         && let Some(root) = ssh.clone()
     {
         let discovery_agent = agent.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4796,12 +4796,16 @@ fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
 async fn git_diff(
     roots: State<'_, Roots>,
     root_id: String,
+    directory: String,
     path: String,
 ) -> Result<String, String> {
-    if let Some(root) = ssh_root(&roots, &root_id)? {
-        return tauri::async_runtime::spawn_blocking(move || ssh_git_diff(&root, &path))
-            .await
-            .map_err(|error| error.to_string())?;
+    if let Some(mut root) = ssh_root(&roots, &root_id)? {
+        return tauri::async_runtime::spawn_blocking(move || {
+            root.path = scoped_ssh_path(&root, &directory)?;
+            ssh_git_diff(&root, &path)
+        })
+        .await
+        .map_err(|error| error.to_string())?;
     }
     let granted = root_path(&roots, &root_id)?;
     let relative = Path::new(&path);
@@ -4894,9 +4898,14 @@ async fn git_diff(
 }
 
 #[tauri::command]
-async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<GitStatus>, String> {
-    if let Some(root) = ssh_root(&roots, &root_id)? {
+async fn git_status(
+    roots: State<'_, Roots>,
+    root_id: String,
+    directory: String,
+) -> Result<Option<GitStatus>, String> {
+    if let Some(mut root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
+            root.path = scoped_ssh_path(&root, &directory)?;
             let repository =
                 match ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"]) {
                     Ok(repository) => repository,
@@ -4982,7 +4991,9 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                 &diff_command,
                 &format!("head -c {}", MAX_GIT_DIFF_BYTES),
             )?;
-            if !diffs.is_empty() && !diffs.ends_with(&[0]) {
+            if diffs.len() == MAX_GIT_DIFF_BYTES as usize {
+                diffs.clear();
+            } else if !diffs.is_empty() && !diffs.ends_with(&[0]) {
                 diffs.truncate(
                     diffs
                         .iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -698,35 +698,18 @@ fn ssh_stream(
     let started = Instant::now();
     let mut status = None;
     let mut output_open = true;
-    loop {
+    let status = loop {
         if started.elapsed() >= SSH_COMMAND_TIMEOUT {
-            let _ = child.kill();
-            let _ = child.wait();
-            drop(receiver);
-            let _ = output.join();
-            let _ = errors.join();
-            return Err("SSH command timed out after 30 seconds".into());
+            break Err("SSH command timed out after 30 seconds".into());
         }
         if output_open {
             match receiver.recv_timeout(Duration::from_millis(25)) {
                 Ok(Ok(chunk)) => {
                     if let Err(error) = receive(&chunk) {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        drop(receiver);
-                        let _ = output.join();
-                        let _ = errors.join();
-                        return Err(error);
+                        break Err(error);
                     }
                 }
-                Ok(Err(error)) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    drop(receiver);
-                    let _ = output.join();
-                    let _ = errors.join();
-                    return Err(error);
-                }
+                Ok(Err(error)) => break Err(error),
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => output_open = false,
             }
@@ -737,23 +720,21 @@ fn ssh_stream(
             match child.try_wait() {
                 Ok(Some(exit)) => status = Some(exit),
                 Ok(None) => {}
-                Err(error) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    drop(receiver);
-                    let _ = output.join();
-                    let _ = errors.join();
-                    return Err(error.to_string());
-                }
+                Err(error) => break Err(error.to_string()),
             }
         }
-        if !output_open && status.is_some() {
-            break;
+        if !output_open && let Some(status) = status {
+            break Ok(status);
         }
+    };
+    if status.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
     }
+    drop(receiver);
     let _ = output.join();
     let errors = errors.join().unwrap_or_default();
-    let status = status.expect("SSH status is set before the loop exits");
+    let status = status?;
     if status.success() {
         Ok(())
     } else {
@@ -3686,32 +3667,29 @@ fn ssh_session_command(
     launch: &SessionCommand<'_>,
     initial_prompt: Option<&str>,
 ) -> Result<CommandBuilder, String> {
-    if launch.agent == "shell" {
-        let remote = ssh_script(&format!(
+    let remote = if launch.agent == "shell" {
+        ssh_script(&format!(
             "cd {} && exec \"${{SHELL:-/bin/sh}}\" -l",
             posix_quote(&root.path)
-        ));
-        let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
-        let mut builder = CommandBuilder::new(ssh);
-        builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);
-        return Ok(builder);
-    }
-    let mut args = ssh_agent_args(launch)?;
-    if launch.agent == "claude"
-        && let Some(prompt) = initial_prompt
-    {
-        args.push(prompt.into());
-    }
-    let command = args
-        .iter()
-        .map(|argument| posix_quote(argument))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let remote = ssh_script(&format!(
-        "cd {} && exec ${{SHELL:-/bin/sh}} -lc {}",
-        posix_quote(&root.path),
-        posix_quote(&format!("exec {command}"))
-    ));
+        ))
+    } else {
+        let mut args = ssh_agent_args(launch)?;
+        if launch.agent == "claude"
+            && let Some(prompt) = initial_prompt
+        {
+            args.push(prompt.into());
+        }
+        let command = args
+            .iter()
+            .map(|argument| posix_quote(argument))
+            .collect::<Vec<_>>()
+            .join(" ");
+        ssh_script(&format!(
+            "cd {} && exec ${{SHELL:-/bin/sh}} -lc {}",
+            posix_quote(&root.path),
+            posix_quote(&format!("exec {command}"))
+        ))
+    };
     let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
     let mut builder = CommandBuilder::new(ssh);
     builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1204,9 +1204,9 @@ fn ssh_provider_session_ids(root: &SshRoot, agent: &str) -> Result<HashSet<Strin
                 "-printf '%f\\n'"
             };
             format!(
-                "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
+                "home=${{KIMI_CODE_HOME:-$HOME/.kimi-code}}; index=\"$home/workspaces.json\"; test -f \"$index\" || exit 0; workspace=$(tr -d '\\n' < \"$index\" | sed 's/}},[[:space:]]*\"/}}\\n\"/g; s/\"root\"[[:space:]]*:[[:space:]]*/\"root\":/g' | grep -F -- {} | sed -n {} | head -n 1); sessions=\"$home/sessions/$workspace\"; test -n \"$workspace\" && test -d \"$sessions\" || exit 0; find \"$sessions\" -mindepth 1 -maxdepth 1 -type d {newest}",
                 posix_quote(&format!("\"root\":{cwd}")),
-                posix_quote(r#"s/.*"\(wd_[^"]*\)":{.*/\1/p"#),
+                posix_quote(r#"s/.*"\(wd_[^"]*\)"[[:space:]]*:[[:space:]]*{.*/\1/p"#),
             )
         }
         _ => return Ok(HashSet::new()),
@@ -4791,18 +4791,22 @@ fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
             "case \"$ancestor\" in {boundary}|{boundary}/*) ;; *) printf '%s\\n' 'This change is outside the selected folder; start a session from the repository root to view it' >&2; exit 1;; esac; "
         )
     };
-    let output = ssh_output(
+    let mut output = Vec::new();
+    ssh_stream(
         root,
         &format!(
-            "root={}; pathspec={}; repository=$(git -C \"$root\" rev-parse --show-toplevel) || exit; file=\"${{repository%/}}/$pathspec\"; ancestor=\"$file\"; while ! test -e \"$ancestor\" && ! test -L \"$ancestor\"; do parent=${{ancestor%/*}}; ancestor=${{parent:-/}}; done; ancestor=$(realpath -- \"$ancestor\") || exit; {scope}if git -C \"$repository\" --literal-pathspecs ls-files --others --exclude-standard -- \"$pathspec\" | grep -q .; then git -C \"$repository\" diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null \"$file\" || test $? -eq 1; else if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --no-color \"$base\" -- \"$pathspec\"; fi | head -c {}",
+            "root={}; pathspec={}; repository=$(git -C \"$root\" rev-parse --show-toplevel) || exit; file=\"${{repository%/}}/$pathspec\"; ancestor=\"$file\"; while ! test -e \"$ancestor\" && ! test -L \"$ancestor\"; do parent=${{ancestor%/*}}; ancestor=${{parent:-/}}; done; ancestor=$(realpath -- \"$ancestor\") || exit; {scope}if git -C \"$repository\" --literal-pathspecs ls-files --others --exclude-standard -- \"$pathspec\" | grep -q .; then git -C \"$repository\" diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null \"$file\" || test $? -eq 1; else if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --no-color \"$base\" -- \"$pathspec\"; fi",
             posix_quote(&root.path),
             posix_quote(&pathspec),
-            MAX_GIT_DIFF_BYTES + 1,
         ),
+        |chunk| {
+            if output.len() + chunk.len() > MAX_GIT_DIFF_BYTES as usize {
+                return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
+            }
+            output.extend_from_slice(chunk);
+            Ok(())
+        },
     )?;
-    if output.len() > MAX_GIT_DIFF_BYTES as usize {
-        return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
-    }
     Ok(String::from_utf8_lossy(&output).into_owned())
 }
 
@@ -4929,11 +4933,10 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
         return tauri::async_runtime::spawn_blocking(move || {
             let marker = format!("lite-git-{}", uuid::Uuid::new_v4());
             let separator = format!("\0{marker}\0");
-            let status_limit = MAX_SSH_OUTPUT_BYTES - MAX_GIT_DIFF_BYTES - 8192;
             let output = ssh_output(
                 &root,
                 &format!(
-                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\" | head -c {status_limit}; printf '\\0%s\\0' {}; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\" | head -c {MAX_GIT_DIFF_BYTES}",
+                    "root={}; repository=$(git -C \"$root\" rev-parse --show-toplevel 2>/dev/null) || {{ printf '%s\\0\\0\\0' {}; exit 0; }}; case \"$root\" in \"$repository\") scope=.;; \"$repository\"/*) scope=${{root#\"$repository\"/}};; *) printf '%s\\n' 'The selected folder is outside the Git repository' >&2; exit 1;; esac; branch=$(git -C \"$root\" branch --show-current) || exit; if git -C \"$repository\" rev-parse --verify HEAD >/dev/null 2>&1; then base=HEAD; else base=$(git hash-object -t tree /dev/null) || exit; fi; printf '%s\\0%s\\0%s\\0' {} \"$repository\" \"$branch\"; git -C \"$repository\" --literal-pathspecs status --porcelain=v1 -z --no-renames --untracked-files=all -- \"$scope\" || exit; printf '\\0%s\\0' {}; git -C \"$repository\" --literal-pathspecs diff --no-ext-diff --no-textconv --no-renames --numstat -z \"$base\" -- \"$scope\"",
                     posix_quote(&root.path),
                     posix_quote(&marker),
                     posix_quote(&marker),
@@ -4957,16 +4960,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                 .windows(separator.len())
                 .position(|window| window == separator)
                 .ok_or("Could not read remote Git status")?;
-            let mut status = body[..split].to_vec();
-            let byte_truncated = status.len() == status_limit as usize;
-            if byte_truncated {
-                status.truncate(
-                    status
-                        .iter()
-                        .rposition(|byte| *byte == 0)
-                        .map_or(0, |position| position + 1),
-                );
-            }
+            let status = &body[..split];
             let mut changes = Vec::new();
             let mut records = status.split(|byte| *byte == 0);
             while let Some(record) = records.next() {
@@ -4985,7 +4979,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     break;
                 }
             }
-            let changes_truncated = byte_truncated || changes.len() > MAX_GIT_CHANGES;
+            let changes_truncated = changes.len() > MAX_GIT_CHANGES;
             changes.truncate(MAX_GIT_CHANGES);
             let scope = root
                 .path

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ const MAX_FILE_BYTES: u64 = 500_000;
 const DIRECTORY_PAGE_SIZE: usize = 250;
 const MAX_GIT_CHANGES: usize = 500;
 const MAX_GIT_DIFF_BYTES: u64 = 1_000_000;
+const MAX_SSH_OUTPUT_BYTES: u64 = 2_000_000;
 const MISSING_DIRECTORY: &str = "The selected folder no longer exists";
 const CODEX_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 // Requests stay bounded so an app server that never answers surfaces an error instead of a stuck tab.
@@ -451,8 +452,21 @@ fn set_keep_awake(wake_lock: State<WakeLock>, enabled: bool) -> Result<(), Strin
     update_keep_awake(&wake_lock, enabled, generation)
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+struct SshRoot {
+    host: String,
+    path: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+enum WorkspaceRoot {
+    Local(PathBuf),
+    Ssh(SshRoot),
+}
+
 #[derive(Default)]
-struct Roots(Mutex<HashMap<String, PathBuf>>);
+struct Roots(Mutex<HashMap<String, WorkspaceRoot>>);
 
 #[derive(Default)]
 struct FileBrowserSettings {
@@ -489,6 +503,7 @@ struct ShellAgent {
 struct DirectoryGrant {
     id: String,
     path: String,
+    host: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -589,10 +604,157 @@ fn path_text(path: &Path) -> String {
 
 fn root_path(roots: &Roots, root_id: &str) -> Result<PathBuf, String> {
     let roots = roots.0.lock().map_err(|error| error.to_string())?;
-    let root = roots
+    let WorkspaceRoot::Local(root) = roots
         .get(root_id)
-        .ok_or("Folder permission is no longer available")?;
+        .ok_or("Folder permission is no longer available")?
+    else {
+        return Err("This workspace is on an SSH host".into());
+    };
     fs::canonicalize(root).map_err(|_| MISSING_DIRECTORY.to_owned())
+}
+
+fn ssh_root(roots: &Roots, root_id: &str) -> Result<Option<SshRoot>, String> {
+    Ok(roots
+        .0
+        .lock()
+        .map_err(|error| error.to_string())?
+        .get(root_id)
+        .and_then(|root| match root {
+            WorkspaceRoot::Ssh(root) => Some(root.clone()),
+            WorkspaceRoot::Local(_) => None,
+        }))
+}
+
+fn posix_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn ssh_command(host: &str) -> Result<Command, String> {
+    if host.is_empty()
+        || host.starts_with('-')
+        || host
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control())
+    {
+        return Err("Enter an SSH host or user@host from your SSH config".into());
+    }
+    let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
+    let mut command = Command::new(ssh);
+    command.args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "--", host]);
+    Ok(command)
+}
+
+fn ssh_output(root: &SshRoot, script: &str) -> Result<Vec<u8>, String> {
+    let mut child = ssh_command(&root.host)?
+        .arg(script)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let stdout = child.stdout.take().ok_or("Could not read SSH output")?;
+    let mut stderr = child.stderr.take().ok_or("Could not read SSH errors")?;
+    let errors = thread::spawn(move || {
+        let mut output = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        while let Ok(count) = stderr.read(&mut buffer) {
+            if count == 0 {
+                break;
+            }
+            output.extend_from_slice(&buffer[..count]);
+            if output.len() > 16_384 {
+                output.drain(..output.len() - 16_384);
+            }
+        }
+        output
+    });
+    let mut output = Vec::new();
+    if let Err(error) = stdout
+        .take(MAX_SSH_OUTPUT_BYTES + 1)
+        .read_to_end(&mut output)
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = errors.join();
+        return Err(error.to_string());
+    }
+    if output.len() > MAX_SSH_OUTPUT_BYTES as usize {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = errors.join();
+        return Err("SSH output is too large; inspect it in the terminal".into());
+    }
+    let status = child.wait().map_err(|error| error.to_string())?;
+    let errors = errors.join().unwrap_or_default();
+    if status.success() {
+        Ok(output)
+    } else {
+        let detail = String::from_utf8_lossy(&errors).trim().to_owned();
+        Err(if detail.is_empty() {
+            format!("SSH command exited with {status}")
+        } else {
+            detail
+        })
+    }
+}
+
+fn ssh_text(root: &SshRoot, script: &str) -> Result<String, String> {
+    String::from_utf8(ssh_output(root, script)?)
+        .map(|output| output.trim().to_owned())
+        .map_err(|_| "SSH command returned non-UTF-8 text".into())
+}
+
+fn ssh_input(root: &SshRoot, script: &str, input: &[u8]) -> Result<(), String> {
+    let mut child = ssh_command(&root.host)?
+        .arg(script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let write = child
+        .stdin
+        .take()
+        .ok_or_else(|| "Could not write to SSH".to_owned())
+        .and_then(|mut stdin| stdin.write_all(input).map_err(|error| error.to_string()));
+    if let Err(error) = write {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    let status = child.wait().map_err(|error| error.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("SSH command exited with {status}"))
+    }
+}
+
+fn remote_path(root: &SshRoot, path: &str) -> Result<String, String> {
+    let root_path = root.path.trim_end_matches('/');
+    let path = path.trim_end_matches('/');
+    if path == root_path || path.starts_with(&format!("{root_path}/")) {
+        Ok(path.to_owned())
+    } else {
+        Err("Path is outside the selected folder".into())
+    }
+}
+
+fn scoped_ssh_path(root: &SshRoot, path: &str) -> Result<String, String> {
+    remote_path(root, path)?;
+    let path = ssh_text(root, &format!("realpath -- {}", posix_quote(path)))?;
+    remote_path(root, &path)
+}
+
+fn scoped_ssh_entry(root: &SshRoot, path: &str) -> Result<String, String> {
+    let path = remote_path(root, path)?;
+    let (parent, name) = path
+        .rsplit_once('/')
+        .ok_or("Path is outside the selected folder")?;
+    if name.is_empty() || matches!(name, "." | "..") {
+        return Err("Path is outside the selected folder".into());
+    }
+    let parent = scoped_ssh_path(root, parent)?;
+    Ok(format!("{parent}/{name}"))
 }
 
 fn scoped_path(root: &Path, path: &str) -> Result<PathBuf, String> {
@@ -684,7 +846,7 @@ fn load_file_browser_settings(app: &AppHandle) -> FileBrowserSettings {
     }
 }
 
-fn read_roots(path: &Path) -> HashMap<String, PathBuf> {
+fn read_roots(path: &Path) -> HashMap<String, WorkspaceRoot> {
     fs::read(path)
         .ok()
         .and_then(|bytes| serde_json::from_slice(&bytes).ok())
@@ -940,7 +1102,7 @@ fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
 fn update_roots(
     app: &AppHandle,
     roots: &Roots,
-    update: impl FnOnce(&mut HashMap<String, PathBuf>),
+    update: impl FnOnce(&mut HashMap<String, WorkspaceRoot>),
 ) -> Result<(), String> {
     let path = roots_path(app)?;
     let mut roots = roots.0.lock().map_err(|error| error.to_string())?;
@@ -1008,11 +1170,12 @@ fn grant_directory(
     let path = fs::canonicalize(path).map_err(|error| error.to_string())?;
     let id = root_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     update_roots(app, roots, |roots| {
-        roots.insert(id.clone(), path.clone());
+        roots.insert(id.clone(), WorkspaceRoot::Local(path.clone()));
     })?;
     Ok(DirectoryGrant {
         id,
         path: path_text(&path),
+        host: None,
     })
 }
 
@@ -1318,12 +1481,72 @@ async fn use_directory(
 }
 
 #[tauri::command]
+async fn use_ssh_directory(
+    app: AppHandle,
+    roots: State<'_, Roots>,
+    host: String,
+    path: String,
+) -> Result<DirectoryGrant, String> {
+    let host = host.trim().to_owned();
+    let path = path.trim();
+    if path.is_empty() {
+        return Err("Enter a folder on the SSH host".into());
+    }
+    let requested = if path == "~" {
+        "$HOME".to_owned()
+    } else if let Some(path) = path.strip_prefix("~/") {
+        format!("$HOME/{}", posix_quote(path))
+    } else {
+        posix_quote(path)
+    };
+    let probe = SshRoot {
+        host: host.clone(),
+        path: String::new(),
+    };
+    let resolved = ssh_text(
+        &probe,
+        &format!("mkdir -p -- {requested} && cd -- {requested} && pwd -P"),
+    )?;
+    if !resolved.starts_with('/') {
+        return Err("The SSH server did not return an absolute folder path".into());
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    let root = SshRoot {
+        host: host.clone(),
+        path: resolved.clone(),
+    };
+    update_roots(&app, &roots, |roots| {
+        roots.insert(id.clone(), WorkspaceRoot::Ssh(root));
+    })?;
+    Ok(DirectoryGrant {
+        id,
+        path: resolved,
+        host: Some(host),
+    })
+}
+
+#[tauri::command]
 async fn follow_directory(
     app: AppHandle,
     roots: State<'_, Roots>,
     root_id: String,
     path: String,
 ) -> Result<DirectoryGrant, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let path = ssh_text(&root, &format!("cd -- {} && pwd -P", posix_quote(&path)))?;
+        let next = SshRoot {
+            host: root.host.clone(),
+            path: path.clone(),
+        };
+        update_roots(&app, &roots, |roots| {
+            roots.insert(root_id.clone(), WorkspaceRoot::Ssh(next));
+        })?;
+        return Ok(DirectoryGrant {
+            id: root_id,
+            path,
+            host: Some(root.host),
+        });
+    }
     root_path(&roots, &root_id)?;
     grant_directory(&app, &roots, PathBuf::from(path), Some(root_id))
 }
@@ -2504,6 +2727,38 @@ fn agent_builder(agent: &str) -> Result<CommandBuilder, String> {
     Ok(CommandBuilder::new(path))
 }
 
+fn session_arguments(
+    agent: &str,
+    resume: bool,
+    session_id: &str,
+    provider_session_id: Option<&str>,
+) -> Result<Vec<String>, String> {
+    match agent {
+        "claude" => Ok(vec![
+            if resume { "--resume" } else { "--session-id" }.into(),
+            provider_session_id.unwrap_or(session_id).into(),
+        ]),
+        "gemini" | "qwen" => Ok(vec![
+            if resume { "--resume" } else { "--session-id" }.into(),
+            session_id.into(),
+        ]),
+        "kimi" => Ok(provider_session_id
+            .map(|id| vec!["--session".into(), id.into()])
+            .unwrap_or_default()),
+        "shell" => Ok(Vec::new()),
+        _ => Err("Unknown session type".into()),
+    }
+}
+
+fn login_arguments(agent: &str) -> Result<Vec<String>, String> {
+    match agent {
+        "claude" => Ok(vec!["auth".into(), "login".into()]),
+        "codex" | "kimi" => Ok(vec!["login".into()]),
+        "gemini" | "qwen" => Ok(Vec::new()),
+        _ => Err("This provider signs in with an API key".into()),
+    }
+}
+
 fn codex_home(app: &AppHandle) -> Result<PathBuf, String> {
     provider_home(app, "CODEX_HOME", ".codex")
 }
@@ -2705,27 +2960,35 @@ fn kimi_session_ids(app: &AppHandle, cwd: &Path) -> HashSet<String> {
     ids
 }
 
-fn agent_command(
-    app: &AppHandle,
-    agent: &str,
-    provider: Option<&str>,
-    model: Option<&str>,
-    reasoning_effort: Option<&str>,
+struct SessionCommand<'a> {
+    agent: &'a str,
+    provider: Option<&'a str>,
+    model: Option<&'a str>,
+    reasoning_effort: Option<&'a str>,
     resume: bool,
-    session_id: &str,
-    provider_session_id: Option<&str>,
-) -> Result<CommandBuilder, String> {
+    session_id: &'a str,
+    provider_session_id: Option<&'a str>,
+}
+
+fn agent_command(app: &AppHandle, launch: &SessionCommand<'_>) -> Result<CommandBuilder, String> {
+    let SessionCommand {
+        agent,
+        provider,
+        model,
+        reasoning_effort,
+        resume,
+        session_id,
+        provider_session_id,
+    } = *launch;
     let mut command = match agent {
         "claude" => {
             let mut command = agent_builder(agent)?;
-            let session_id = provider_session_id.unwrap_or(session_id);
-            if resume {
-                command.args(["--resume", session_id]);
-            } else {
-                // Naming the session after its folder is the one thing that stops Claude Code from
-                // naming it after what it is doing, and that name is what the tab is titled with.
-                command.args(["--session-id", session_id]);
-            }
+            command.args(session_arguments(
+                agent,
+                resume,
+                session_id,
+                provider_session_id,
+            )?);
             command
         }
         "codex" => {
@@ -2810,11 +3073,7 @@ fn agent_command(
         }
         "gemini" => {
             let mut command = agent_builder(agent)?;
-            command.args(if resume {
-                ["--resume", session_id]
-            } else {
-                ["--session-id", session_id]
-            });
+            command.args(session_arguments(agent, resume, session_id, None)?);
             command
         }
         "kimi" => {
@@ -2822,18 +3081,17 @@ fn agent_command(
             // which two tabs there would both land on, and it creates no entry for discovery to record,
             // so the tab could never learn which session it is showing.
             let mut command = agent_builder(agent)?;
-            if let Some(provider_session_id) = provider_session_id {
-                command.args(["--session", provider_session_id]);
-            }
+            command.args(session_arguments(
+                agent,
+                resume,
+                session_id,
+                provider_session_id,
+            )?);
             command
         }
         "qwen" => {
             let mut command = agent_builder(agent)?;
-            command.args(if resume {
-                ["--resume", session_id]
-            } else {
-                ["--session-id", session_id]
-            });
+            command.args(session_arguments(agent, resume, session_id, None)?);
             command
         }
         "shell" => {
@@ -2863,26 +3121,8 @@ fn agent_command(
 
 // Each CLI owns its sign-in and opens the browser itself, so Lite only runs the command and shows it.
 fn login_command(agent: &str) -> Result<CommandBuilder, String> {
-    let mut command = match agent {
-        "claude" => {
-            let mut command = agent_builder(agent)?;
-            command.args(["auth", "login"]);
-            command
-        }
-        "codex" => {
-            let mut command = agent_builder(agent)?;
-            command.arg("login");
-            command
-        }
-        "gemini" => agent_builder(agent)?,
-        "kimi" => {
-            let mut command = agent_builder(agent)?;
-            command.arg("login");
-            command
-        }
-        "qwen" => agent_builder(agent)?,
-        _ => return Err("This provider signs in with an API key".into()),
-    };
+    let mut command = agent_builder(agent)?;
+    command.args(login_arguments(agent)?);
     if let Some(path) = user_path() {
         command.env("PATH", path);
     }
@@ -3187,8 +3427,14 @@ fn open_external(url: &str) -> Result<(), String> {
         .map_err(|error| format!("Could not open the link: {error}"))
 }
 
-fn configure_session_command(command: &mut CommandBuilder, cwd: &Path, theme: Option<&str>) {
-    command.cwd(path_text(cwd));
+fn configure_session_command(
+    command: &mut CommandBuilder,
+    cwd: Option<&Path>,
+    theme: Option<&str>,
+) {
+    if let Some(cwd) = cwd {
+        command.cwd(path_text(cwd));
+    }
     command.env("TERM", "xterm-256color");
     // A launched app inherits no locale, so a session copies its own UTF-8 as Mac Roman: `─` as `‚îÄ`.
     #[cfg(target_os = "macos")]
@@ -3202,6 +3448,92 @@ fn configure_session_command(command: &mut CommandBuilder, cwd: &Path, theme: Op
             "15;0"
         },
     );
+}
+
+fn ssh_agent_args(launch: &SessionCommand<'_>, signing_in: bool) -> Result<Vec<String>, String> {
+    let SessionCommand {
+        agent,
+        provider,
+        model,
+        reasoning_effort,
+        resume,
+        session_id,
+        provider_session_id,
+    } = *launch;
+    if agent == "shell" {
+        return Ok(vec!["${SHELL:-/bin/sh}".into(), "-l".into()]);
+    }
+    let executable = agent_executable(agent).ok_or("Unknown session type")?;
+    let mut args = vec![executable.to_owned()];
+    if signing_in {
+        args.extend(login_arguments(agent)?);
+        return Ok(args);
+    }
+    if agent != "codex" {
+        args.extend(session_arguments(
+            agent,
+            resume,
+            session_id,
+            provider_session_id,
+        )?);
+        return Ok(args);
+    }
+    args.extend([
+        "-c".into(),
+        r#"tui.notification_method="osc9""#.into(),
+        "-c".into(),
+        r#"tui.notification_condition="always""#.into(),
+    ]);
+    if let Some(provider) = codex_provider(provider) {
+        args.extend(["--profile".into(), provider.id.into()]);
+        if provider.id == "deepseek" {
+            if let Some(model) = model {
+                args.extend(["-c".into(), format!("model=\"{model}\"")]);
+            }
+            if let Some(effort) = reasoning_effort {
+                args.extend(["-c".into(), format!("model_reasoning_effort=\"{effort}\"")]);
+            }
+        }
+    }
+    if let Some(id) = provider_session_id {
+        args.extend(["resume".into(), id.into()]);
+    }
+    Ok(args)
+}
+
+fn ssh_session_command(
+    root: &SshRoot,
+    launch: &SessionCommand<'_>,
+    signing_in: bool,
+    initial_prompt: Option<&str>,
+) -> Result<CommandBuilder, String> {
+    let mut args = ssh_agent_args(launch, signing_in)?;
+    if !signing_in
+        && launch.agent == "claude"
+        && let Some(prompt) = initial_prompt
+    {
+        args.push(prompt.into());
+    }
+    let command = args
+        .iter()
+        .map(|argument| {
+            if argument == "${SHELL:-/bin/sh}" {
+                argument.clone()
+            } else {
+                posix_quote(argument)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let remote = format!(
+        "cd -- {} && exec ${{SHELL:-/bin/sh}} -lc {}",
+        posix_quote(&root.path),
+        posix_quote(&format!("exec {command}"))
+    );
+    let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
+    let mut builder = CommandBuilder::new(ssh);
+    builder.args(["-tt", "--", &root.host, &remote]);
+    Ok(builder)
 }
 
 #[tauri::command]
@@ -3228,28 +3560,38 @@ async fn spawn_session(
     cols: u16,
     rows: u16,
 ) -> Result<Option<String>, String> {
-    if !roots
-        .0
-        .lock()
-        .map_err(|error| error.to_string())?
-        .contains_key(&root_id)
+    let ssh = ssh_root(&roots, &root_id)?;
+    if ssh.is_none()
+        && !roots
+            .0
+            .lock()
+            .map_err(|error| error.to_string())?
+            .contains_key(&root_id)
     {
         uuid::Uuid::parse_str(&root_id).map_err(|_| "Invalid folder permission")?;
         let path = fs::canonicalize(cwd).map_err(|_| MISSING_DIRECTORY)?;
         update_roots(&app, &roots, |roots| {
-            roots.entry(root_id.clone()).or_insert(path);
+            roots
+                .entry(root_id.clone())
+                .or_insert(WorkspaceRoot::Local(path));
         })?;
     }
-    let cwd = root_path(&roots, &root_id)?;
+    let cwd = if let Some(root) = ssh.as_ref() {
+        PathBuf::from(&root.path)
+    } else {
+        root_path(&roots, &root_id)?
+    };
     // A sign-in runs the provider's own login command and owns no session of its own.
     let signing_in = mode.as_deref() == Some("login");
     // A tab whose provider history was removed starts again instead of becoming permanently unusable.
-    let claude_launch = (resume && !signing_in && agent == "claude")
+    let claude_launch = (resume && !signing_in && agent == "claude" && ssh.is_none())
         .then(|| claude_launch_id(&app, provider_session_id.as_deref().unwrap_or(&session_id)));
     let mut resume = resume
         && match agent.as_str() {
-            "claude" => claude_launch.as_ref().is_some_and(|(_, resume)| *resume),
-            "gemini" | "qwen" => native_session_path(&app, &agent, &session_id).is_some(),
+            "claude" if ssh.is_none() => claude_launch.as_ref().is_some_and(|(_, resume)| *resume),
+            "gemini" | "qwen" if ssh.is_none() => {
+                native_session_path(&app, &agent, &session_id).is_some()
+            }
             _ => true,
         };
     // The tab keeps the id it was given so the next launch reopens the same conversation, and a
@@ -3268,7 +3610,8 @@ async fn spawn_session(
             uuid::Uuid::new_v4().to_string()
         });
     }
-    if !signing_in
+    if ssh.is_none()
+        && !signing_in
         && (agent == "codex" || agent == "kimi")
         && let Some(saved_provider_session_id) = provider_sessions
             .0
@@ -3324,7 +3667,8 @@ async fn spawn_session(
         .map_err(|error| error.to_string())?;
     // An app server that cannot answer costs the check, not the session: the tab opens on the recorded
     // thread and Codex itself says whether it can resume, as the discovery below already assumes.
-    if !signing_in
+    if ssh.is_none()
+        && !signing_in
         && agent == "codex"
         && let Some(thread_id) = provider_session_id.as_deref()
         && !codex_thread_resumable(&codex_server, thread_id).unwrap_or(true)
@@ -3333,7 +3677,8 @@ async fn spawn_session(
         provider_session_id = None;
     }
     // A Kimi session the user deleted should start a new one instead of failing the terminal.
-    if !signing_in
+    if ssh.is_none()
+        && !signing_in
         && agent == "kimi"
         && let Some(known) = provider_session_id.as_deref()
         && !kimi_session_ids(&app, &cwd).contains(known)
@@ -3341,41 +3686,50 @@ async fn spawn_session(
         update_provider_session(&app, &provider_sessions, &session_id, None)?;
         provider_session_id = None;
     }
-    let mut command = if signing_in {
+    let launch = SessionCommand {
+        agent: &agent,
+        provider: provider.as_deref(),
+        model: model.as_deref(),
+        reasoning_effort: reasoning_effort.as_deref(),
+        resume,
+        session_id: &session_id,
+        provider_session_id: provider_session_id.as_deref(),
+    };
+    let mut command = if let Some(root) = ssh.as_ref() {
+        ssh_session_command(root, &launch, signing_in, initial_prompt.as_deref())?
+    } else if signing_in {
         login_command(&agent)?
     } else {
-        agent_command(
-            &app,
-            &agent,
-            provider.as_deref(),
-            model.as_deref(),
-            reasoning_effort.as_deref(),
-            resume,
-            &session_id,
-            provider_session_id.as_deref(),
-        )?
+        agent_command(&app, &launch)?
     };
-    if !signing_in && agent == "claude" {
+    if ssh.is_none() && !signing_in && agent == "claude" {
         let settings = claude_settings(&app, &session_id, &run_id)?;
         command.args(["--settings", &path_text(&settings)]);
         if let Some(prompt) = initial_prompt {
             command.arg(prompt);
         }
     }
-    configure_session_command(&mut command, &cwd, theme.as_deref());
+    configure_session_command(
+        &mut command,
+        ssh.is_none().then_some(cwd.as_path()),
+        theme.as_deref(),
+    );
     // Codex records a new thread per launch, so its discovery watches for one the tab did not start with.
     // Kimi attaches to the directory's session instead, so its discovery reads that session directly.
-    let known_sessions =
-        if !signing_in && provider_session_id.is_none() && (agent == "codex" || agent == "kimi") {
-            if agent == "kimi" {
-                Some(HashSet::new())
-            } else {
-                // Losing discovery costs exact resume, not the session, so a failure still opens the terminal.
-                codex_thread_ids(&codex_server, &cwd).ok()
-            }
+    let known_sessions = if ssh.is_none()
+        && !signing_in
+        && provider_session_id.is_none()
+        && (agent == "codex" || agent == "kimi")
+    {
+        if agent == "kimi" {
+            Some(HashSet::new())
         } else {
-            None
-        };
+            // Losing discovery costs exact resume, not the session, so a failure still opens the terminal.
+            codex_thread_ids(&codex_server, &cwd).ok()
+        }
+    } else {
+        None
+    };
     let mut child = match pair.slave.spawn_command(command) {
         Ok(child) => child,
         Err(error) => {
@@ -3760,6 +4114,55 @@ async fn list_directory(
     path: String,
     after: Option<DirectoryCursor>,
 ) -> Result<DirectoryListing, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let path = scoped_ssh_path(&root, &path)?;
+        let output = ssh_output(
+            &root,
+            &format!(
+                "find {} -mindepth 1 -maxdepth 1 -printf '%f\\0%p\\0%y\\0'",
+                posix_quote(&path)
+            ),
+        )?;
+        let fields = output.split(|byte| *byte == 0).collect::<Vec<_>>();
+        let after =
+            after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
+        let mut page = BTreeMap::new();
+        let mut has_more = false;
+        for record in fields.chunks_exact(3) {
+            let name = String::from_utf8_lossy(record[0]).into_owned();
+            if settings.hide_hidden.load(Ordering::Relaxed) && name.starts_with('.') {
+                continue;
+            }
+            let entry = FileEntry {
+                name,
+                path: String::from_utf8_lossy(record[1]).into_owned(),
+                is_directory: record[2] == b"d",
+                is_symlink: record[2] == b"l",
+            };
+            let key = directory_key(&entry.name, &entry.path, entry.is_directory);
+            if after.as_ref().is_some_and(|after| key <= *after) {
+                continue;
+            }
+            page.insert(key, entry);
+            if page.len() > DIRECTORY_PAGE_SIZE {
+                page.pop_last();
+                has_more = true;
+            }
+        }
+        let entries = page.into_values().collect::<Vec<_>>();
+        let next_cursor = has_more.then(|| {
+            let entry = entries.last().expect("a truncated page is not empty");
+            DirectoryCursor {
+                name: entry.name.clone(),
+                path: entry.path.clone(),
+                is_directory: entry.is_directory,
+            }
+        });
+        return Ok(DirectoryListing {
+            entries,
+            next_cursor,
+        });
+    }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
     let after = after.map(|cursor| directory_key(&cursor.name, &cursor.path, cursor.is_directory));
@@ -3811,6 +4214,20 @@ async fn read_text_file(
     root_id: String,
     path: String,
 ) -> Result<String, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let path = scoped_ssh_path(&root, &path)?;
+        let size = ssh_text(&root, &format!("wc -c < {}", posix_quote(&path)))?
+            .parse::<u64>()
+            .map_err(|_| "Could not read remote file size")?;
+        if size > MAX_FILE_BYTES {
+            return Err("File is larger than 500 KB".into());
+        }
+        let bytes = ssh_output(&root, &format!("cat -- {}", posix_quote(&path)))?;
+        if bytes.contains(&0) {
+            return Err("Binary files cannot be previewed".into());
+        }
+        return String::from_utf8(bytes).map_err(|_| "File is not UTF-8 text".into());
+    }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
     let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
@@ -3834,6 +4251,16 @@ async fn write_text_file(
     if contents.len() > MAX_FILE_BYTES as usize {
         return Err("File is larger than 500 KB".into());
     }
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let path = scoped_ssh_path(&root, &path)?;
+        let parent = path.rsplit_once('/').map_or("/", |(parent, _)| parent);
+        let script = format!(
+            "set -e; test -f {file}; tmp=$(mktemp {parent}/.lite.XXXXXX); trap 'rm -f -- \"$tmp\"' EXIT; cat > \"$tmp\"; chmod --reference={file} \"$tmp\"; mv -- \"$tmp\" {file}; trap - EXIT",
+            file = posix_quote(&path),
+            parent = posix_quote(parent),
+        );
+        return ssh_input(&root, &script, contents.as_bytes());
+    }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_path(&root, &path)?;
     if !path.is_file() {
@@ -3852,6 +4279,13 @@ async fn delete_entry(
     root_id: String,
     path: String,
 ) -> Result<(), String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let path = scoped_ssh_entry(&root, &path)?;
+        if path == root.path.trim_end_matches('/') {
+            return Err("The selected folder cannot be deleted".into());
+        }
+        return ssh_text(&root, &format!("rm -rf -- {}", posix_quote(&path))).map(|_| ());
+    }
     let root = root_path(&roots, &root_id)?;
     let path = scoped_entry(&root, &path)?;
     remove_entry(&path)
@@ -3975,6 +4409,31 @@ fn bounded_git_output(
     Ok(String::from_utf8_lossy(&output).into_owned())
 }
 
+fn ssh_git_output(root: &SshRoot, directory: &str, args: &[&str]) -> Result<Vec<u8>, String> {
+    let command = std::iter::once("git".to_owned())
+        .chain(std::iter::once("-C".to_owned()))
+        .chain(std::iter::once(directory.to_owned()))
+        .chain(args.iter().map(|argument| (*argument).to_owned()))
+        .map(|argument| posix_quote(&argument))
+        .collect::<Vec<_>>()
+        .join(" ");
+    ssh_output(root, &command)
+}
+
+fn ssh_git_text(root: &SshRoot, directory: &str, args: &[&str]) -> Result<String, String> {
+    String::from_utf8(ssh_git_output(root, directory, args)?)
+        .map(|output| output.trim().to_owned())
+        .map_err(|_| "Git returned non-UTF-8 text".into())
+}
+
+fn ssh_git_base(root: &SshRoot, repository: &str) -> Result<String, String> {
+    if ssh_git_output(root, repository, &["rev-parse", "--verify", "HEAD"]).is_ok() {
+        Ok("HEAD".into())
+    } else {
+        ssh_text(root, "git hash-object -t tree /dev/null")
+    }
+}
+
 fn git_diff_base(git: &Path, repository: &Path) -> Result<String, String> {
     if command_output(git, repository, &["rev-parse", "--verify", "HEAD"]).is_ok() {
         return Ok("HEAD".into());
@@ -3997,6 +4456,67 @@ async fn git_diff(
     root_id: String,
     path: String,
 ) -> Result<String, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let relative = Path::new(&path);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err("This change is outside the selected folder".into());
+        }
+        let repository = ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"])?;
+        let pathspec = path_text(relative);
+        let file = format!("{}/{}", repository.trim_end_matches('/'), pathspec);
+        remote_path(&root, &file).map_err(|_| {
+            "This change is outside the selected folder; start a session from the repository root to view it"
+        })?;
+        let untracked = !ssh_git_output(
+            &root,
+            &repository,
+            &[
+                "--literal-pathspecs",
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                "-z",
+                "--",
+                &pathspec,
+            ],
+        )?
+        .is_empty();
+        let output = if untracked {
+            ssh_output(
+                &root,
+                &format!(
+                    "git -C {} diff --no-index --no-ext-diff --no-textconv --no-renames --no-color -- /dev/null {} || test $? -eq 1",
+                    posix_quote(&repository),
+                    posix_quote(&file)
+                ),
+            )?
+        } else {
+            let base = ssh_git_base(&root, &repository)?;
+            ssh_git_output(
+                &root,
+                &repository,
+                &[
+                    "--literal-pathspecs",
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--no-renames",
+                    "--no-color",
+                    &base,
+                    "--",
+                    &pathspec,
+                ],
+            )?
+        };
+        if output.len() > MAX_GIT_DIFF_BYTES as usize {
+            return Err("Diff is larger than 1 MB; inspect it with Git in the terminal".into());
+        }
+        return Ok(String::from_utf8_lossy(&output).into_owned());
+    }
     let granted = root_path(&roots, &root_id)?;
     let relative = Path::new(&path);
     if relative.is_absolute()
@@ -4089,6 +4609,109 @@ async fn git_diff(
 
 #[tauri::command]
 async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<GitStatus>, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        let repository = match ssh_git_text(&root, &root.path, &["rev-parse", "--show-toplevel"]) {
+            Ok(repository) => repository,
+            Err(_) => return Ok(None),
+        };
+        let scope = root
+            .path
+            .strip_prefix(&repository)
+            .ok_or("The selected folder is outside the Git repository")?
+            .trim_start_matches('/');
+        let scope_text = if scope.is_empty() { "." } else { scope };
+        let branch = ssh_git_text(&root, &root.path, &["branch", "--show-current"])?;
+        let output = ssh_git_output(
+            &root,
+            &repository,
+            &[
+                "--literal-pathspecs",
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--no-renames",
+                "--untracked-files=all",
+                "--",
+                scope_text,
+            ],
+        )?;
+        let mut changes = Vec::new();
+        let mut records = output.split(|byte| *byte == 0);
+        while let Some(record) = records.next() {
+            if record.len() < 4 || record[2] != b' ' {
+                continue;
+            }
+            let status = String::from_utf8_lossy(&record[..2]).into_owned();
+            if status.bytes().any(|byte| matches!(byte, b'R' | b'C')) {
+                let _ = records.next();
+            }
+            changes.push(GitChange {
+                status,
+                path: String::from_utf8(record[3..].to_vec())
+                    .map_err(|_| "Git status contains a non-UTF-8 path")?,
+            });
+            if changes.len() > MAX_GIT_CHANGES {
+                break;
+            }
+        }
+        let changes_truncated = changes.len() > MAX_GIT_CHANGES;
+        changes.truncate(MAX_GIT_CHANGES);
+        changes.retain(|change| Path::new(&change.path).starts_with(scope));
+        let base = ssh_git_base(&root, &repository)?;
+        let diffs = ssh_git_output(
+            &root,
+            &repository,
+            &[
+                "--literal-pathspecs",
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-renames",
+                "--numstat",
+                "-z",
+                &base,
+                "--",
+                scope_text,
+            ],
+        )?;
+        let mut line_diffs = BTreeMap::new();
+        for record in diffs
+            .split(|byte| *byte == 0)
+            .filter(|record| !record.is_empty())
+        {
+            let mut fields = record.splitn(3, |byte| *byte == b'\t');
+            let (Some(additions), Some(deletions), Some(path)) = (
+                fields
+                    .next()
+                    .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
+                fields
+                    .next()
+                    .and_then(|value| String::from_utf8_lossy(value).parse().ok()),
+                fields.next(),
+            ) else {
+                continue;
+            };
+            line_diffs.insert(
+                String::from_utf8_lossy(path).into_owned(),
+                LineDiff {
+                    additions,
+                    deletions,
+                },
+            );
+        }
+        line_diffs.retain(|path, _| Path::new(path).starts_with(scope));
+        return Ok(Some(GitStatus {
+            branch: if branch.is_empty() {
+                "Detached HEAD".into()
+            } else {
+                branch
+            },
+            worktree: repository,
+            changes,
+            line_diffs,
+            changes_truncated,
+        }));
+    }
     let path = root_path(&roots, &root_id)?;
     // Locating Git runs a login shell, so one refresh resolves it once rather than once per command.
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
@@ -4250,6 +4873,13 @@ fn browse_url(remote: &str) -> Option<String> {
 // the full status reads the whole worktree.
 #[tauri::command]
 async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<String>, String> {
+    if let Some(root) = ssh_root(&roots, &root_id)? {
+        return Ok(
+            ssh_git_text(&root, &root.path, &["remote", "get-url", "origin"])
+                .ok()
+                .and_then(|remote| browse_url(&remote)),
+        );
+    }
     let path = root_path(&roots, &root_id)?;
     let git = resolve_executable("git").unwrap_or_else(|| "git".into());
     Ok(
@@ -5275,6 +5905,7 @@ pub fn run() {
             follow_directory,
             github_items,
             use_directory,
+            use_ssh_directory,
             default_directory,
             revoke_directory,
             spawn_session,
@@ -5341,7 +5972,7 @@ mod tests {
         let mut command = CommandBuilder::new("test");
         command.env_clear();
 
-        configure_session_command(&mut command, Path::new("."), None);
+        configure_session_command(&mut command, Some(Path::new(".")), None);
 
         assert_eq!(
             command.get_env("LC_CTYPE"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3673,7 +3673,7 @@ fn ssh_session_command(
     );
     let ssh = resolve_executable("ssh").ok_or("Could not find SSH in your PATH")?;
     let mut builder = CommandBuilder::new(ssh);
-    builder.args(["-tt", "--", &root.host, &remote]);
+    builder.args(["-tt", "-o", "ConnectTimeout=10", "--", &root.host, &remote]);
     Ok(builder)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1581,9 +1581,9 @@ async fn use_ssh_directory(
         return Err("Enter a folder on the SSH host".into());
     }
     let requested = if path == "~" {
-        "$HOME".to_owned()
+        "\"$HOME\"".to_owned()
     } else if let Some(path) = path.strip_prefix("~/") {
-        format!("$HOME/{}", posix_quote(path))
+        format!("\"$HOME\"/{}", posix_quote(path))
     } else {
         posix_quote(path)
     };
@@ -1627,21 +1627,10 @@ async fn follow_directory(
     if let Some(root) = ssh_root(&roots, &root_id)? {
         let target = path;
         let resolved = root.clone();
-        let path = tauri::async_runtime::spawn_blocking(move || {
-            ssh_text(
-                &resolved,
-                &format!("cd -- {} && pwd -P", posix_quote(&target)),
-            )
-        })
-        .await
-        .map_err(|error| error.to_string())??;
-        let next = SshRoot {
-            host: root.host.clone(),
-            path: path.clone(),
-        };
-        update_roots(&app, &roots, |roots| {
-            roots.insert(root_id.clone(), WorkspaceRoot::Ssh(next));
-        })?;
+        let path =
+            tauri::async_runtime::spawn_blocking(move || scoped_ssh_path(&resolved, &target))
+                .await
+                .map_err(|error| error.to_string())??;
         return Ok(DirectoryGrant {
             id: root_id,
             path,
@@ -4592,7 +4581,14 @@ fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
     let repository = ssh_git_text(root, &root.path, &["rev-parse", "--show-toplevel"])?;
     let pathspec = path_text(relative);
     let file = format!("{}/{}", repository.trim_end_matches('/'), pathspec);
-    remote_path(root, &file).map_err(|_| {
+    let ancestor = ssh_text(
+        root,
+        &format!(
+            "path={}; while ! test -e \"$path\" && ! test -L \"$path\"; do parent=${{path%/*}}; path=${{parent:-/}}; done; realpath -- \"$path\"",
+            posix_quote(&file)
+        ),
+    )?;
+    remote_path(root, &ancestor).map_err(|_| {
         "This change is outside the selected folder; start a session from the repository root to view it"
     })?;
     let untracked = !ssh_git_output(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4745,26 +4745,6 @@ fn bounded_git_output(
     Ok(String::from_utf8_lossy(&output).into_owned())
 }
 
-fn ssh_git_command(directory: &str, args: &[&str]) -> String {
-    std::iter::once("git".to_owned())
-        .chain(std::iter::once("-C".to_owned()))
-        .chain(std::iter::once(directory.to_owned()))
-        .chain(args.iter().map(|argument| (*argument).to_owned()))
-        .map(|argument| posix_quote(&argument))
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn ssh_git_output(root: &SshRoot, directory: &str, args: &[&str]) -> Result<Vec<u8>, String> {
-    ssh_output(root, &ssh_git_command(directory, args))
-}
-
-fn ssh_git_text(root: &SshRoot, directory: &str, args: &[&str]) -> Result<String, String> {
-    String::from_utf8(ssh_git_output(root, directory, args)?)
-        .map(|output| output.strip_suffix('\n').unwrap_or(&output).to_owned())
-        .map_err(|_| "Git returned non-UTF-8 text".into())
-}
-
 fn ssh_git_diff(root: &SshRoot, path: &str) -> Result<String, String> {
     let relative = Path::new(path);
     if relative.is_absolute()
@@ -5147,11 +5127,12 @@ fn browse_url(remote: &str) -> Option<String> {
 async fn git_remote(roots: State<'_, Roots>, root_id: String) -> Result<Option<String>, String> {
     if let Some(root) = ssh_root(&roots, &root_id)? {
         return tauri::async_runtime::spawn_blocking(move || {
-            Ok(
-                ssh_git_text(&root, &root.path, &["remote", "get-url", "origin"])
-                    .ok()
-                    .and_then(|remote| browse_url(&remote)),
+            Ok(ssh_text(
+                &root,
+                &format!("git -C {} remote get-url origin", posix_quote(&root.path)),
             )
+            .ok()
+            .and_then(|remote| browse_url(&remote)))
         })
         .await
         .map_err(|error| error.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1641,10 +1641,10 @@ async fn use_ssh_directory(
     path: String,
 ) -> Result<DirectoryGrant, String> {
     let host = host.trim().to_owned();
-    let path = path.trim();
-    if path.is_empty() {
+    if path.trim().is_empty() {
         return Err("Enter a folder on the SSH host".into());
     }
+    let path = path.as_str();
     let requested = if path == "~" {
         "\"$HOME\"".to_owned()
     } else if let Some(path) = path.strip_prefix("~/") {
@@ -4922,11 +4922,23 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     scope_text,
                 ],
             );
-            let output = ssh_bounded_git_output(
+            let mut output = ssh_bounded_git_output(
                 &root,
                 &status_command,
-                &format!("head -z -n {}", 2 * (MAX_GIT_CHANGES + 1)),
+                &format!(
+                    "head -z -n {} | head -c {MAX_SSH_OUTPUT_BYTES}",
+                    2 * (MAX_GIT_CHANGES + 1)
+                ),
             )?;
+            let byte_truncated = output.len() == MAX_SSH_OUTPUT_BYTES as usize;
+            if byte_truncated {
+                output.truncate(
+                    output
+                        .iter()
+                        .rposition(|byte| *byte == 0)
+                        .map_or(0, |position| position + 1),
+                );
+            }
             let mut changes = Vec::new();
             let mut records = output.split(|byte| *byte == 0);
             while let Some(record) = records.next() {
@@ -4946,7 +4958,7 @@ async fn git_status(roots: State<'_, Roots>, root_id: String) -> Result<Option<G
                     break;
                 }
             }
-            let changes_truncated = changes.len() > MAX_GIT_CHANGES;
+            let changes_truncated = byte_truncated || changes.len() > MAX_GIT_CHANGES;
             changes.truncate(MAX_GIT_CHANGES);
             changes.retain(|change| Path::new(&change.path).starts_with(scope));
             let base = ssh_git_base(&root, &repository)?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3004,7 +3004,7 @@ function App() {
                           className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground enabled:hover:text-foreground"
                           aria-label={selected.host ? undefined : `Open ${selected.cwd} in file browser`}
                           disabled={Boolean(selected.host)}
-                          title={hostPath(selected, selected.cwd)}
+                          title={selected.host ? hostPath(selected, selected.cwd) : undefined}
                           onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
                         />
                       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2315,11 +2315,12 @@ function App() {
   // Which repository a folder was cloned from is a fact about the folder, so it is asked for once when
   // the selection changes and never watched.
   const rootId = selected?.rootId ?? "";
+  const directory = selected?.cwd ?? "";
   useEffect(() => {
     setRemote("");
     if (!rootId) return;
     let cancelled = false;
-    void invoke<string | null>("git_remote", { rootId })
+    void invoke<string | null>("git_remote", { rootId, directory })
       .then((url) => {
         if (!cancelled) setRemote(url ?? "");
       })
@@ -2327,7 +2328,7 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [rootId]);
+  }, [directory, rootId]);
 
   async function signIn(agent: Session["agent"]) {
     setSettingsOpen(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -759,13 +759,14 @@ function groupSessions(
   const groups = new Map<string, SessionGroup>();
   for (const session of sessions) {
     const value = sessionGroupKey(session, grouping, attention, working);
+    const groupPath = grouping === "repository" ? (session.repo ?? session.cwd) : session.cwd;
     const status = grouping === "state" ? SESSION_STATUS[value as keyof typeof SESSION_STATUS] : undefined;
     const group = groups.get(value) ?? {
       name:
         grouping === "state"
           ? SESSION_STATE_LABELS[value as keyof typeof SESSION_STATE_LABELS]
           : (grouping === "directory" || grouping === "repository") && session.host
-            ? `${session.host}:${folderName(session.repo ?? session.cwd) || session.repo || session.cwd}`
+            ? `${session.host}:${folderName(groupPath) || groupPath}`
             : folderName(value) || value,
       key: `${grouping}:${value}`,
       title: status?.label ?? value,
@@ -2994,16 +2995,9 @@ function App() {
                     <TooltipContent>Switch session · {shortcutText("switchSession")}</TooltipContent>
                   </Tooltip>
                   {selected.host ? (
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <span className="block min-w-0 max-w-full truncate font-mono text-[11px] text-muted-foreground" />
-                        }
-                      >
-                        {selected.host}:{selected.cwd}
-                      </TooltipTrigger>
-                      <TooltipContent>Remote workspace</TooltipContent>
-                    </Tooltip>
+                    <span className="block min-w-0 max-w-full truncate font-mono text-[11px] text-muted-foreground">
+                      {selected.host}:{selected.cwd}
+                    </span>
                   ) : (
                     <button
                       type="button"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1624,6 +1624,7 @@ function App() {
   const receiveOutput = useRef<(sessionId: string, runId: string, data: Uint8Array) => void>(() => {});
   const recoveries = useRef(new Map<string, Promise<void>>());
   const recoveryFailures = useRef(new Set<string>());
+  const directoryUpdates = useRef(new Map<string, Promise<void>>());
   // Sessions whose worktree the user agreed to force-remove, mapped to whether the approval
   // covered real changes (true) or only ignored files and submodules (false); read at cleanup.
   const forceWorktree = useRef(new Map<string, boolean>());
@@ -2027,13 +2028,23 @@ function App() {
   const markDirectory = useCallback((sessionId: string, path: string) => {
     const session = sessionsRef.current.find((item) => item.id === sessionId);
     if (session?.agent !== "shell" || session.cwd === path) return;
-    void invoke<{ id: string; path: string }>("follow_directory", { rootId: session.rootId, path })
-      .then((grant) => {
+    const update = (directoryUpdates.current.get(sessionId) ?? Promise.resolve())
+      .then(async () => {
+        const current = sessionsRef.current.find((item) => item.id === sessionId);
+        if (!current || current.cwd === path) return;
+        const grant = await invoke<{ id: string; path: string }>("follow_directory", {
+          rootId: current.rootId,
+          path,
+        });
         setSessions((current) =>
           current.map((item) => (item.id === sessionId ? { ...item, cwd: grant.path, rootId: grant.id } : item)),
         );
       })
       .catch((reason) => setError(String(reason)));
+    directoryUpdates.current.set(sessionId, update);
+    void update.then(() => {
+      if (directoryUpdates.current.get(sessionId) === update) directoryUpdates.current.delete(sessionId);
+    });
   }, []);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2174,6 +2174,7 @@ function App() {
         runId,
         rootId: session.rootId,
         cwd: session.cwd,
+        host: session.host ?? null,
         providerSessionId: session.providerSessionId,
         agent: session.agent,
         provider: session.provider,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2027,11 +2027,14 @@ function App() {
 
   const markDirectory = useCallback((sessionId: string, path: string) => {
     const session = sessionsRef.current.find((item) => item.id === sessionId);
-    if (session?.agent !== "shell" || session.cwd === path) return;
-    const update = (directoryUpdates.current.get(sessionId) ?? Promise.resolve())
+    if (session?.agent !== "shell") return;
+    const pending = directoryUpdates.current.get(sessionId);
+    // A return to the current cwd still belongs behind an in-flight change.
+    if (!pending && session.cwd === path) return;
+    const update = (pending ?? Promise.resolve())
       .then(async () => {
         const current = sessionsRef.current.find((item) => item.id === sessionId);
-        if (!current || current.cwd === path) return;
+        if (!current) return;
         const grant = await invoke<{ id: string; path: string }>("follow_directory", {
           rootId: current.rootId,
           path,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2979,7 +2979,11 @@ function App() {
                   </Tooltip>
                   {selected.host ? (
                     <Tooltip>
-                      <TooltipTrigger render={<span className="block w-fit max-w-full truncate" />}>
+                      <TooltipTrigger
+                        render={
+                          <span className="block min-w-0 max-w-full truncate font-mono text-[11px] text-muted-foreground" />
+                        }
+                      >
                         {selected.host}:{selected.cwd}
                       </TooltipTrigger>
                       <TooltipContent>Remote workspace</TooltipContent>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -733,8 +733,11 @@ interface SessionGroup {
 }
 
 function sessionGroupKey(session: Session, grouping: SessionGrouping, attention: Set<string>, working: Set<string>) {
-  if (grouping === "repository") return session.repo ?? session.cwd;
-  if (grouping === "directory") return session.cwd;
+  if (grouping === "repository") {
+    const repository = session.repo ?? session.cwd;
+    return session.host ? `${session.host}:${repository}` : repository;
+  }
+  if (grouping === "directory") return session.host ? `${session.host}:${session.cwd}` : session.cwd;
   if (grouping === "state") {
     if (!session.running) return "disconnected";
     if (attention.has(session.id)) return "attention";
@@ -760,7 +763,9 @@ function groupSessions(
       name:
         grouping === "state"
           ? SESSION_STATE_LABELS[value as keyof typeof SESSION_STATE_LABELS]
-          : folderName(value) || value,
+          : (grouping === "directory" || grouping === "repository") && session.host
+            ? `${session.host}:${folderName(session.repo ?? session.cwd) || session.repo || session.cwd}`
+            : folderName(value) || value,
       key: `${grouping}:${value}`,
       title: status?.label ?? value,
       sessions: [],
@@ -1097,7 +1102,7 @@ function SessionSwitcher({
                   <ItemContent>
                     <ItemTitle className="w-full text-xs">{session.name}</ItemTitle>
                     <ItemDescription className="truncate font-mono text-[10px]">
-                      {shortPath(session.cwd)} · {sessionLabel(session)}
+                      {sessionPath(session)} · {sessionLabel(session)}
                     </ItemDescription>
                   </ItemContent>
                 </Item>
@@ -1429,9 +1434,9 @@ function SessionRow({
           </div>
           <div
             className="mt-0.5 block w-fit max-w-full truncate font-mono text-[10px] text-muted-foreground"
-            title={session.cwd}
+            title={session.host ? `${session.host}:${session.cwd}` : session.cwd}
           >
-            {shortPath(session.cwd)}
+            {sessionPath(session)}
           </div>
         </div>
       )}
@@ -1513,6 +1518,11 @@ function runOnStart(sessionId: string, command: string) {
 function shortPath(cwd: string) {
   const parts = cwd.split(/[\\/]/).filter(Boolean);
   return parts.slice(-2).join("/");
+}
+
+function sessionPath(session: Session) {
+  const path = shortPath(session.cwd);
+  return session.host ? `${session.host}:${path}` : path;
 }
 
 // A tab named after its folder says nothing, and several in one folder say the same nothing, so the
@@ -2318,12 +2328,11 @@ function App() {
   // Which repository a folder was cloned from is a fact about the folder, so it is asked for once when
   // the selection changes and never watched.
   const rootId = selected?.rootId ?? "";
-  const directory = selected?.cwd ?? "";
   useEffect(() => {
     setRemote("");
     if (!rootId) return;
     let cancelled = false;
-    void invoke<string | null>("git_remote", { rootId, directory })
+    void invoke<string | null>("git_remote", { rootId })
       .then((url) => {
         if (!cancelled) setRemote(url ?? "");
       })
@@ -2331,7 +2340,7 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [directory, rootId]);
+  }, [rootId]);
 
   async function signIn(agent: Session["agent"]) {
     setSettingsOpen(false);
@@ -3301,7 +3310,7 @@ function App() {
                               onRecover={() => recoverSession(session)}
                               onPrompt={(text) => {
                                 const agent = session.agent === "shell" ? commandAgent(text) : undefined;
-                                if (agent)
+                                if (agent && !session.host)
                                   void invoke("watch_shell_agent", { sessionId: session.id, agent }).catch((reason) =>
                                     console.error(`Lite could not follow the agent in session ${session.id}:`, reason),
                                   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -733,12 +733,17 @@ interface SessionGroup {
   sessions: Session[];
 }
 
+function hostPath(session: Session, path: string) {
+  return session.host ? `${session.host}:${path}` : path;
+}
+
+function sessionGroupPath(session: Session, grouping: SessionGrouping) {
+  return grouping === "repository" ? (session.repo ?? session.cwd) : session.cwd;
+}
+
 function sessionGroupKey(session: Session, grouping: SessionGrouping, attention: Set<string>, working: Set<string>) {
-  if (grouping === "repository") {
-    const repository = session.repo ?? session.cwd;
-    return session.host ? `${session.host}:${repository}` : repository;
-  }
-  if (grouping === "directory") return session.host ? `${session.host}:${session.cwd}` : session.cwd;
+  if (grouping === "repository" || grouping === "directory")
+    return hostPath(session, sessionGroupPath(session, grouping));
   if (grouping === "state") {
     if (!session.running) return "disconnected";
     if (attention.has(session.id)) return "attention";
@@ -759,15 +764,13 @@ function groupSessions(
   const groups = new Map<string, SessionGroup>();
   for (const session of sessions) {
     const value = sessionGroupKey(session, grouping, attention, working);
-    const groupPath = grouping === "repository" ? (session.repo ?? session.cwd) : session.cwd;
+    const groupPath = sessionGroupPath(session, grouping);
     const status = grouping === "state" ? SESSION_STATUS[value as keyof typeof SESSION_STATUS] : undefined;
     const group = groups.get(value) ?? {
       name:
         grouping === "state"
           ? SESSION_STATE_LABELS[value as keyof typeof SESSION_STATE_LABELS]
-          : (grouping === "directory" || grouping === "repository") && session.host
-            ? `${session.host}:${folderName(groupPath) || groupPath}`
-            : folderName(value) || value,
+          : hostPath(session, folderName(groupPath) || groupPath),
       key: `${grouping}:${value}`,
       title: status?.label ?? value,
       sessions: [],
@@ -1436,7 +1439,7 @@ function SessionRow({
           </div>
           <div
             className="mt-0.5 block w-fit max-w-full truncate font-mono text-[10px] text-muted-foreground"
-            title={session.host ? `${session.host}:${session.cwd}` : session.cwd}
+            title={hostPath(session, session.cwd)}
           >
             {sessionPath(session)}
           </div>
@@ -1523,8 +1526,7 @@ function shortPath(cwd: string) {
 }
 
 function sessionPath(session: Session) {
-  const path = shortPath(session.cwd);
-  return session.host ? `${session.host}:${path}` : path;
+  return hostPath(session, shortPath(session.cwd));
 }
 
 // A tab named after its folder says nothing, and several in one folder say the same nothing, so the
@@ -2994,28 +2996,16 @@ function App() {
                     </TooltipTrigger>
                     <TooltipContent>Switch session · {shortcutText("switchSession")}</TooltipContent>
                   </Tooltip>
-                  {selected.host ? (
-                    <span
-                      className="block min-w-0 max-w-full truncate font-mono text-[11px] text-muted-foreground"
-                      title={`${selected.host}:${selected.cwd}`}
-                    >
-                      {selected.host}:{selected.cwd}
-                    </span>
-                  ) : (
-                    <button
-                      type="button"
-                      className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground hover:text-foreground"
-                      aria-label={`Open ${selected.cwd} in file browser`}
-                      onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
-                    >
-                      <Tooltip>
-                        <TooltipTrigger render={<span className="block w-fit max-w-full truncate" />}>
-                          {selected.cwd}
-                        </TooltipTrigger>
-                        <TooltipContent>Open {selected.cwd} in file browser</TooltipContent>
-                      </Tooltip>
-                    </button>
-                  )}
+                  <button
+                    type="button"
+                    className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground enabled:hover:text-foreground"
+                    aria-label={selected.host ? undefined : `Open ${selected.cwd} in file browser`}
+                    disabled={Boolean(selected.host)}
+                    title={hostPath(selected, selected.cwd)}
+                    onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
+                  >
+                    <span className="block w-fit max-w-full truncate">{hostPath(selected, selected.cwd)}</span>
+                  </button>
                 </>
               ) : (
                 <span className="text-sm font-semibold">Lite</span>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,7 @@ import "./App.css";
 const STORAGE_KEY = "lite.sessions.v1";
 const WORKING_KEY = "lite.working.v1";
 const SESSION_VIEW_KEY = "lite.sessionView.v1";
+const REMOTE_SSH_KEY = "lite.remoteSsh.v1";
 type SessionGrouping = "none" | "repository" | "directory" | "state";
 type SessionSort = "newest" | "oldest" | "name-asc" | "name-desc" | "manual";
 const SESSION_GROUPINGS: { value: SessionGrouping; label: string }[] = [
@@ -1566,6 +1567,7 @@ function App() {
   const [fileBrowserVersion, setFileBrowserVersion] = useState(0);
   const [notifications, setNotifications] = useState(() => localStorage.getItem(NOTIFICATIONS_KEY) !== "false");
   const [keepAwake, setKeepAwake] = useState(() => localStorage.getItem(KEEP_AWAKE_KEY) === "true");
+  const [remoteSsh, setRemoteSsh] = useState(() => localStorage.getItem(REMOTE_SSH_KEY) === "true");
   const [closeWarningCount, setCloseWarningCount] = useState(0);
   const [closingApp, setClosingApp] = useState(false);
   const [closingAll, setClosingAll] = useState(false);
@@ -2169,6 +2171,11 @@ function App() {
   const changeKeepAwake = useCallback((enabled: boolean) => {
     localStorage.setItem(KEEP_AWAKE_KEY, String(enabled));
     setKeepAwake(enabled);
+  }, []);
+
+  const changeRemoteSsh = useCallback((enabled: boolean) => {
+    localStorage.setItem(REMOTE_SSH_KEY, String(enabled));
+    setRemoteSsh(enabled);
   }, []);
 
   const launch = useCallback(async (session: Session, resume: boolean, initialPrompt?: string) => {
@@ -3774,6 +3781,7 @@ function App() {
           <NewSessionDialog
             open={newSessionOpen}
             choice={newSessionChoice}
+            remoteSsh={remoteSsh}
             onOpenChange={(open) => {
               setNewSessionOpen(open);
               // A welcome tile's choice is for the dialog it opened; the next opening is the user's own.
@@ -3839,6 +3847,8 @@ function App() {
             onNotificationsChange={changeNotifications}
             keepAwake={keepAwake}
             onKeepAwakeChange={changeKeepAwake}
+            remoteSsh={remoteSsh}
+            onRemoteSshChange={changeRemoteSsh}
             theme={theme}
             onThemeChange={setTheme}
             versionBadge={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2961,19 +2961,28 @@ function App() {
                     </TooltipTrigger>
                     <TooltipContent>Switch session · {shortcutText("switchSession")}</TooltipContent>
                   </Tooltip>
-                  <button
-                    type="button"
-                    className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground hover:text-foreground"
-                    aria-label={`Open ${selected.cwd} in file browser`}
-                    onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
-                  >
+                  {selected.host ? (
                     <Tooltip>
                       <TooltipTrigger render={<span className="block w-fit max-w-full truncate" />}>
-                        {selected.cwd}
+                        {selected.host}:{selected.cwd}
                       </TooltipTrigger>
-                      <TooltipContent>Open {selected.cwd} in file browser</TooltipContent>
+                      <TooltipContent>Remote workspace</TooltipContent>
                     </Tooltip>
-                  </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground hover:text-foreground"
+                      aria-label={`Open ${selected.cwd} in file browser`}
+                      onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
+                    >
+                      <Tooltip>
+                        <TooltipTrigger render={<span className="block w-fit max-w-full truncate" />}>
+                          {selected.cwd}
+                        </TooltipTrigger>
+                        <TooltipContent>Open {selected.cwd} in file browser</TooltipContent>
+                      </Tooltip>
+                    </button>
+                  )}
                 </>
               ) : (
                 <span className="text-sm font-semibold">Lite</span>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2995,7 +2995,10 @@ function App() {
                     <TooltipContent>Switch session · {shortcutText("switchSession")}</TooltipContent>
                   </Tooltip>
                   {selected.host ? (
-                    <span className="block min-w-0 max-w-full truncate font-mono text-[11px] text-muted-foreground">
+                    <span
+                      className="block min-w-0 max-w-full truncate font-mono text-[11px] text-muted-foreground"
+                      title={`${selected.host}:${selected.cwd}`}
+                    >
                       {selected.host}:{selected.cwd}
                     </span>
                   ) : (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2996,16 +2996,23 @@ function App() {
                     </TooltipTrigger>
                     <TooltipContent>Switch session · {shortcutText("switchSession")}</TooltipContent>
                   </Tooltip>
-                  <button
-                    type="button"
-                    className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground enabled:hover:text-foreground"
-                    aria-label={selected.host ? undefined : `Open ${selected.cwd} in file browser`}
-                    disabled={Boolean(selected.host)}
-                    title={hostPath(selected, selected.cwd)}
-                    onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
-                  >
-                    <span className="block w-fit max-w-full truncate">{hostPath(selected, selected.cwd)}</span>
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          className="min-w-0 max-w-full overflow-hidden text-left font-mono text-[11px] text-muted-foreground enabled:hover:text-foreground"
+                          aria-label={selected.host ? undefined : `Open ${selected.cwd} in file browser`}
+                          disabled={Boolean(selected.host)}
+                          title={hostPath(selected, selected.cwd)}
+                          onClick={() => void invoke("open_directory", { rootId: selected.rootId })}
+                        />
+                      }
+                    >
+                      <span className="block w-fit max-w-full truncate">{hostPath(selected, selected.cwd)}</span>
+                    </TooltipTrigger>
+                    {selected.host ? null : <TooltipContent>Open {selected.cwd} in file browser</TooltipContent>}
+                  </Tooltip>
                 </>
               ) : (
                 <span className="text-sm font-semibold">Lite</span>

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1264,6 +1264,7 @@ export function clearInspectorCache(sessionId: string) {
 
 function GitPanel({
   rootId,
+  directory,
   sessionId,
   remote,
   active,
@@ -1272,6 +1273,7 @@ function GitPanel({
   onLoad,
 }: {
   rootId: string;
+  directory: string;
   sessionId: string;
   remote: string;
   active: boolean;
@@ -1350,11 +1352,11 @@ function GitPanel({
   const refresh = useCallback(async () => {
     setError("");
     try {
-      setStatus(await invoke<GitStatus | null>("git_status", { rootId }));
+      setStatus(await invoke<GitStatus | null>("git_status", { rootId, directory }));
     } catch (reason) {
       setError(String(reason));
     }
-  }, [rootId]);
+  }, [directory, rootId]);
 
   async function openDiff(path: string) {
     const request = ++diffRequest.current;
@@ -1363,7 +1365,7 @@ function GitPanel({
     setDiffError("");
     setDiffLoading(true);
     try {
-      const source = await invoke<string>("git_diff", { rootId, path });
+      const source = await invoke<string>("git_diff", { rootId, directory, path });
       if (diffRequest.current === request) setDiffSource(source);
     } catch (reason) {
       if (diffRequest.current === request) setDiffError(String(reason));
@@ -1730,6 +1732,7 @@ export const Inspector = memo(function Inspector({
               <GitPanel
                 key={`${session.rootId}:${reload.git}`}
                 rootId={session.rootId}
+                directory={session.cwd}
                 sessionId={session.id}
                 remote={remote}
                 active={tab === "git" && !collapsed}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -391,7 +391,7 @@ function FileTree({
   const [children, setChildren] = useState<Record<string, DirectoryListing & { after: DirectoryCursor | null }>>({});
   // The root is the folder the session works in; showing it shut asks for a click to say what the
   // panel is already for, so it opens with the tree it was asked to show.
-  const [expanded, setExpanded] = useState(() => new Set<string>([root]));
+  const [expanded, setExpanded] = useState(() => new Set<string>());
   const loading = useRef(new Set<string>());
   const [loadingPaths, setLoadingPaths] = useState(() => new Set<string>());
   const [expandingAll, setExpandingAll] = useState(false);

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -423,6 +423,7 @@ function FileTree({
 
   useEffect(() => {
     let mounted = true;
+    setExpanded((current) => including(current, root));
     void load(root).finally(() => {
       if (mounted) onLoad("files");
     });
@@ -968,7 +969,6 @@ function FileViewer({
 
 interface FileEditorState {
   rootId: string;
-  root: string;
   selected: FileEntry;
   source: string;
   draft: string;
@@ -995,7 +995,7 @@ function FilesPanel({
 }) {
   const [cached] = useState(() => {
     const current = fileEditorsBySession.get(sessionId);
-    if (current?.rootId === rootId && current.root === root) return current;
+    if (current?.rootId === rootId) return current;
     fileEditorsBySession.delete(sessionId);
   });
   const [selected, setSelected] = useState<FileEntry | null>(cached?.selected ?? null);
@@ -1028,7 +1028,7 @@ function FilesPanel({
       if (request.current === id) {
         setSource(contents);
         setDraft(contents);
-        fileEditorsBySession.set(sessionId, { rootId, root, selected: entry, source: contents, draft: contents });
+        fileEditorsBySession.set(sessionId, { rootId, selected: entry, source: contents, draft: contents });
       }
     } catch (reason) {
       if (request.current === id) {
@@ -1047,14 +1047,14 @@ function FilesPanel({
     await invoke("write_text_file", { rootId, path: entry.path, contents });
     if (request.current !== id) return;
     const current = fileEditorsBySession.get(sessionId);
-    if (current?.rootId === rootId && current.root === root && current.selected.path === entry.path)
+    if (current?.rootId === rootId && current.selected.path === entry.path)
       fileEditorsBySession.set(sessionId, { ...current, source: contents });
     if (selectedRef.current?.path === entry.path) setSource(contents);
   }
 
   function changeDraft(contents: string) {
     setDraft(contents);
-    if (selected) fileEditorsBySession.set(sessionId, { rootId, root, selected, source, draft: contents });
+    if (selected) fileEditorsBySession.set(sessionId, { rootId, selected, source, draft: contents });
   }
 
   function closeFile() {
@@ -1265,7 +1265,6 @@ export function clearInspectorCache(sessionId: string) {
 
 function GitPanel({
   rootId,
-  directory,
   sessionId,
   remote,
   active,
@@ -1274,7 +1273,6 @@ function GitPanel({
   onLoad,
 }: {
   rootId: string;
-  directory: string;
   sessionId: string;
   remote: string;
   active: boolean;
@@ -1353,11 +1351,11 @@ function GitPanel({
   const refresh = useCallback(async () => {
     setError("");
     try {
-      setStatus(await invoke<GitStatus | null>("git_status", { rootId, directory }));
+      setStatus(await invoke<GitStatus | null>("git_status", { rootId }));
     } catch (reason) {
       setError(String(reason));
     }
-  }, [directory, rootId]);
+  }, [rootId]);
 
   async function openDiff(path: string) {
     const request = ++diffRequest.current;
@@ -1366,7 +1364,7 @@ function GitPanel({
     setDiffError("");
     setDiffLoading(true);
     try {
-      const source = await invoke<string>("git_diff", { rootId, directory, path });
+      const source = await invoke<string>("git_diff", { rootId, path });
       if (diffRequest.current === request) setDiffSource(source);
     } catch (reason) {
       if (diffRequest.current === request) setDiffError(String(reason));
@@ -1453,6 +1451,7 @@ function GitPanel({
 
 // Each harness and provider reports what it reports; Lite never fills the gap with a number of its own.
 function missingUsage(session: Session): string {
+  if (session.host) return "Remote sessions report no provider usage.";
   if (session.agent === "shell") return "Shell sessions report no provider usage.";
   if (session.agent === "codex" && session.provider && session.provider !== "openai")
     return `${providerLabel(session.provider)} publishes no account limits locally. Session context appears after the first response.`;
@@ -1479,6 +1478,7 @@ function UsagePanel({
       agent: session.agent,
       provider: session.provider,
       sessionId: session.id,
+      host: session.host,
     })
       .then((next) => {
         if (!disposed) {
@@ -1495,7 +1495,7 @@ function UsagePanel({
     return () => {
       disposed = true;
     };
-  }, [onLoad, session.agent, session.provider, session.id]);
+  }, [onLoad, session.agent, session.provider, session.id, session.host]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -1717,7 +1717,7 @@ export const Inspector = memo(function Inspector({
           {visited.has("files") ? (
             <TabsContent value="files" keepMounted className="min-h-0 overflow-hidden">
               <FilesPanel
-                key={`${session.rootId}:${session.cwd}:${reload.files}`}
+                key={`${session.rootId}:${reload.files}`}
                 root={session.cwd}
                 rootId={session.rootId}
                 sessionId={session.id}
@@ -1731,9 +1731,8 @@ export const Inspector = memo(function Inspector({
           {visited.has("git") ? (
             <TabsContent value="git" keepMounted className="min-h-0 overflow-hidden">
               <GitPanel
-                key={`${session.rootId}:${session.cwd}:${reload.git}`}
+                key={`${session.rootId}:${reload.git}`}
                 rootId={session.rootId}
-                directory={session.cwd}
                 sessionId={session.id}
                 remote={remote}
                 active={tab === "git" && !collapsed}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -968,6 +968,7 @@ function FileViewer({
 
 interface FileEditorState {
   rootId: string;
+  root: string;
   selected: FileEntry;
   source: string;
   draft: string;
@@ -994,7 +995,7 @@ function FilesPanel({
 }) {
   const [cached] = useState(() => {
     const current = fileEditorsBySession.get(sessionId);
-    if (current?.rootId === rootId) return current;
+    if (current?.rootId === rootId && current.root === root) return current;
     fileEditorsBySession.delete(sessionId);
   });
   const [selected, setSelected] = useState<FileEntry | null>(cached?.selected ?? null);
@@ -1027,7 +1028,7 @@ function FilesPanel({
       if (request.current === id) {
         setSource(contents);
         setDraft(contents);
-        fileEditorsBySession.set(sessionId, { rootId, selected: entry, source: contents, draft: contents });
+        fileEditorsBySession.set(sessionId, { rootId, root, selected: entry, source: contents, draft: contents });
       }
     } catch (reason) {
       if (request.current === id) {
@@ -1046,14 +1047,14 @@ function FilesPanel({
     await invoke("write_text_file", { rootId, path: entry.path, contents });
     if (request.current !== id) return;
     const current = fileEditorsBySession.get(sessionId);
-    if (current?.rootId === rootId && current.selected.path === entry.path)
+    if (current?.rootId === rootId && current.root === root && current.selected.path === entry.path)
       fileEditorsBySession.set(sessionId, { ...current, source: contents });
     if (selectedRef.current?.path === entry.path) setSource(contents);
   }
 
   function changeDraft(contents: string) {
     setDraft(contents);
-    if (selected) fileEditorsBySession.set(sessionId, { rootId, selected, source, draft: contents });
+    if (selected) fileEditorsBySession.set(sessionId, { rootId, root, selected, source, draft: contents });
   }
 
   function closeFile() {
@@ -1716,7 +1717,7 @@ export const Inspector = memo(function Inspector({
           {visited.has("files") ? (
             <TabsContent value="files" keepMounted className="min-h-0 overflow-hidden">
               <FilesPanel
-                key={`${session.rootId}:${reload.files}`}
+                key={`${session.rootId}:${session.cwd}:${reload.files}`}
                 root={session.cwd}
                 rootId={session.rootId}
                 sessionId={session.id}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1730,7 +1730,7 @@ export const Inspector = memo(function Inspector({
           {visited.has("git") ? (
             <TabsContent value="git" keepMounted className="min-h-0 overflow-hidden">
               <GitPanel
-                key={`${session.rootId}:${reload.git}`}
+                key={`${session.rootId}:${session.cwd}:${reload.git}`}
                 rootId={session.rootId}
                 directory={session.cwd}
                 sessionId={session.id}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -405,6 +405,7 @@ export function NewSessionDialog({
               <Switch
                 id="remote-workspace"
                 checked={remote}
+                disabled={creating}
                 onCheckedChange={(checked) => {
                   localStorage.setItem(REMOTE_KEY, String(checked));
                   if (directory) void invoke("revoke_directory", { rootId: directory.id });

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -32,6 +32,8 @@ const DEEPSEEK_MODEL_KEY = "lite.newSession.deepseekModel.v1";
 const DEEPSEEK_REASONING_KEY = "lite.newSession.deepseekReasoning.v1";
 const NAME_KEY = "lite.newSession.name.v1";
 const WORKTREE_KEY = "lite.newSession.worktree.v1";
+const REMOTE_KEY = "lite.newSession.remote.v1";
+const SSH_HOST_KEY = "lite.newSession.sshHost.v1";
 const DEEPSEEK_MODELS = [
   { value: "deepseek-v4-flash", label: "Flash" },
   { value: "deepseek-v4-pro", label: "Pro" },
@@ -61,6 +63,7 @@ const SECTION = "text-[11px] font-medium tracking-wide text-muted-foreground upp
 interface DirectoryGrant {
   id: string;
   path: string;
+  host: string | null;
 }
 
 interface Repository {
@@ -107,6 +110,8 @@ export function NewSessionDialog({
   });
   const [directory, setDirectory] = useState<DirectoryGrant>();
   const [path, setPath] = useState("");
+  const [remote, setRemote] = useState(() => localStorage.getItem(REMOTE_KEY) === "true");
+  const [host, setHost] = useState(() => localStorage.getItem(SSH_HOST_KEY) ?? "");
   const [availability, setAvailability] = useState<Record<string, Availability>>({});
   const [auth, setAuth] = useState<ProviderAuth[]>();
   const [installing, setInstalling] = useState("");
@@ -131,11 +136,11 @@ export function NewSessionDialog({
     if (isOpen && chosen) setChoiceId(chosen);
   }, [isOpen, chosen]);
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
-  const missing = status && !status.available ? status : undefined;
+  const missing = !remote && status && !status.available ? status : undefined;
   // The first explicit open asks every harness in parallel. The answer is kept for this app run, so
   // reopening the dialog does not repeat five version processes and five network requests.
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || remote) return;
     let disposed = false;
     void checkAgentUpdates().then((result) => {
       if (!disposed) setUpdates(result);
@@ -143,7 +148,7 @@ export function NewSessionDialog({
     return () => {
       disposed = true;
     };
-  }, [isOpen]);
+  }, [isOpen, remote]);
 
   // A typed path settles for a moment before it is probed, so a folder is never looked up once per
   // keystroke. The probe is read-only and needs no grant: it asks git about the folder the grant
@@ -152,6 +157,12 @@ export function NewSessionDialog({
     if (!isOpen || !path.trim()) {
       setRepo(null);
       setFolder("checking");
+      setWorktree("");
+      return;
+    }
+    if (remote) {
+      setFolder("directory");
+      setRepo(null);
       setWorktree("");
       return;
     }
@@ -179,7 +190,7 @@ export function NewSessionDialog({
       disposed = true;
       window.clearTimeout(probe);
     };
-  }, [isOpen, path]);
+  }, [isOpen, path, remote]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -187,36 +198,39 @@ export function NewSessionDialog({
     setError("");
     setAvailability({});
     setAuth(undefined);
-    void invoke<DirectoryGrant | null>("default_directory")
-      .then((selected) => {
-        if (disposed && selected) void invoke("revoke_directory", { rootId: selected.id });
-        else if (selected) {
-          setDirectory(selected);
-          setPath(selected.path);
-        }
-      })
-      .catch((reason) => {
-        if (!disposed) setError(String(reason));
-      });
-    void invoke<ProviderAuth[]>("provider_auth")
-      .then((result) => {
-        if (!disposed) setAuth(result);
-      })
-      .catch((reason) => {
-        if (!disposed) setError(String(reason));
-      });
-    // Installation and provider setup can change while the app runs, so refresh them on each open.
-    for (const option of SESSION_CHOICES) {
-      void invoke<Availability>("agent_availability", { agent: option.agent, provider: option.provider })
-        .then((result) => {
-          if (!disposed) setAvailability((current) => ({ ...current, [option.id]: result }));
+    if (!remote)
+      void invoke<DirectoryGrant | null>("default_directory")
+        .then((selected) => {
+          if (disposed && selected) void invoke("revoke_directory", { rootId: selected.id });
+          else if (selected) {
+            setDirectory(selected);
+            setPath(selected.path);
+          }
         })
-        .catch(() => {});
+        .catch((reason) => {
+          if (!disposed) setError(String(reason));
+        });
+    if (!remote) {
+      void invoke<ProviderAuth[]>("provider_auth")
+        .then((result) => {
+          if (!disposed) setAuth(result);
+        })
+        .catch((reason) => {
+          if (!disposed) setError(String(reason));
+        });
+      // Installation and provider setup can change while the app runs, so refresh them on each open.
+      for (const option of SESSION_CHOICES) {
+        void invoke<Availability>("agent_availability", { agent: option.agent, provider: option.provider })
+          .then((result) => {
+            if (!disposed) setAvailability((current) => ({ ...current, [option.id]: result }));
+          })
+          .catch(() => {});
+      }
     }
     return () => {
       disposed = true;
     };
-  }, [isOpen]);
+  }, [isOpen, remote]);
 
   async function chooseFolder() {
     setError("");
@@ -236,9 +250,13 @@ export function NewSessionDialog({
   }
 
   async function grant(): Promise<DirectoryGrant | undefined> {
-    if (directory && directory.path === path.trim()) return directory;
+    if (directory && directory.path === path.trim() && directory.host === (remote ? host.trim() : null))
+      return directory;
     try {
-      const selected = await invoke<DirectoryGrant>("use_directory", { path });
+      const selected = await invoke<DirectoryGrant>(remote ? "use_ssh_directory" : "use_directory", {
+        path,
+        ...(remote ? { host: host.trim() } : {}),
+      });
       if (directory) void invoke("revoke_directory", { rootId: directory.id });
       setDirectory(selected);
       setPath(selected.path);
@@ -269,13 +287,14 @@ export function NewSessionDialog({
       let worktree = false;
       // The probe's answer can lag the folder field, so the granted folder is asked directly:
       // the worktree and the recorded repository always describe where the session will run.
-      let root: string | null;
-      try {
-        root = (await invoke<DirectoryProbe>("directory_probe", { path: folder.path })).repository?.root ?? null;
-      } catch (reason) {
-        setError(String(reason));
-        return;
-      }
+      let root: string | null = null;
+      if (!remote)
+        try {
+          root = (await invoke<DirectoryProbe>("directory_probe", { path: folder.path })).repository?.root ?? null;
+        } catch (reason) {
+          setError(String(reason));
+          return;
+        }
       // The toggle must still describe this folder: root === repo fails when the folder changed
       // after the probe that enabled the option, and a worktree is never made on a stale answer.
       if (root && root === repo && worktreeOn) {
@@ -298,6 +317,7 @@ export function NewSessionDialog({
         model: choice.provider === "deepseek" ? deepseekModel : undefined,
         reasoningEffort: choice.provider === "deepseek" ? deepseekReasoning : undefined,
         cwd: folder.path,
+        host: folder.host ?? undefined,
         rootId: folder.id,
         name: name || defaultSessionName(folder.path),
         running: false,
@@ -350,8 +370,9 @@ export function NewSessionDialog({
   // Everything the dialog can be asked for arrives here: the submit button, Enter from the folder field,
   // and a second click on the agent already chosen. An agent that is not installed reads them all as a
   // request to install it, which is the only one of the two it can answer.
-  const folderReady =
-    path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim());
+  const folderReady = remote
+    ? host.trim() && path.trim()
+    : path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim());
   const ready = !installing && !creating && Boolean(missing || folderReady);
   function start() {
     if (missing?.installable) void install();
@@ -376,6 +397,43 @@ export function NewSessionDialog({
             <DialogDescription>Pick a project folder, then choose the agent that should work in it.</DialogDescription>
           </DialogHeader>
           <DialogBody className="min-w-0 space-y-4">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="remote-workspace" className={SECTION}>
+                Remote SSH
+              </Label>
+              <Switch
+                id="remote-workspace"
+                checked={remote}
+                onCheckedChange={(checked) => {
+                  localStorage.setItem(REMOTE_KEY, String(checked));
+                  if (directory) void invoke("revoke_directory", { rootId: directory.id });
+                  setDirectory(undefined);
+                  setPath("");
+                  setRemote(checked);
+                }}
+              />
+            </div>
+            {remote ? (
+              <div className="space-y-1.5">
+                <Label htmlFor="ssh-host" className={SECTION}>
+                  SSH host
+                </Label>
+                <Input
+                  id="ssh-host"
+                  value={host}
+                  className="font-mono"
+                  placeholder="user@server or SSH config name"
+                  name="ssh-host"
+                  autoComplete="off"
+                  spellCheck={false}
+                  onChange={(event) => {
+                    setHost(event.target.value);
+                    localStorage.setItem(SSH_HOST_KEY, event.target.value);
+                  }}
+                />
+                <p className="text-xs text-muted-foreground">Uses your SSH config and agent sign-in on the server.</p>
+              </div>
+            ) : null}
             <div className="space-y-1.5">
               <Label htmlFor="project-folder" className={SECTION}>
                 Project folder
@@ -386,7 +444,7 @@ export function NewSessionDialog({
                     id="project-folder"
                     value={path}
                     className={`pr-8 font-mono ${folder === "directory" ? "border-success focus-visible:border-success focus-visible:ring-success/20" : folder === "missing" ? "border-amber-500 focus-visible:border-amber-500 focus-visible:ring-amber-500/20" : ""}`}
-                    placeholder="Type or choose a project folder…"
+                    placeholder={remote ? "/home/user/project" : "Type or choose a project folder…"}
                     name="project-folder"
                     autoComplete="off"
                     aria-invalid={folder === "other" || undefined}
@@ -422,6 +480,7 @@ export function NewSessionDialog({
                   size="icon"
                   tooltip="Browse"
                   aria-label="Browse for a folder"
+                  disabled={remote}
                   onClick={() => void chooseFolder()}
                 >
                   <FolderOpen />
@@ -551,7 +610,11 @@ export function NewSessionDialog({
                           className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : updatable ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
                         >
                           <span className="block truncate">{sessionLabel(option)}</span>
-                          {state && !state.available ? (
+                          {remote ? (
+                            <span className="block truncate text-xs font-normal text-muted-foreground">
+                              Runs on {host.trim() || "SSH host"}
+                            </span>
+                          ) : state && !state.available ? (
                             <span className="block truncate text-xs font-normal text-muted-foreground">
                               {state.installable ? "Not installed" : "Setup required"}
                             </span>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -442,7 +442,9 @@ export function NewSessionDialog({
                     localStorage.setItem(SSH_HOST_KEY, event.target.value);
                   }}
                 />
-                <p className="text-xs text-muted-foreground">Uses your SSH config and agent sign-in on the server.</p>
+                <p className="text-xs text-muted-foreground">
+                  Uses your SSH config and agent sign-in on the Linux server.
+                </p>
               </div>
             ) : null}
             <div className="space-y-1.5">

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -169,7 +169,7 @@ export function NewSessionDialog({
       return;
     }
     if (remote) {
-      setFolder("directory");
+      setFolder("checking");
       setRepo(null);
       setWorktree("");
       return;

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -42,6 +42,10 @@ type DeepSeekModel = (typeof DEEPSEEK_MODELS)[number]["value"];
 const DEEPSEEK_REASONING = ["low", "high", "max"] as const;
 type DeepSeekReasoning = (typeof DEEPSEEK_REASONING)[number];
 
+function remoteUnsupported(remote: boolean, choice: (typeof SESSION_CHOICES)[number]) {
+  return remote && choice.agent === "codex" && choice.provider !== "openai";
+}
+
 let updateChecks: Promise<Record<string, boolean | null>> | undefined;
 
 function checkAgentUpdates() {
@@ -131,7 +135,7 @@ export function NewSessionDialog({
     localStorage.getItem(NAME_KEY) === "true" ? "" : undefined,
   );
   const choice = SESSION_CHOICES.find((option) => option.id === choiceId) ?? SESSION_CHOICES[0];
-  const remoteUnsupported = remote && choice.agent === "codex" && choice.provider !== "openai";
+  const unsupported = remoteUnsupported(remote, choice);
   const status = availability[choice.id];
   useEffect(() => {
     if (isOpen && chosen) setChoiceId(chosen);
@@ -374,7 +378,7 @@ export function NewSessionDialog({
   const folderReady = remote
     ? host.trim() && path.trim()
     : path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim());
-  const ready = !remoteUnsupported && !installing && !creating && Boolean(missing || folderReady);
+  const ready = !unsupported && !installing && !creating && Boolean(missing || folderReady);
   function start() {
     if (missing?.installable) void install();
     else if (missing)
@@ -570,7 +574,7 @@ export function NewSessionDialog({
               <div className="grid min-w-0 grid-cols-2 gap-2">
                 {SESSION_CHOICES.map((option) => {
                   const active = choiceId === option.id;
-                  const unsupported = remote && option.agent === "codex" && option.provider !== "openai";
+                  const unsupported = remoteUnsupported(remote, option);
                   const deepseek = option.id === "deepseek";
                   const state = availability[option.id];
                   const update = updates[option.agent];

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -131,6 +131,7 @@ export function NewSessionDialog({
     localStorage.getItem(NAME_KEY) === "true" ? "" : undefined,
   );
   const choice = SESSION_CHOICES.find((option) => option.id === choiceId) ?? SESSION_CHOICES[0];
+  const remoteUnsupported = remote && choice.agent === "codex" && choice.provider !== "openai";
   const status = availability[choice.id];
   useEffect(() => {
     if (isOpen && chosen) setChoiceId(chosen);
@@ -373,7 +374,7 @@ export function NewSessionDialog({
   const folderReady = remote
     ? host.trim() && path.trim()
     : path.trim() && folder !== "other" && status && repo !== undefined && (!repo || !worktreeOn || branch.trim());
-  const ready = !installing && !creating && Boolean(missing || folderReady);
+  const ready = !remoteUnsupported && !installing && !creating && Boolean(missing || folderReady);
   function start() {
     if (missing?.installable) void install();
     else if (missing)
@@ -568,6 +569,7 @@ export function NewSessionDialog({
               <div className="grid min-w-0 grid-cols-2 gap-2">
                 {SESSION_CHOICES.map((option) => {
                   const active = choiceId === option.id;
+                  const unsupported = remote && option.agent === "codex" && option.provider !== "openai";
                   const deepseek = option.id === "deepseek";
                   const state = availability[option.id];
                   const update = updates[option.agent];
@@ -595,7 +597,7 @@ export function NewSessionDialog({
                         variant={active && !deepseek ? "secondary" : active ? "ghost" : "outline"}
                         className={`h-14 w-full min-w-0 justify-start overflow-hidden pl-3 ${action ? "pr-11" : "pr-3"} ${active && deepseek ? "rounded-b-none" : ""}`}
                         aria-pressed={active}
-                        disabled={Boolean(installing)}
+                        disabled={Boolean(installing) || unsupported}
                         title={"note" in option ? option.note : sessionLabel(option)}
                         onClick={() => {
                           if (active && ready) start();
@@ -610,7 +612,11 @@ export function NewSessionDialog({
                           className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : updatable ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
                         >
                           <span className="block truncate">{sessionLabel(option)}</span>
-                          {remote ? (
+                          {unsupported ? (
+                            <span className="block truncate text-xs font-normal text-muted-foreground">
+                              Local workspace only
+                            </span>
+                          ) : remote ? (
                             <span className="block truncate text-xs font-normal text-muted-foreground">
                               Runs on {host.trim() || "SSH host"}
                             </span>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -162,15 +162,9 @@ export function NewSessionDialog({
   // keystroke. The probe is read-only and needs no grant: it asks git about the folder the grant
   // would name.
   useEffect(() => {
-    if (!isOpen || !path.trim()) {
+    if (!isOpen || remote || !path.trim()) {
       setRepo(null);
       setFolder("checking");
-      setWorktree("");
-      return;
-    }
-    if (remote) {
-      setFolder("checking");
-      setRepo(null);
       setWorktree("");
       return;
     }
@@ -206,7 +200,7 @@ export function NewSessionDialog({
     setError("");
     setAvailability({});
     setAuth(undefined);
-    if (!remote)
+    if (!remote) {
       void invoke<DirectoryGrant | null>("default_directory")
         .then((selected) => {
           if (disposed && selected) void invoke("revoke_directory", { rootId: selected.id });
@@ -218,7 +212,6 @@ export function NewSessionDialog({
         .catch((reason) => {
           if (!disposed) setError(String(reason));
         });
-    if (!remote) {
       void invoke<ProviderAuth[]>("provider_auth")
         .then((result) => {
           if (!disposed) setAuth(result);

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -725,7 +725,7 @@ export function NewSessionDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={!ready}>
-              {!status || (installing && missing?.installable) ? <Spinner /> : null}
+              {(!remote && !status) || (installing && missing?.installable) ? <Spinner /> : null}
               {installing && missing?.installable
                 ? `Installing ${sessionLabel(choice)}…`
                 : missing?.installable

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -436,7 +436,8 @@ export function NewSessionDialog({
                   }}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Uses your SSH config and agent sign-in on the Linux server.
+                  Uses your SSH config and agent sign-in on the Linux server. Connect once from a terminal first; key
+                  authentication must be non-interactive.
                 </p>
               </div>
             ) : null}

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -91,12 +91,14 @@ interface Availability {
 export function NewSessionDialog({
   open: isOpen,
   choice: chosen,
+  remoteSsh,
   onOpenChange,
   onCreate,
 }: {
   open: boolean;
   // A choice made outside the dialog — a welcome tile — which the dialog opens on.
   choice?: string;
+  remoteSsh: boolean;
   onOpenChange: (open: boolean) => void;
   onCreate: (session: Session) => void;
 }) {
@@ -114,7 +116,8 @@ export function NewSessionDialog({
   });
   const [directory, setDirectory] = useState<DirectoryGrant>();
   const [path, setPath] = useState("");
-  const [remote, setRemote] = useState(() => localStorage.getItem(REMOTE_KEY) === "true");
+  const [remoteSelected, setRemoteSelected] = useState(() => localStorage.getItem(REMOTE_KEY) === "true");
+  const remote = remoteSsh && remoteSelected;
   const [host, setHost] = useState(() => localStorage.getItem(SSH_HOST_KEY) ?? "");
   const [availability, setAvailability] = useState<Record<string, Availability>>({});
   const [auth, setAuth] = useState<ProviderAuth[]>();
@@ -402,23 +405,25 @@ export function NewSessionDialog({
             <DialogDescription>Pick a project folder, then choose the agent that should work in it.</DialogDescription>
           </DialogHeader>
           <DialogBody className="min-w-0 space-y-4">
-            <div className="flex items-center gap-2">
-              <Label htmlFor="remote-workspace" className={SECTION}>
-                Remote SSH
-              </Label>
-              <Switch
-                id="remote-workspace"
-                checked={remote}
-                disabled={creating}
-                onCheckedChange={(checked) => {
-                  localStorage.setItem(REMOTE_KEY, String(checked));
-                  if (directory) void invoke("revoke_directory", { rootId: directory.id });
-                  setDirectory(undefined);
-                  setPath("");
-                  setRemote(checked);
-                }}
-              />
-            </div>
+            {remoteSsh ? (
+              <div className="flex items-center gap-2">
+                <Label htmlFor="remote-workspace" className={SECTION}>
+                  Remote SSH
+                </Label>
+                <Switch
+                  id="remote-workspace"
+                  checked={remote}
+                  disabled={creating}
+                  onCheckedChange={(checked) => {
+                    localStorage.setItem(REMOTE_KEY, String(checked));
+                    if (directory) void invoke("revoke_directory", { rootId: directory.id });
+                    setDirectory(undefined);
+                    setPath("");
+                    setRemoteSelected(checked);
+                  }}
+                />
+              </div>
+            ) : null}
             {remote ? (
               <div className="space-y-1.5">
                 <Label htmlFor="ssh-host" className={SECTION}>

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -617,17 +617,15 @@ export function NewSessionDialog({
                           className={`min-w-0 flex-1 text-left ${managed && update === false ? "[&_[data-slot=item-description]_svg]:text-green-600 dark:[&_[data-slot=item-description]_svg]:text-green-400" : updatable ? "[&_[data-slot=item-description]_svg]:text-amber-600 dark:[&_[data-slot=item-description]_svg]:text-amber-400" : ""}`}
                         >
                           <span className="block truncate">{sessionLabel(option)}</span>
-                          {unsupported ? (
+                          {unsupported || remote || (state && !state.available) ? (
                             <span className="block truncate text-xs font-normal text-muted-foreground">
-                              Local workspace only
-                            </span>
-                          ) : remote ? (
-                            <span className="block truncate text-xs font-normal text-muted-foreground">
-                              Runs on {host.trim() || "SSH host"}
-                            </span>
-                          ) : state && !state.available ? (
-                            <span className="block truncate text-xs font-normal text-muted-foreground">
-                              {state.installable ? "Not installed" : "Setup required"}
+                              {unsupported
+                                ? "Local workspace only"
+                                : remote
+                                  ? `Runs on ${host.trim() || "SSH host"}`
+                                  : state?.installable
+                                    ? "Not installed"
+                                    : "Setup required"}
                             </span>
                           ) : authProvider ? (
                             <ProviderAuthDescription provider={authProvider} status={authStatus} />

--- a/src/settings-dialog.tsx
+++ b/src/settings-dialog.tsx
@@ -14,6 +14,7 @@ import {
   Moon,
   RefreshCw,
   RotateCcw,
+  Server,
   SlidersHorizontal,
   Sun,
   Trash2,
@@ -149,6 +150,8 @@ export function SettingsDialog({
   onNotificationsChange,
   keepAwake,
   onKeepAwakeChange,
+  remoteSsh,
+  onRemoteSshChange,
   theme,
   onThemeChange,
   versionBadge,
@@ -165,6 +168,8 @@ export function SettingsDialog({
   onNotificationsChange: (enabled: boolean) => Promise<void>;
   keepAwake: boolean;
   onKeepAwakeChange: (enabled: boolean) => void;
+  remoteSsh: boolean;
+  onRemoteSshChange: (enabled: boolean) => void;
   theme: Theme;
   onThemeChange: (theme: Theme) => void;
   versionBadge: ReactNode;
@@ -330,6 +335,18 @@ export function SettingsDialog({
                   </ItemContent>
                   <ItemActions>
                     <Switch aria-label="Keep system awake" checked={keepAwake} onCheckedChange={onKeepAwakeChange} />
+                  </ItemActions>
+                </Item>
+                <Item variant="outline">
+                  <ItemMedia variant="icon">
+                    <Server />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>Remote SSH</ItemTitle>
+                    <ItemDescription>Show Remote SSH workspaces when creating a session.</ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Switch aria-label="Remote SSH" checked={remoteSsh} onCheckedChange={onRemoteSshChange} />
                   </ItemActions>
                 </Item>
                 {notificationsSupported ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export interface Session {
   // A name the user typed is theirs, so nothing the session says about itself overwrites it again.
   renamed?: boolean;
   cwd: string;
+  // Present when the root lives on an SSH host while Lite's interface stays local.
+  host?: string;
   rootId: string;
   running: boolean;
   providerSessionId?: string;


### PR DESCRIPTION
## Summary

- add SSH-backed workspace grants alongside local folder grants
- run terminals and supported coding agents on the selected Linux host
- route Files and Git inspection/editing through bounded, scoped SSH commands
- keep authentication with the user's SSH config and remote CLI sign-in

## Validation

- Checked 50 files in 45ms. No fixes applied.
- vite v8.2.1 building client environment for production...
[2Ktransforming...✓ 2936 modules transformed.
rendering chunks...
computing gzip size...
dist/assets/vercel-7qFLBAX3.svg                       0.10 kB │ gzip:   0.12 kB
dist/assets/npm-B9KN-Ntj.svg                          0.13 kB │ gzip:   0.14 kB
dist/assets/favicon-5k2L6pP5.svg                      0.14 kB │ gzip:   0.14 kB
dist/assets/uv-F8wIEKlh.svg                           0.14 kB │ gzip:   0.14 kB
dist/assets/vim-Dls2bNAn.svg                          0.15 kB │ gzip:   0.15 kB
dist/assets/terraform-BlPcYaG6.svg                    0.16 kB │ gzip:   0.14 kB
dist/assets/markdown-CpukAbx0.svg                     0.16 kB │ gzip:   0.15 kB
dist/assets/mdx-BtBWUBcH.svg                          0.16 kB │ gzip:   0.15 kB
dist/assets/font-BRNRC2Ch.svg                         0.16 kB │ gzip:   0.14 kB
dist/assets/ruff-kgacv5ZG.svg                         0.17 kB │ gzip:   0.15 kB
dist/assets/disc-KZKi35ao.svg                         0.17 kB │ gzip:   0.15 kB
dist/assets/key-COm7LFld.svg                          0.17 kB │ gzip:   0.16 kB
dist/assets/exe-GVF74Ms1.svg                          0.17 kB │ gzip:   0.15 kB
dist/assets/toml-ZLHWK_sx.svg                         0.18 kB │ gzip:   0.16 kB
dist/assets/audio-Bywf1Co-.svg                        0.18 kB │ gzip:   0.16 kB
dist/assets/h-BHMofc-S.svg                            0.18 kB │ gzip:   0.16 kB
dist/assets/video-B_X_LvvN.svg                        0.19 kB │ gzip:   0.15 kB
dist/assets/yaml-BZ3ilcHv.svg                         0.19 kB │ gzip:   0.17 kB
dist/assets/java-BoeaJ1Gf.svg                         0.20 kB │ gzip:   0.17 kB
dist/assets/javaclass-BcpaDqY_.svg                    0.20 kB │ gzip:   0.17 kB
dist/assets/solidity-L_2RId-b.svg                     0.21 kB │ gzip:   0.16 kB
dist/assets/readme-CRQaYHSO.svg                       0.21 kB │ gzip:   0.17 kB
dist/assets/pnpm-yTf4SVeA.svg                         0.22 kB │ gzip:   0.15 kB
dist/assets/console-D3K9rxA0.svg                      0.22 kB │ gzip:   0.18 kB
dist/assets/folder-DwAapo2z.svg                       0.22 kB │ gzip:   0.17 kB
dist/assets/license-xAqV9Xi9.svg                      0.22 kB │ gzip:   0.17 kB
dist/assets/fortran-CP3ZdKVq.svg                      0.23 kB │ gzip:   0.18 kB
dist/assets/zip-Dw2p3C1u.svg                          0.23 kB │ gzip:   0.17 kB
dist/assets/hpp-1fokgAwc.svg                          0.23 kB │ gzip:   0.19 kB
dist/assets/html-C5jflT5q.svg                         0.23 kB │ gzip:   0.19 kB
dist/assets/document-DC-WjD_F.svg                     0.23 kB │ gzip:   0.19 kB
dist/assets/log-PUd3bLPV.svg                          0.23 kB │ gzip:   0.20 kB
dist/assets/c-DSMamfmd.svg                            0.24 kB │ gzip:   0.18 kB
dist/assets/objective-c-D9CspH-N.svg                  0.24 kB │ gzip:   0.18 kB
dist/assets/lock-CXdZHto3.svg                         0.24 kB │ gzip:   0.18 kB
dist/assets/word-CFvm8uAr.svg                         0.25 kB │ gzip:   0.20 kB
dist/assets/webassembly-BMgXNvua.svg                  0.25 kB │ gzip:   0.19 kB
dist/assets/zig-CwGkQIG3.svg                          0.25 kB │ gzip:   0.19 kB
dist/assets/vue-DJBoCu9j.svg                          0.25 kB │ gzip:   0.20 kB
dist/assets/gemfile-BBynEIXH.svg                      0.26 kB │ gzip:   0.20 kB
dist/assets/codeowners-D6jwx6Op.svg                   0.26 kB │ gzip:   0.20 kB
dist/assets/typescript-D_U-p-G1.svg                   0.26 kB │ gzip:   0.18 kB
dist/assets/table-D7AWR19h.svg                        0.26 kB │ gzip:   0.20 kB
dist/assets/tune-9adzML3q.svg                         0.26 kB │ gzip:   0.17 kB
dist/assets/hex-DmlOiWGa.svg                          0.27 kB │ gzip:   0.20 kB
dist/assets/folder-open-CyEp7Dg1.svg                  0.27 kB │ gzip:   0.19 kB
dist/assets/next-CCXOG12z.svg                         0.27 kB │ gzip:   0.19 kB
dist/assets/typescript-def-DriBH7_f.svg               0.27 kB │ gzip:   0.19 kB
dist/assets/jar-DFsnj_df.svg                          0.28 kB │ gzip:   0.18 kB
dist/assets/certificate-Itcn-kkw.svg                  0.28 kB │ gzip:   0.20 kB
dist/assets/julia-DJIRuqFZ.svg                        0.28 kB │ gzip:   0.19 kB
dist/assets/onnx-LOzSMtGs.svg                         0.28 kB │ gzip:   0.19 kB
dist/assets/tailwindcss-E29z3cu4.svg                  0.28 kB │ gzip:   0.19 kB
dist/assets/lib-BSLl2hIz.svg                          0.28 kB │ gzip:   0.21 kB
dist/assets/poetry-BzkVVJUz.svg                       0.28 kB │ gzip:   0.19 kB
dist/assets/elixir-swoXiCa5.svg                       0.29 kB │ gzip:   0.21 kB
dist/assets/xml-C-Q_MfUP.svg                          0.29 kB │ gzip:   0.21 kB
dist/assets/javascript-DN_vk0so.svg                   0.29 kB │ gzip:   0.18 kB
dist/assets/folder-kotlin-CDP7ZEGR.svg                0.29 kB │ gzip:   0.21 kB
dist/assets/proto-BKheaoud.svg                        0.29 kB │ gzip:   0.17 kB
dist/assets/contributing-SBExBaCT.svg                 0.30 kB │ gzip:   0.21 kB
dist/assets/diff-C38PglOG.svg                         0.30 kB │ gzip:   0.23 kB
dist/assets/folder-home-LOjDJaus.svg                  0.30 kB │ gzip:   0.21 kB
dist/assets/folder-ui-ClHv1ed-.svg                    0.30 kB │ gzip:   0.22 kB
dist/assets/biome-C4m9PMtY.svg                        0.31 kB │ gzip:   0.23 kB
dist/assets/conduct-BkB2tjgj.svg                      0.31 kB │ gzip:   0.21 kB
dist/assets/folder-download-B_nR3Fos.svg              0.31 kB │ gzip:   0.22 kB
dist/assets/changelog-DQV91D4J.svg                    0.31 kB │ gzip:   0.23 kB
dist/assets/folder-upload-C2YiWBPO.svg                0.31 kB │ gzip:   0.22 kB
dist/assets/vitest-BArfhq13.svg                       0.31 kB │ gzip:   0.23 kB
dist/assets/file-AwgZ2m-g.svg                         0.31 kB │ gzip:   0.21 kB
dist/assets/folder-layout-kmfVSlJ0.svg                0.31 kB │ gzip:   0.23 kB
dist/assets/folder-node-CPSLK9Mp.svg                  0.32 kB │ gzip:   0.23 kB
dist/assets/folder-windows-t2tcs8FQ.svg               0.32 kB │ gzip:   0.22 kB
dist/assets/cpp-INM4-kSs.svg                          0.32 kB │ gzip:   0.21 kB
dist/assets/less-DgAaLSXO.svg                         0.32 kB │ gzip:   0.19 kB
dist/assets/folder-environment-CKvOrWKC.svg           0.32 kB │ gzip:   0.23 kB
dist/assets/cmake-BQaPjfyp.svg                        0.32 kB │ gzip:   0.23 kB
dist/assets/csharp-CsWYnqLf.svg                       0.33 kB │ gzip:   0.22 kB
dist/assets/folder-template-COE2eji2.svg              0.33 kB │ gzip:   0.22 kB
dist/assets/database-Cj22jZTN.svg                     0.33 kB │ gzip:   0.19 kB
dist/assets/folder-store-BQQU_iu8.svg                 0.33 kB │ gzip:   0.24 kB
dist/assets/folder-export-MyzFrusn.svg                0.33 kB │ gzip:   0.23 kB
dist/assets/folder-kotlin-open-ZOMSRrxN.svg           0.34 kB │ gzip:   0.23 kB
dist/assets/folder-api-Bl97pBgh.svg                   0.34 kB │ gzip:   0.24 kB
dist/assets/folder-components-Bj5NLmit.svg            0.34 kB │ gzip:   0.23 kB
dist/assets/image-BvX5VAOD.svg                        0.34 kB │ gzip:   0.24 kB
dist/assets/prettier-CblUXfdG.svg                     0.34 kB │ gzip:   0.22 kB
dist/assets/folder-font-BGhANhwo.svg                  0.35 kB │ gzip:   0.24 kB
dist/assets/folder-keys-BAJx1aT0.svg                  0.35 kB │ gzip:   0.24 kB
dist/assets/folder-home-open-D6HbPLZd.svg             0.35 kB │ gzip:   0.24 kB
dist/assets/folder-import-GvZxZFmq.svg                0.35 kB │ gzip:   0.24 kB
dist/assets/folder-include-D0MMusBv.svg               0.35 kB │ gzip:   0.24 kB
dist/assets/folder-ui-open-DBnPKi0L.svg               0.35 kB │ gzip:   0.24 kB
dist/assets/folder-download-open-DAJb9J4Z.svg         0.35 kB │ gzip:   0.24 kB
dist/assets/folder-upload-open-B9DljTuh.svg           0.36 kB │ gzip:   0.24 kB
dist/assets/folder-class-BN00rw4G.svg                 0.36 kB │ gzip:   0.23 kB
dist/assets/folder-interface-G2B-eu1L.svg             0.36 kB │ gzip:   0.23 kB
dist/assets/folder-layout-open-DEG00tJQ.svg           0.36 kB │ gzip:   0.25 kB
dist/assets/folder-node-open-DqtVbm1f.svg             0.36 kB │ gzip:   0.25 kB
dist/assets/folder-windows-open-SdxLlZlW.svg          0.36 kB │ gzip:   0.24 kB
dist/assets/folder-dist-B2qNb_Hc.svg                  0.37 kB │ gzip:   0.24 kB
dist/assets/folder-environment-open-BC9pFuhf.svg      0.37 kB │ gzip:   0.25 kB
dist/assets/nodejs-Ftt-223_.svg                       0.37 kB │ gzip:   0.24 kB
dist/assets/folder-template-open-B6WEh6uQ.svg         0.37 kB │ gzip:   0.24 kB
dist/assets/folder-app-DI719GoN.svg                   0.38 kB │ gzip:   0.23 kB
dist/assets/folder-context-CcuyCVj6.svg               0.38 kB │ gzip:   0.24 kB
dist/assets/folder-java-BcrbciCk.svg                  0.38 kB │ gzip:   0.25 kB
dist/assets/folder-store-open-B7D2e24v.svg            0.38 kB │ gzip:   0.26 kB
dist/assets/jupyter-CF7u6bs_.svg                      0.38 kB │ gzip:   0.20 kB
dist/assets/folder-export-open-D5EBwgH1.svg           0.38 kB │ gzip:   0.25 kB
dist/assets/folder-docs-Il3jauFH.svg                  0.38 kB │ gzip:   0.25 kB
dist/assets/scala-aE0d5Kis.svg                        0.39 kB │ gzip:   0.26 kB
dist/assets/folder-api-open-DcRyX_4M.svg              0.39 kB │ gzip:   0.26 kB
dist/assets/folder-test-D74shkBU.svg                  0.39 kB │ gzip:   0.25 kB
dist/assets/folder-components-open-DN1rva41.svg       0.39 kB │ gzip:   0.26 kB
dist/assets/folder-video-Dc2ugN5x.svg                 0.39 kB │ gzip:   0.24 kB
dist/assets/folder-font-open-BqGtDoE9.svg             0.39 kB │ gzip:   0.26 kB
dist/assets/folder-keys-open-D5eAwTxN.svg             0.39 kB │ gzip:   0.26 kB
dist/assets/folder-queue-rHN8sNvB.svg                 0.40 kB │ gzip:   0.25 kB
dist/assets/folder-vscode-CM1f9QfZ.svg                0.40 kB │ gzip:   0.27 kB
dist/assets/folder-scripts-KD6zmqmd.svg               0.40 kB │ gzip:   0.25 kB
dist/assets/postcss-nFnRZwev.svg                      0.40 kB │ gzip:   0.23 kB
dist/assets/robots-a3009G78.svg                       0.40 kB │ gzip:   0.23 kB
dist/assets/folder-coverage-DN90eLXL.svg              0.40 kB │ gzip:   0.26 kB
dist/assets/assembly-Bet93dzY.svg                     0.40 kB │ gzip:   0.21 kB
dist/assets/folder-import-open-DnUV3Alk.svg           0.40 kB │ gzip:   0.26 kB
dist/assets/folder-include-open-CrEdZW3H.svg          0.40 kB │ gzip:   0.26 kB
dist/assets/vite-DRU0wIJ-.svg                         0.40 kB │ gzip:   0.26 kB
dist/assets/folder-mock-BLZ-_VlX.svg                  0.40 kB │ gzip:   0.26 kB
dist/assets/folder-views-D822Hs0D.svg                 0.40 kB │ gzip:   0.28 kB
dist/assets/tsconfig-Bjf4jQfg.svg                     0.41 kB │ gzip:   0.23 kB
dist/assets/folder-class-open-CGFTHmOG.svg            0.41 kB │ gzip:   0.25 kB
dist/assets/folder-interface-open-DSwmvzIY.svg        0.41 kB │ gzip:   0.25 kB
dist/assets/folder-backup-Do4jB7Zx.svg                0.41 kB │ gzip:   0.27 kB
dist/assets/folder-temp-BdnOS0pZ.svg                  0.41 kB │ gzip:   0.27 kB
dist/assets/folder-archive-Dd1Ygspe.svg               0.41 kB │ gzip:   0.26 kB
dist/assets/folder-client-DRfjlLjh.svg                0.42 kB │ gzip:   0.26 kB
dist/assets/folder-utils-D3PvfJM8.svg                 0.42 kB │ gzip:   0.26 kB
dist/assets/folder-dist-open-DJOLziRX.svg             0.42 kB │ gzip:   0.26 kB
dist/assets/folder-tasks-BHZnJWyq.svg                 0.42 kB │ gzip:   0.26 kB
dist/assets/folder-images-DOsq5fAP.svg                0.42 kB │ gzip:   0.27 kB
dist/assets/folder-shared-ChhXPWET.svg                0.42 kB │ gzip:   0.26 kB
dist/assets/folder-meta-D_maqWTL.svg                  0.42 kB │ gzip:   0.26 kB
dist/assets/folder-resource-C3et2vz1.svg              0.42 kB │ gzip:   0.26 kB
dist/assets/gradle-O_eVyvNV.svg                       0.42 kB │ gzip:   0.25 kB
dist/assets/folder-app-open-MuA3Ms7E.svg              0.42 kB │ gzip:   0.25 kB
dist/assets/folder-context-open-BMygj4-4.svg          0.42 kB │ gzip:   0.27 kB
dist/assets/folder-java-open-BSecEUeF.svg             0.42 kB │ gzip:   0.27 kB
dist/assets/folder-terraform-DATk77z-.svg             0.42 kB │ gzip:   0.27 kB
dist/assets/prisma-CqGoYTXg.svg                       0.42 kB │ gzip:   0.28 kB
dist/assets/folder-examples-BeajTQQN.svg              0.43 kB │ gzip:   0.26 kB
dist/assets/folder-private-BAZmkYnU.svg               0.43 kB │ gzip:   0.26 kB
dist/assets/folder-job-BNSqzG_q.svg                   0.43 kB │ gzip:   0.26 kB
dist/assets/folder-log-D24as1X8.svg                   0.43 kB │ gzip:   0.27 kB
dist/assets/folder-docs-open-BFKe4q7R.svg             0.43 kB │ gzip:   0.28 kB
dist/assets/haskell-CRLyx32i.svg                      0.43 kB │ gzip:   0.25 kB
dist/assets/folder-test-open-DtbK-mY4.svg             0.44 kB │ gzip:   0.27 kB
dist/assets/folder-audio-DCr99Ns1.svg                 0.44 kB │ gzip:   0.27 kB
dist/assets/folder-input-B0TpI_1h.svg                 0.44 kB │ gzip:   0.29 kB
dist/assets/folder-routes-DKyGW8DW.svg                0.44 kB │ gzip:   0.29 kB
dist/assets/folder-video-open-Dxu8wt28.svg            0.44 kB │ gzip:   0.26 kB
dist/assets/folder-android-BTUYFENj.svg               0.44 kB │ gzip:   0.29 kB
dist/assets/folder-hook-BFDNzSTR.svg                  0.44 kB │ gzip:   0.26 kB
dist/assets/folder-messages-D4SfXfPe.svg              0.44 kB │ gzip:   0.27 kB
dist/assets/folder-queue-open-Cw-W9pFC.svg            0.44 kB │ gzip:   0.27 kB
dist/assets/folder-vscode-open-BeQNx0OH.svg           0.44 kB │ gzip:   0.29 kB
dist/assets/folder-scripts-open-tJTJVBio.svg          0.45 kB │ gzip:   0.27 kB
dist/assets/folder-coverage-open-D0BXIPOm.svg         0.45 kB │ gzip:   0.28 kB
dist/assets/folder-packages-Du9W85fI.svg              0.45 kB │ gzip:   0.28 kB
dist/assets/folder-secure-C3Avprgc.svg                0.45 kB │ gzip:   0.26 kB
dist/assets/folder-mock-open-CRxJdLBc.svg             0.45 kB │ gzip:   0.28 kB
dist/assets/folder-views-open-CjtJcwL4.svg            0.45 kB │ gzip:   0.30 kB
dist/assets/folder-backup-open-BQ4-S4VG.svg           0.46 kB │ gzip:   0.29 kB
dist/assets/folder-temp-open-DGinnGKo.svg             0.46 kB │ gzip:   0.29 kB
dist/assets/folder-archive-open-BDB0cETm.svg          0.46 kB │ gzip:   0.28 kB
dist/assets/folder-client-open-Wj37pmXU.svg           0.46 kB │ gzip:   0.28 kB
dist/assets/folder-utils-open-C3damcNr.svg            0.46 kB │ gzip:   0.28 kB
dist/assets/folder-tasks-open-CiNeH7_7.svg            0.47 kB │ gzip:   0.29 kB
dist/assets/folder-images-open-FkWsDIY2.svg           0.47 kB │ gzip:   0.29 kB
dist/assets/folder-rust-Clno2v9O.svg                  0.47 kB │ gzip:   0.29 kB
dist/assets/folder-shared-open-BxL99m2v.svg           0.47 kB │ gzip:   0.28 kB
dist/assets/folder-meta-open-DDXgWdSv.svg             0.47 kB │ gzip:   0.28 kB
dist/assets/folder-resource-open-CAuaHxgw.svg         0.47 kB │ gzip:   0.28 kB
dist/assets/folder-terraform-open-Dmw7KBaE.svg        0.47 kB │ gzip:   0.29 kB
dist/assets/folder-database-CQ_w4HF2.svg              0.47 kB │ gzip:   0.26 kB
dist/assets/folder-examples-open-B0gVzAeg.svg         0.47 kB │ gzip:   0.28 kB
dist/assets/folder-lib-DEsHA4sk.svg                   0.47 kB │ gzip:   0.29 kB
dist/assets/folder-private-open-BEmqq5gH.svg          0.47 kB │ gzip:   0.28 kB
dist/assets/folder-job-open-C_8nUXP2.svg              0.48 kB │ gzip:   0.29 kB
dist/assets/folder-log-open-DpkZO0or.svg              0.48 kB │ gzip:   0.29 kB
dist/assets/folder-audio-open-B4pFJCHU.svg            0.48 kB │ gzip:   0.29 kB
dist/assets/folder-input-open-B5whtWdG.svg            0.48 kB │ gzip:   0.31 kB
dist/assets/folder-server-CDls0feg.svg                0.49 kB │ gzip:   0.26 kB
dist/assets/folder-routes-open-M9dXFXgJ.svg           0.49 kB │ gzip:   0.31 kB
dist/assets/ruby-BHFOa6L9.svg                         0.49 kB │ gzip:   0.32 kB
dist/assets/folder-ios-BMIlm2h4.svg                   0.49 kB │ gzip:   0.28 kB
dist/assets/folder-android-open-jAh71mMV.svg          0.49 kB │ gzip:   0.31 kB
dist/assets/folder-hook-open-BNZ-zYpR.svg             0.49 kB │ gzip:   0.28 kB
dist/assets/folder-messages-open-Bkfs7TNw.svg         0.49 kB │ gzip:   0.29 kB
dist/assets/folder-middleware-C7nvv9fd.svg            0.49 kB │ gzip:   0.28 kB
dist/assets/folder-plugin-tBkdd-M9.svg                0.49 kB │ gzip:   0.28 kB
dist/assets/folder-packages-open-HsJ3spiu.svg         0.50 kB │ gzip:   0.29 kB
dist/assets/folder-secure-open-CVbMT-x3.svg           0.50 kB │ gzip:   0.28 kB
dist/assets/folder-ci-kLtpStxo.svg                    0.50 kB │ gzip:   0.30 kB
dist/assets/folder-generator-DVmEkYOb.svg             0.50 kB │ gzip:   0.30 kB
dist/assets/swift-C0ltu3i6.svg                        0.50 kB │ gzip:   0.31 kB
dist/assets/android-CpjzHt5t.svg                      0.50 kB │ gzip:   0.28 kB
dist/assets/folder-debug-BrsAsBk8.svg                 0.51 kB │ gzip:   0.31 kB
dist/assets/kotlin-CNvEmvgH.svg                       0.51 kB │ gzip:   0.32 kB
dist/assets/jest-BcvUOTaR.svg                         0.51 kB │ gzip:   0.30 kB
dist/assets/folder-rust-open-BpwCpkJh.svg             0.52 kB │ gzip:   0.31 kB
dist/assets/folder-database-open-Dt-Mnn6o.svg         0.52 kB │ gzip:   0.28 kB
dist/assets/folder-lib-open-CrVB0ZaH.svg              0.52 kB │ gzip:   0.31 kB
dist/assets/rust-DMNQdMcG.svg                         0.52 kB │ gzip:   0.32 kB
dist/assets/folder-core-CPeo38f8.svg                  0.53 kB │ gzip:   0.28 kB
dist/assets/folder-helper-1-HWjY-h.svg                0.53 kB │ gzip:   0.33 kB
dist/assets/pytorch-Cn8bH_sd.svg                      0.53 kB │ gzip:   0.33 kB
dist/assets/folder-server-open-DucLUDRf.svg           0.53 kB │ gzip:   0.28 kB
dist/assets/folder-ios-open-C274IIZs.svg              0.54 kB │ gzip:   0.30 kB
dist/assets/json-CtNz2G1q.svg                         0.54 kB │ gzip:   0.31 kB
dist/assets/erlang-CFKD46V5.svg                       0.54 kB │ gzip:   0.35 kB
dist/assets/folder-middleware-open-MwNjsrYz.svg       0.54 kB │ gzip:   0.30 kB
dist/assets/folder-plugin-open-CoYDGowT.svg           0.54 kB │ gzip:   0.30 kB
dist/assets/folder-ci-open-BwnGGgNy.svg               0.55 kB │ gzip:   0.32 kB
dist/assets/folder-generator-open-BcAolmBh.svg        0.55 kB │ gzip:   0.32 kB
dist/index.html                                       0.55 kB │ gzip:   0.35 kB
dist/assets/folder-tools-nOE_Obd-.svg                 0.55 kB │ gzip:   0.32 kB
dist/assets/folder-container-CmRItCTx.svg             0.55 kB │ gzip:   0.33 kB
dist/assets/folder-review-zhhYxBc6.svg                0.55 kB │ gzip:   0.31 kB
dist/assets/folder-debug-open-b9EaT9B1.svg            0.55 kB │ gzip:   0.33 kB
dist/assets/folder-lottie-D4N2ytUB.svg                0.57 kB │ gzip:   0.33 kB
dist/assets/lua-DGjzYnY0.svg                          0.57 kB │ gzip:   0.23 kB
dist/assets/folder-core-open-WkHDhCHU.svg             0.57 kB │ gzip:   0.31 kB
dist/assets/folder-admin-C4gnwl1L.svg                 0.57 kB │ gzip:   0.34 kB
dist/assets/folder-i18n-CR1T91sl.svg                  0.58 kB │ gzip:   0.36 kB
dist/assets/folder-helper-open-CMFIYFK6.svg           0.58 kB │ gzip:   0.35 kB
dist/assets/folder-features-B6I3f33u.svg              0.59 kB │ gzip:   0.35 kB
dist/assets/folder-jupyter-CD1gL0z5.svg               0.60 kB │ gzip:   0.33 kB
dist/assets/folder-tools-open-DKaTZvIT.svg            0.60 kB │ gzip:   0.34 kB
dist/assets/folder-container-open-Bc65NlOG.svg        0.60 kB │ gzip:   0.36 kB
dist/assets/folder-review-open-B_h4aFb3.svg           0.60 kB │ gzip:   0.33 kB
dist/assets/folder-migrations-BkS4Itay.svg            0.60 kB │ gzip:   0.36 kB
dist/assets/folder-benchmark-CIOtOQGF.svg             0.60 kB │ gzip:   0.36 kB
dist/assets/powershell-C6NGchuF.svg                   0.61 kB │ gzip:   0.35 kB
dist/assets/folder-svg-7ByKnrd9.svg                   0.61 kB │ gzip:   0.32 kB
dist/assets/test-js-OwrXCHKi.svg                      0.61 kB │ gzip:   0.34 kB
dist/assets/test-jsx-B8K3rlw-.svg                     0.61 kB │ gzip:   0.34 kB
dist/assets/test-ts-Uf59rGo6.svg                      0.61 kB │ gzip:   0.34 kB
dist/assets/folder-lottie-open-C-hn6T70.svg           0.61 kB │ gzip:   0.35 kB
dist/assets/folder-admin-open-ChrCfJ7M.svg            0.62 kB │ gzip:   0.36 kB
dist/assets/folder-i18n-open-DaBvhDgb.svg             0.62 kB │ gzip:   0.38 kB
dist/assets/folder-features-open-CsqhThqX.svg         0.64 kB │ gzip:   0.37 kB
dist/assets/dependabot-H7cYtumZ.svg                   0.64 kB │ gzip:   0.29 kB
dist/assets/folder-jupyter-open-D-ps5hLR.svg          0.64 kB │ gzip:   0.35 kB
dist/assets/folder-migrations-open-ecL9vcGr.svg       0.65 kB │ gzip:   0.38 kB
dist/assets/folder-benchmark-open-CJ1TOzqh.svg        0.65 kB │ gzip:   0.37 kB
dist/assets/folder-svg-open-BSOkY45M.svg              0.66 kB │ gzip:   0.33 kB
dist/assets/folder-docker-CjQ9Kw0l.svg                0.66 kB │ gzip:   0.39 kB
dist/assets/eslint-DzpFfw-i.svg                       0.66 kB │ gzip:   0.29 kB
dist/assets/css-BSpPuOMr.svg                          0.67 kB │ gzip:   0.29 kB
dist/assets/folder-animation-D4xV17GO.svg             0.68 kB │ gzip:   0.32 kB
dist/assets/python-misc-BbpyPaM-.svg                  0.68 kB │ gzip:   0.32 kB
dist/assets/astro-BUUa0maZ.svg                        0.68 kB │ gzip:   0.40 kB
dist/assets/folder-git-DV4F1Q0m.svg                   0.68 kB │ gzip:   0.34 kB
dist/assets/dart-kd3Gtzqg.svg                         0.69 kB │ gzip:   0.38 kB
dist/assets/folder-target-CKjM5v9Y.svg                0.69 kB │ gzip:   0.40 kB
dist/assets/folder-docker-open-BazcZt32.svg           0.71 kB │ gzip:   0.41 kB
dist/assets/folder-macos-CT4I8GeH.svg                 0.72 kB │ gzip:   0.41 kB
dist/assets/git-83tqA80G.svg                          0.72 kB │ gzip:   0.37 kB
dist/assets/folder-animation-open-DTuYgEko.svg        0.73 kB │ gzip:   0.34 kB
dist/assets/r-DgBVcMP_.svg                            0.73 kB │ gzip:   0.43 kB
dist/assets/folder-git-open-DVRIqVs2.svg              0.73 kB │ gzip:   0.37 kB
dist/assets/folder-target-open-CoWXV_q-.svg           0.74 kB │ gzip:   0.41 kB
dist/assets/go-B7ZFxYI_.svg                           0.74 kB │ gzip:   0.32 kB
dist/assets/go-mod-BhkxLSQa.svg                       0.74 kB │ gzip:   0.32 kB
dist/assets/cabal-CXQaD4_8.svg                        0.75 kB │ gzip:   0.44 kB
dist/assets/dll-BmYiFphX.svg                          0.77 kB │ gzip:   0.41 kB
dist/assets/python-B51K8IGV.svg                       0.77 kB │ gzip:   0.38 kB
dist/assets/folder-macos-open-DkJBEW95.svg            0.77 kB │ gzip:   0.42 kB
dist/assets/folder-public-NMwz5a25.svg                0.79 kB │ gzip:   0.39 kB
dist/assets/folder-github-4QqaYhvh.svg                0.83 kB │ gzip:   0.45 kB
dist/assets/folder-public-open-DVn5Mkoj.svg           0.84 kB │ gzip:   0.42 kB
dist/assets/maven-Cp_nbRKZ.svg                        0.86 kB │ gzip:   0.42 kB
dist/assets/tex-Hzjkwjtg.svg                          0.86 kB │ gzip:   0.45 kB
dist/assets/cuda-DIAU-Jy3.svg                         0.86 kB │ gzip:   0.48 kB
dist/assets/folder-css-BCQ7GOJ_.svg                   0.86 kB │ gzip:   0.38 kB
dist/assets/php-Di6_0azE.svg                          0.88 kB │ gzip:   0.45 kB
dist/assets/folder-github-open-DrfXo6_2.svg           0.88 kB │ gzip:   0.47 kB
dist/assets/folder-json-Cqb9unWE.svg                  0.89 kB │ gzip:   0.47 kB
dist/assets/folder-src-DtSHeecs.svg                   0.90 kB │ gzip:   0.46 kB
dist/assets/folder-css-open-DwyUxnjk.svg              0.91 kB │ gzip:   0.40 kB
dist/assets/yarn--gleSda9.svg                         0.91 kB │ gzip:   0.49 kB
dist/assets/folder-linux-CJYFRqYO.svg                 0.92 kB │ gzip:   0.49 kB
dist/assets/folder-json-open-Bo-al590.svg             0.94 kB │ gzip:   0.49 kB
dist/assets/makefile-B4F0WZrz.svg                     0.94 kB │ gzip:   0.41 kB
dist/assets/folder-controller-Bfr05mnG.svg            0.95 kB │ gzip:   0.45 kB
dist/assets/folder-src-open-CEDoEzI0.svg              0.95 kB │ gzip:   0.48 kB
dist/assets/folder-config-DpDnRxBP.svg                0.95 kB │ gzip:   0.45 kB
dist/assets/folder-typescript-CSeC9950.svg            0.96 kB │ gzip:   0.52 kB
dist/assets/folder-linux-open-DOZJuFTv.svg            0.97 kB │ gzip:   0.51 kB
dist/assets/playwright-CZDGDv97.svg                   0.97 kB │ gzip:   0.55 kB
dist/assets/pdf-FSVsLfd_.svg                          0.97 kB │ gzip:   0.55 kB
dist/assets/folder-claude-DPDhI4Nx.svg                0.97 kB │ gzip:   0.55 kB
dist/assets/bun-DsZhmzEY.svg                          0.99 kB │ gzip:   0.47 kB
dist/assets/folder-husky-Bgnpq53U.svg                 0.99 kB │ gzip:   0.55 kB
dist/assets/graphql-BKt2gD_N.svg                      1.00 kB │ gzip:   0.38 kB
dist/assets/folder-controller-open-CiE6-oRn.svg       1.00 kB │ gzip:   0.46 kB
dist/assets/folder-config-open-BAzE5aMG.svg           1.00 kB │ gzip:   0.47 kB
dist/assets/folder-typescript-open-D55txqm_.svg       1.01 kB │ gzip:   0.54 kB
dist/assets/folder-gitlab-hKjbxLri.svg                1.02 kB │ gzip:   0.48 kB
dist/assets/folder-claude-open-Cb8-t85h.svg           1.02 kB │ gzip:   0.57 kB
dist/assets/folder-husky-open-CBkU_H5A.svg            1.04 kB │ gzip:   0.57 kB
dist/assets/folder-python-DYQYPj6A.svg                1.04 kB │ gzip:   0.50 kB
dist/assets/folder-gitlab-open-BcZfak5w.svg           1.07 kB │ gzip:   0.50 kB
dist/assets/folder-src-tauri-C6HrdwKk.svg             1.08 kB │ gzip:   0.51 kB
dist/assets/folder-python-open-VKfe9bLO.svg           1.09 kB │ gzip:   0.52 kB
dist/assets/react-DVwDfBp3.svg                        1.10 kB │ gzip:   0.53 kB
dist/assets/react_ts-_1j79TVC.svg                     1.10 kB │ gzip:   0.53 kB
dist/assets/folder-javascript-IygbsW6N.svg            1.11 kB │ gzip:   0.57 kB
dist/assets/tauri-Dq0-hcjj.svg                        1.12 kB │ gzip:   0.50 kB
dist/assets/folder-src-tauri-open-CqMF10TW.svg        1.13 kB │ gzip:   0.54 kB
dist/assets/folder-javascript-open-aSmsRs1E.svg       1.16 kB │ gzip:   0.59 kB
dist/assets/pkl-vAv-q5Xo.svg                          1.20 kB │ gzip:   0.64 kB
dist/assets/sass-9oWjJ7Kf.svg                         1.28 kB │ gzip:   0.66 kB
dist/assets/svg-BGAtL3nZ.svg                          1.28 kB │ gzip:   0.48 kB
dist/assets/settings-DyEElZBl.svg                     1.33 kB │ gzip:   0.66 kB
dist/assets/docker-DmVDHlbn.svg                       1.50 kB │ gzip:   0.56 kB
dist/assets/svelte-BzdjuKpL.svg                       1.66 kB │ gzip:   0.76 kB
dist/assets/clojure-B26qS46w.svg                      1.81 kB │ gzip:   0.93 kB
dist/assets/folder-intellij-DnqbtBBL.svg              2.36 kB │ gzip:   0.88 kB
dist/assets/folder-intellij-open-zgsklybM.svg         2.41 kB │ gzip:   0.90 kB
dist/assets/folder-kubernetes-WqLe9Qz7.svg            3.08 kB │ gzip:   1.32 kB
dist/assets/folder-kubernetes-open-DAag2M1_.svg       3.13 kB │ gzip:   1.34 kB
dist/splash.html                                      3.33 kB │ gzip:   1.26 kB
dist/assets/nix-B4Y-u9vY.svg                          4.11 kB │ gzip:   2.05 kB
dist/assets/ultralytics-logotype-CGo9qJ9s.svg         5.25 kB │ gzip:   2.01 kB
dist/assets/editorconfig-pGlPAdhs.svg                 8.09 kB │ gzip:   3.44 kB
dist/assets/geist-latin-wght-normal-BgDaEnEv.woff2   29.40 kB
dist/assets/terminal-BrP-ENHg.css                     3.93 kB │ gzip:   1.01 kB
dist/assets/main-BDPWXuKc.css                        89.01 kB │ gzip:  15.50 kB
dist/assets/chevron-up-7NC7cmhJ.js                    0.19 kB │ gzip:   0.16 kB
dist/assets/diff-ChtP43wD.js                          0.30 kB │ gzip:   0.23 kB
dist/assets/brainfuck-D5EjA2JK.js                     0.59 kB │ gzip:   0.32 kB
dist/assets/properties-C357ku5U.js                    0.66 kB │ gzip:   0.34 kB
dist/assets/rolldown-runtime-hePW80VL.js              0.71 kB │ gzip:   0.42 kB
dist/assets/cmake-84nbDH0I.js                         0.75 kB │ gzip:   0.45 kB
dist/assets/asciiarmor-C_eisQCp.js                    0.77 kB │ gzip:   0.40 kB
dist/assets/protobuf-D1ij_kNL.js                      0.80 kB │ gzip:   0.51 kB
dist/assets/http-CLVgA2GD.js                          0.84 kB │ gzip:   0.42 kB
dist/assets/solr-BBopId9w.js                          0.86 kB │ gzip:   0.45 kB
dist/assets/troff-C2dAgh7P.js                         0.95 kB │ gzip:   0.43 kB
dist/assets/toml-BPTmHmyx.js                          1.04 kB │ gzip:   0.53 kB
dist/assets/spreadsheet-CTIncYxj.js                   1.13 kB │ gzip:   0.53 kB
dist/assets/mbox-BEMVcqjs.js                          1.38 kB │ gzip:   0.65 kB
dist/assets/rpm-gpDK5sbt.js                           1.59 kB │ gzip:   0.81 kB
dist/assets/sieve-BAxa3IjF.js                         1.61 kB │ gzip:   0.77 kB
dist/assets/factor-LKH5gN8L.js                        1.66 kB │ gzip:   0.60 kB
dist/assets/eiffel-BEjRio4Q.js                        1.69 kB │ gzip:   0.90 kB
dist/assets/z80-Co3PbHdE.js                           1.75 kB │ gzip:   0.79 kB
dist/assets/mumps-BSzj6Xyz.js                         1.82 kB │ gzip:   0.95 kB
dist/assets/elm-Cshzl8qu.js                           1.86 kB │ gzip:   0.81 kB
dist/assets/mathematica-u8YMmbU0.js                   1.89 kB │ gzip:   0.80 kB
dist/assets/dockerfile-DJkHQgkl.js                    1.90 kB │ gzip:   0.65 kB
dist/assets/turtle-Cx3rYX2g.js                        1.95 kB │ gzip:   0.89 kB
dist/assets/ebnf-D4c0_ac3.js                          1.97 kB │ gzip:   0.80 kB
dist/assets/dist-Cvkh0ks5.js                          1.99 kB │ gzip:   1.26 kB
dist/assets/smalltalk-BLp5-jwC.js                     1.99 kB │ gzip:   0.85 kB
dist/assets/fcl-ClOhbFR7.js                           2.02 kB │ gzip:   0.95 kB
dist/assets/ntriples-B9h1VB_g.js                      2.06 kB │ gzip:   0.72 kB
dist/assets/dtd-DTF72YNO.js                           2.09 kB │ gzip:   0.87 kB
dist/assets/octave-D2Q8cUp1.js                        2.10 kB │ gzip:   1.07 kB
dist/assets/yacas-CXXgtw0p.js                         2.14 kB │ gzip:   1.08 kB
dist/assets/pascal-Dp_KdFgX.js                        2.25 kB │ gzip:   1.17 kB
dist/assets/simple-mode-DXiLM1-G.js                   2.27 kB │ gzip:   1.09 kB
dist/assets/apl-gfMMiTNf.js                           2.29 kB │ gzip:   1.22 kB
dist/assets/commonlisp-DgAKBe0r.js                    2.31 kB │ gzip:   1.09 kB
dist/assets/tcl-BGfruO1u.js                           2.35 kB │ gzip:   1.22 kB
dist/assets/shell-DwuoZtxw.js                         2.43 kB │ gzip:   1.20 kB
dist/assets/webidl-D5jiJvOU.js                        2.44 kB │ gzip:   1.24 kB
dist/assets/pig-AF4Hwhju.js                           2.51 kB │ gzip:   1.37 kB
dist/assets/puppet-BZyAS7I4.js                        2.51 kB │ gzip:   1.19 kB
dist/assets/forth-Cezjo90N.js                         2.54 kB │ gzip:   1.32 kB
dist/assets/dist-BD3JS2kO.js                          2.60 kB │ gzip:   1.49 kB
dist/assets/velocity-CqftRsjg.js                      2.70 kB │ gzip:   1.11 kB
dist/assets/tiddlywiki-VlUiK86J.js                    2.76 kB │ gzip:   1.07 kB
dist/assets/modelica-CqHI_q-D.js                      2.79 kB │ gzip:   1.28 kB
dist/assets/oz-BwTct_5T.js                            2.88 kB │ gzip:   1.27 kB
dist/assets/r-CxDmU1I4.js                             2.92 kB │ gzip:   1.33 kB
dist/assets/stex-DNzd62Q_.js                          3.09 kB │ gzip:   1.17 kB
dist/assets/lua-CiA1ziua.js                           3.13 kB │ gzip:   1.40 kB
dist/assets/cypher-p9eYesGn.js                        3.18 kB │ gzip:   1.49 kB
dist/assets/tiki-AK6FwT8q.js                          3.22 kB │ gzip:   1.25 kB
dist/assets/vhdl-kS471soi.js                          3.31 kB │ gzip:   1.49 kB
dist/assets/dist-DCcI0ISe.js                          3.32 kB │ gzip:   1.69 kB
dist/assets/sparql-Dz-mlCAC.js                        3.33 kB │ gzip:   1.59 kB
dist/assets/mscgen-qgSLujhx.js                        3.49 kB │ gzip:   0.97 kB
dist/assets/vb-BthdM_4N.js                            3.65 kB │ gzip:   1.81 kB
dist/assets/d-DWkQyNnU.js                             3.69 kB │ gzip:   1.67 kB
dist/assets/q-B9NhS7L_.js                             3.69 kB │ gzip:   1.69 kB
dist/assets/swift-DKB6_1j6.js                         3.76 kB │ gzip:   1.81 kB
dist/assets/coffeescript-De_zI4J0.js                  3.84 kB │ gzip:   1.69 kB
dist/assets/fortran-Bt6PBEDR.js                       3.86 kB │ gzip:   1.93 kB
dist/assets/asn1-DCl_8MCW.js                          3.97 kB │ gzip:   1.95 kB
dist/assets/dylan-BCDoL_-p.js                         4.04 kB │ gzip:   1.63 kB
dist/assets/asterisk-BEn0Cwpx.js                      4.05 kB │ gzip:   1.73 kB
dist/assets/livescript-BXxG0Yva.js                    4.08 kB │ gzip:   1.62 kB
dist/assets/ttcn-cfg-2b4Gb5sE.js                      4.09 kB │ gzip:   1.72 kB
dist/assets/groovy-CUpZ7dEl.js                        4.12 kB │ gzip:   1.74 kB
dist/assets/haskell-BRsoo5mP.js                       4.15 kB │ gzip:   1.91 kB
dist/assets/gas-BHEdbvp9.js                           4.55 kB │ gzip:   1.27 kB
dist/assets/mllike-B45xgp2S.js                        4.82 kB │ gzip:   1.57 kB
dist/assets/ttcn-PPSTk1ow.js                          4.84 kB │ gzip:   2.14 kB
dist/assets/dist-Blft7v1z.js                          4.93 kB │ gzip:   2.34 kB
dist/assets/crystal-Bsdphhtm.js                       5.01 kB │ gzip:   2.10 kB
dist/assets/ruby-BjXV7-Qa.js                          5.02 kB │ gzip:   2.14 kB
dist/assets/ecl-BVIeWmwY.js                           5.11 kB │ gzip:   2.30 kB
dist/assets/julia-CQfgDRfP.js                         5.26 kB │ gzip:   2.16 kB
dist/assets/vbscript-D9f6rSsU.js                      5.43 kB │ gzip:   2.56 kB
dist/assets/mirc-C9zpzAZU.js                          5.91 kB │ gzip:   2.70 kB
dist/assets/xquery-BKJx4mf9.js                        6.15 kB │ gzip:   2.57 kB
dist/assets/cobol-DHLQUbN7.js                         6.19 kB │ gzip:   2.98 kB
dist/assets/python-B_1Jd8HM.js                        6.27 kB │ gzip:   2.67 kB
dist/assets/scheme-D9qYN0V5.js                        6.35 kB │ gzip:   2.37 kB
dist/assets/pug-Gsm0M45u.js                           6.64 kB │ gzip:   1.99 kB
dist/assets/textile-C4jVoHG1.js                       6.74 kB │ gzip:   2.44 kB
dist/assets/nsis-CfSuhXs5.js                          6.80 kB │ gzip:   2.99 kB
dist/assets/nginx-BMaDbqW3.js                         7.40 kB │ gzip:   2.73 kB
dist/assets/powershell-BcIto6Sf.js                    7.69 kB │ gzip:   3.29 kB
dist/assets/erlang-BV0c4Hdn.js                        7.84 kB │ gzip:   2.90 kB
dist/assets/haxe-DjVOVvNP.js                          7.86 kB │ gzip:   2.94 kB
dist/assets/verilog-7LoJAqYT.js                       8.18 kB │ gzip:   3.46 kB
dist/assets/sas-C2OyD2Y6.js                           9.33 kB │ gzip:   4.11 kB
dist/assets/clojure-BflJGmDX.js                       9.40 kB │ gzip:   4.02 kB
dist/assets/perl-BkSkiI9m.js                          9.73 kB │ gzip:   3.50 kB
dist/assets/idl-BUZw3wgd.js                           9.82 kB │ gzip:   4.40 kB
dist/assets/gherkin-oBAE_ms0.js                      10.15 kB │ gzip:   5.09 kB
dist/assets/dist-AifrMdlI.js                         11.56 kB │ gzip:   5.18 kB
dist/assets/dist-DsibX6ZM.js                         14.30 kB │ gzip:   5.76 kB
dist/assets/dist-COhCLaZ2.js                         16.23 kB │ gzip:   7.47 kB
dist/assets/javascript-DoL9Wb-Q.js                   16.96 kB │ gzip:   5.72 kB
dist/assets/dist-CWxSgKYJ.js                         20.69 kB │ gzip:   9.33 kB
dist/assets/dist-DjvwbX9B.js                         20.95 kB │ gzip:   9.66 kB
dist/assets/clike-D_6L3tnO.js                        22.05 kB │ gzip:   7.75 kB
dist/assets/dist-C_38dRZf.js                         22.95 kB │ gzip:  10.42 kB
dist/assets/stylus-BOVgKnng.js                       23.51 kB │ gzip:   8.55 kB
dist/assets/css-CnaYoQib.js                          24.66 kB │ gzip:   8.25 kB
dist/assets/dist-RB3DjINe.js                         26.45 kB │ gzip:   8.68 kB
dist/assets/dist-BnAT9hys.js                         26.84 kB │ gzip:  12.71 kB
dist/assets/dist-D_-aCIjc.js                         28.37 kB │ gzip:  11.53 kB
dist/assets/dist-DmUNnIQO.js                         30.72 kB │ gzip:  12.74 kB
dist/assets/sql-DuQMFDvy.js                          36.83 kB │ gzip:  10.90 kB
dist/assets/file-icons-e5Ij_VWG.js                   40.60 kB │ gzip:   9.60 kB
dist/assets/dist-Nib4azX1.js                         40.70 kB │ gzip:  16.93 kB
dist/assets/dist-BxK4dCFX.js                         43.87 kB │ gzip:  15.10 kB
dist/assets/dist-Cc6roUeT.js                         44.58 kB │ gzip:  19.33 kB
dist/assets/dist-CInkv_ug.js                         46.97 kB │ gzip:  13.43 kB
dist/assets/dist-LdPSvZrB.js                         70.78 kB │ gzip:  26.09 kB
dist/assets/dist-BxbT3qMk.js                         84.63 kB │ gzip:  33.76 kB
dist/assets/dist-4trYess4.js                         97.74 kB │ gzip:  28.63 kB
dist/assets/dist-BACDMbpe.js                        103.89 kB │ gzip:  34.75 kB
dist/assets/source-editor-D1FBR-Ed.js               119.60 kB │ gzip:  38.37 kB
dist/assets/code-preview-DM1Jy6Lo.js                251.64 kB │ gzip:  79.08 kB
dist/assets/dist-C7DvmJiE.js                        313.21 kB │ gzip: 101.49 kB
dist/assets/terminal-B8UDNw0K.js                    375.96 kB │ gzip:  97.07 kB
dist/assets/main-BP1ABLIs.js                        656.56 kB │ gzip: 205.25 kB

✓ built in 347ms
- 
- 
- 
running 6 tests
test tests::session_locale_is_utf8_only_on_macos ... ok
test tests::scoped_entry_rejects_parent_segments ... ok
test tests::remove_entry_deletes_nonempty_directories ... ok
test tests::scoped_entry_keeps_a_symlink_as_the_deletion_target ... ok
test tests::git_changes_preserve_human_status_markers_in_filenames ... ok
test tests::unborn_diff_includes_staged_and_worktree_content ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added optional Remote SSH workspaces, allowing supported terminal agents and scoped file/Git operations to run on a selected Linux host through the user’s SSH configuration.

### 📊 Key Changes
- Added SSH workspace grants with host and remote path tracking, including validation, non-interactive authentication, bounded output, command timeouts, and path-scope checks.
- Added Remote SSH controls to settings and the new-session dialog, with persisted host and feature preferences; remote folder browsing is replaced by typed paths.
- Added remote terminal launches for shell, Claude, Codex, Gemini, Kimi, and Qwen, including provider session discovery and resume handling where supported.
- Routed remote file listing, reading, writing, deletion, Git status, diffs, and origin inspection through scoped SSH commands with existing size and pagination limits.
- Updated session labels, grouping, directory-follow behavior, and usage messaging to include remote hosts and handle remote-session limitations.

### 🎯 Purpose & Impact
Users can create and manage sessions against Linux folders on SSH hosts while Lite continues running locally; remote Codex provider integrations and provider usage reporting remain unavailable, and local workspace behavior is otherwise preserved.