### PR TITLE
Refresh harness updates when opening sessions

### DIFF
--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -154,6 +154,7 @@ export function NewSessionDialog({
   useEffect(() => {
     if (!isOpen || remote) return;
     let disposed = false;
+    setUpdates({});
     void checkAgentUpdates().then((result) => {
       if (!disposed) setUpdates(result);
     });

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -57,7 +57,11 @@ function checkAgentUpdates() {
         return [agent, null] as const;
       }
     }),
-  ).then(Object.fromEntries);
+  )
+    .then(Object.fromEntries)
+    .finally(() => {
+      updateChecks = undefined;
+    });
   return updateChecks;
 }
 
@@ -145,8 +149,8 @@ export function NewSessionDialog({
   }, [isOpen, chosen]);
   // An agent that is not installed cannot take a session yet, so the dialog offers to install it instead.
   const missing = !remote && status && !status.available ? status : undefined;
-  // The first explicit open asks every harness in parallel. The answer is kept for this app run, so
-  // reopening the dialog does not repeat five version processes and five network requests.
+  // Each explicit open asks every harness in parallel. Concurrent opens share the same work, while a
+  // later open checks again so a newly published version or a failed registry request does not stay stale.
   useEffect(() => {
     if (!isOpen || remote) return;
     let disposed = false;
@@ -354,13 +358,7 @@ export function NewSessionDialog({
       setAvailability((current) => ({ ...current, ...Object.fromEntries(results) }));
       const result = results.find(([id]) => id === option.id)?.[1];
       if (result && !result.available && result.installable) setError(result.detail);
-      else {
-        updateChecks = (updateChecks ?? Promise.resolve(updates)).then((current) => ({
-          ...current,
-          [option.agent]: false,
-        }));
-        setUpdates((current) => ({ ...current, [option.agent]: false }));
-      }
+      else setUpdates((current) => ({ ...current, [option.agent]: false }));
     } catch (reason) {
       setError(String(reason));
     } finally {


### PR DESCRIPTION
## Summary

- refresh version availability for every local harness whenever New Session opens
- deduplicate only concurrent checks instead of caching results for the app lifetime
- allow registry failures to retry on the next explicit open

## Validation

- `bun run check`
- `bun run build`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the New Session dialog to refresh local harness availability on each explicit open while sharing only concurrent checks, preventing stale version or registry results.

### 📊 Key Changes

- Clears displayed update results whenever the local New Session dialog opens.
- Re-runs version checks for every local harness on later opens instead of retaining results for the app lifetime.
- Resets the shared update-check promise after completion, so concurrent opens deduplicate work without caching completed checks.
- Allows failed registry checks to run again on the next explicit open.
- Stops installation handling from modifying the shared update-check state.

### 🎯 Purpose & Impact

- Newly published harness versions and recovered registry availability are detected when the dialog is reopened.
- Concurrent dialog checks still share a single in-progress operation, avoiding duplicate checks while they overlap.