### PR TITLE
Fix session recovery and Git context

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.37"
+version = "0.0.38"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2546,12 +2546,9 @@ function App() {
   }
 
   async function restartSessionNow(session: Session, fresh: Session, select: boolean): Promise<boolean> {
+    const wasWorking = workingRef.current.has(session.id);
     runs.current.delete(session.id);
     forgetShellAgent(session.id);
-    const timer = workTimers.current.get(session.id);
-    if (timer) window.clearTimeout(timer);
-    workTimers.current.delete(session.id);
-    setWorking((current) => without(current, session.id));
     replaceRecentSession(session.id, fresh.id);
     setStartingIds((current) => including(current, fresh.id));
     setSessions((current) => current.map((item) => (item.id === session.id ? fresh : item)));
@@ -2573,6 +2570,10 @@ function App() {
       }
       return false;
     }
+    const timer = workTimers.current.get(session.id);
+    if (timer) window.clearTimeout(timer);
+    workTimers.current.delete(session.id);
+    setWorking((current) => without(current, session.id));
     if (!(await launch(fresh, false))) {
       replaceRecentSession(fresh.id, session.id);
       await invoke("delete_session_data", { sessionId: fresh.id }).catch(() => {});
@@ -2582,7 +2583,10 @@ function App() {
       setSessions((current) => current.map((item) => (item.id === fresh.id ? restored : item)));
       setSelectedId((current) => (current === fresh.id ? session.id : current));
       resumed.current = session.id;
-      if (await launch(restored, true)) setError("Restart failed; the original session was restored.");
+      if (await launch(restored, true)) {
+        if (wasWorking) markWorking(session.id);
+        setError("Restart failed; the original session was restored.");
+      }
       return false;
     }
     if (fresh.agent === "kimi") startKimiConversation(fresh.id);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Toaster, toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { clearInspectorCache, Inspector, SearchInput } from "@/inspector";
+import { clearInspectorCache, Inspector, rememberGitHubReferences, SearchInput } from "@/inspector";
 import { including, swapped, without } from "@/lib/utils";
 import { NewSessionDialog, SESSION_CHOICES } from "@/new-session-dialog";
 import {
@@ -1597,6 +1597,7 @@ function App() {
   // Sessions whose terminal has written something recently, which is what separates a connected
   // session that is working from one that is merely connected.
   const [working, setWorking] = useState(loadWorking);
+  const workingRef = useRef(working);
   // Work that was live when the previous process disappeared is resumed once in this process.
   const interrupted = useRef(new Set(working));
   const [shellAgents, setShellAgents] = useState<Map<string, Agent>>(new Map());
@@ -1733,6 +1734,7 @@ function App() {
   }
   visibleRef.current = shut.sidebar ? sessions : displayed;
   sessionsRef.current = sessions;
+  workingRef.current = working;
   themeRef.current = theme;
   selectedRef.current = selected;
   notificationsRef.current = notifications;
@@ -1911,7 +1913,7 @@ function App() {
   }, [sessions]);
 
   // This is written while work changes rather than at shutdown, so a power loss still leaves the
-  // next Lite process an exact list. An install freezes the last state before it stops the PTYs.
+  // next Lite process an exact list. Installing snapshots the live list before freezing this effect.
   useEffect(() => {
     if (updateStatus !== "installing") localStorage.setItem(WORKING_KEY, JSON.stringify([...working]));
   }, [updateStatus, working]);
@@ -2546,6 +2548,10 @@ function App() {
   async function restartSessionNow(session: Session, fresh: Session, select: boolean): Promise<boolean> {
     runs.current.delete(session.id);
     forgetShellAgent(session.id);
+    const timer = workTimers.current.get(session.id);
+    if (timer) window.clearTimeout(timer);
+    workTimers.current.delete(session.id);
+    setWorking((current) => without(current, session.id));
     replaceRecentSession(session.id, fresh.id);
     setStartingIds((current) => including(current, fresh.id));
     setSessions((current) => current.map((item) => (item.id === session.id ? fresh : item)));
@@ -2900,6 +2906,17 @@ function App() {
 
   async function installUpdate() {
     setUpdateProgress(null);
+    // React may not have committed the last working-state effect when this click changes the update
+    // state. Persist from the live owners now, excluding closed, disconnected and shell sessions.
+    const sessions = new Set(
+      sessionsRef.current
+        .filter((session) => session.running && !session.mode && session.agent !== "shell")
+        .map((session) => session.id),
+    );
+    localStorage.setItem(
+      WORKING_KEY,
+      JSON.stringify([...workingRef.current].filter((sessionId) => sessions.has(sessionId))),
+    );
     setUpdateStatus("installing");
     // A download only reports itself while it is running, so it is heard for exactly that long. A
     // successful install restarts Lite from underneath this, and the failures it can return come
@@ -3308,6 +3325,9 @@ function App() {
                               working={working.has(session.id)}
                               starting={startingIds.has(session.id)}
                               onZoom={zoomTerminal}
+                              onOutput={(output, terminalStream) =>
+                                rememberGitHubReferences(session.id, output, terminalStream)
+                              }
                               onRecover={() => recoverSession(session)}
                               onPrompt={(text) => {
                                 const agent = session.agent === "shell" ? commandAgent(text) : undefined;

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -140,6 +140,27 @@ function retainGitHubItems(sessionId: string, updates: GitHubItem[]) {
   return items;
 }
 
+// Full-screen terminals can redraw a link away before the Git panel is opened. Remember references
+// when xterm renders them; the panel fills in their current GitHub metadata when it is visited.
+export function rememberGitHubReferences(sessionId: string, output: string, terminalStream: string) {
+  const { explicit } = githubItemReferences(output, "", terminalStream, "");
+  if (!explicit.length) return;
+  const current = sessionGitHubItems(sessionId);
+  const known = new Set(current.map((item) => itemKey(item.url)));
+  const additions = explicit
+    .filter((url) => !known.has(itemKey(url)))
+    .map((url) => ({
+      url,
+      title: null,
+      state: null,
+      occurredAt: null,
+      updatedAt: null,
+      additions: null,
+      deletions: null,
+    }));
+  if (additions.length) retainGitHubItems(sessionId, additions);
+}
+
 // The colors GitHub itself answers in, so a glance here reads the same as a glance there.
 const GITHUB_STATE = {
   open: "success",

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -32,7 +32,6 @@ const DEEPSEEK_MODEL_KEY = "lite.newSession.deepseekModel.v1";
 const DEEPSEEK_REASONING_KEY = "lite.newSession.deepseekReasoning.v1";
 const NAME_KEY = "lite.newSession.name.v1";
 const WORKTREE_KEY = "lite.newSession.worktree.v1";
-const REMOTE_KEY = "lite.newSession.remote.v1";
 const SSH_HOST_KEY = "lite.newSession.sshHost.v1";
 const DEEPSEEK_MODELS = [
   { value: "deepseek-v4-flash", label: "Flash" },
@@ -120,7 +119,7 @@ export function NewSessionDialog({
   });
   const [directory, setDirectory] = useState<DirectoryGrant>();
   const [path, setPath] = useState("");
-  const [remoteSelected, setRemoteSelected] = useState(() => localStorage.getItem(REMOTE_KEY) === "true");
+  const [remoteSelected, setRemoteSelected] = useState(false);
   const remote = remoteSsh && remoteSelected;
   const [host, setHost] = useState(() => localStorage.getItem(SSH_HOST_KEY) ?? "");
   const [availability, setAvailability] = useState<Record<string, Availability>>({});
@@ -281,7 +280,10 @@ export function NewSessionDialog({
       setDirectory(undefined);
     }
     // A cancelled dialog stays mounted, so a name typed into it must not wait for the next session.
-    if (!open) setTitle((current) => (current === undefined ? undefined : ""));
+    if (!open) {
+      setTitle((current) => (current === undefined ? undefined : ""));
+      setRemoteSelected(false);
+    }
     onOpenChange(open);
   }
 
@@ -333,6 +335,7 @@ export function NewSessionDialog({
       });
       setDirectory(undefined);
       setTitle((current) => (current === undefined ? undefined : ""));
+      setRemoteSelected(false);
       onOpenChange(false);
     } finally {
       setCreating(false);
@@ -407,7 +410,6 @@ export function NewSessionDialog({
                   checked={remote}
                   disabled={creating}
                   onCheckedChange={(checked) => {
-                    localStorage.setItem(REMOTE_KEY, String(checked));
                     if (directory) void invoke("revoke_directory", { rootId: directory.id });
                     setDirectory(undefined);
                     setPath("");

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -14,6 +14,7 @@ import {
   connectTerminalOutput,
   MAX_OUTPUT_BYTES,
   notifyTerminalOutput,
+  readTerminalStream,
   recordTerminalInput,
   subscribeOutput,
   writeSession,
@@ -143,6 +144,7 @@ export function TerminalView({
   starting,
   onZoom,
   onPrompt,
+  onOutput,
   onRecover,
 }: {
   sessionId: string;
@@ -154,12 +156,15 @@ export function TerminalView({
   starting: boolean;
   onZoom: (step: -1 | 0 | 1) => void;
   onPrompt: (text: string) => void;
+  onOutput: (output: string, terminalStream: string) => void;
   onRecover: () => Promise<void>;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Held in a ref so a new prompt handler never rebuilds the terminal underneath the session.
   const promptRef = useRef(onPrompt);
   promptRef.current = onPrompt;
+  const outputRef = useRef(onOutput);
+  outputRef.current = onOutput;
   const recoverRef = useRef(onRecover);
   recoverRef.current = onRecover;
   const zoomRef = useRef(onZoom);
@@ -228,6 +233,7 @@ export function TerminalView({
     // The addon waits for output to go quiet before rebuilding its result map, which a live TUI may
     // never do. Refresh at a bounded rate while it writes; the addon's own timer handles the final pass.
     let searchRefresh = 0;
+    let outputRefresh = 0;
     const refreshSearch = () => {
       const query = searchQueryRef.current;
       if (!query) return;
@@ -238,6 +244,11 @@ export function TerminalView({
     };
     const parsed = terminal.onWriteParsed(() => {
       notifyTerminalOutput(sessionId);
+      window.clearTimeout(outputRefresh);
+      outputRefresh = window.setTimeout(
+        () => outputRef.current(renderedOutput(terminal), readTerminalStream(sessionId)),
+        250,
+      );
       if (!searchQueryRef.current) return;
       if (!searchRefresh)
         searchRefresh = window.setTimeout(() => {
@@ -342,6 +353,7 @@ export function TerminalView({
     return () => {
       window.clearTimeout(settle);
       window.clearTimeout(searchRefresh);
+      window.clearTimeout(outputRefresh);
       observer.disconnect();
       searchResults.dispose();
       input.dispose();

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -242,13 +242,16 @@ export function TerminalView({
       searchAddon.clearDecorations();
       searchAddon.findNext(query, { ...searchOptions(themeRef.current), incremental: true });
     };
+    const rememberOutput = () => outputRef.current(renderedOutput(terminal), readTerminalStream(sessionId));
     const parsed = terminal.onWriteParsed(() => {
       notifyTerminalOutput(sessionId);
-      window.clearTimeout(outputRefresh);
-      outputRefresh = window.setTimeout(
-        () => outputRef.current(renderedOutput(terminal), readTerminalStream(sessionId)),
-        250,
-      );
+      if (!outputRefresh) {
+        rememberOutput();
+        outputRefresh = window.setTimeout(() => {
+          outputRefresh = 0;
+          rememberOutput();
+        }, 250);
+      }
       if (!searchQueryRef.current) return;
       if (!searchRefresh)
         searchRefresh = window.setTimeout(() => {


### PR DESCRIPTION
## Summary

- default every new-session dialog to a local workspace instead of remembering Remote SSH
- snapshot only currently live working sessions before an update restart and clear replaced session activity
- retain rendered GitHub PR and issue links before Claude redraws them out of its terminal history
- bump Lite from 0.0.37 to 0.0.38

## Validation

- `bun run check`
- `bun test` (20 passed)
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` (7 passed)
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Fixed Lite session recovery, update-state persistence, GitHub link retention, and new-session defaults, and bumped the application version to 0.0.38.

### 📊 Key Changes

- New-session dialogs now start with local workspace selected and reset the Remote SSH selection when closed or after creating a session.
- Update installation snapshots only live, connected working sessions, while session replacement clears obsolete working-state timers and entries and restores activity if recovery fails.
- Terminal output now records GitHub PR and issue references as they are rendered, preserving links that may later disappear from a redrawn terminal.
- Updated the Rust package and lockfile version from 0.0.37 to 0.0.38.

### 🎯 Purpose & Impact

- New sessions no longer inherit a previous Remote SSH choice, reducing accidental remote session creation.
- Restart and update recovery preserves active work more accurately and removes activity for replaced or disconnected sessions.
- GitHub references remain available to the Git panel after terminal redraws, with their metadata populated when the panel is opened.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
