### PR TITLE
Select session title when renaming

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1405,6 +1405,7 @@ function SessionRow({
           defaultValue={session.name}
           className="min-w-0 flex-1"
           aria-label="Session name"
+          onFocus={(event) => event.currentTarget.select()}
           onBlur={(event) => saveName(event.currentTarget.value)}
           onKeyDown={(event) => {
             if (event.key === "Enter") event.currentTarget.blur();


### PR DESCRIPTION
## Summary

- select the existing session name when the rename input receives focus
- allow immediate typing to replace the full title

## Validation

- `bun run check`
- `bun run build`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Session renaming now selects the existing title when the name input receives focus, allowing users to replace it immediately by typing.

### 📊 Key Changes

- Added an `onFocus` handler to the session name input in `SessionRow`.
- The handler selects the full current session name when editing begins.
- Existing save behavior remains tied to input blur, with Enter still committing the edit by triggering blur.

### 🎯 Purpose & Impact

- Renaming sessions no longer requires users to manually select or delete the existing title before typing a replacement.