### PR TITLE
Add undoable Git repository removal

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.38"
+version = "0.0.39"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1249,11 +1249,11 @@ function RepositoryCard({
 
   return (
     <section className="overflow-hidden rounded-lg border">
-      <div className="flex items-start">
+      <div className="group/repository flex items-start hover:bg-muted focus-within:bg-muted">
         {repository.url ? (
           <button
             type="button"
-            className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2.5 text-left hover:bg-muted"
+            className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2.5 text-left"
             title={`Open ${repository.url}`}
             data-context-url={repository.url}
             onClick={() => void invoke("open_url", { url: repository.url })}
@@ -1266,7 +1266,7 @@ function RepositoryCard({
         {onRemove ? (
           <ActionIconButton
             size="icon-sm"
-            className="mt-1.5 mr-1.5 text-muted-foreground hover:text-destructive"
+            className="mt-1.5 mr-1.5 hidden text-muted-foreground hover:text-destructive group-hover/repository:inline-flex group-focus-within/repository:inline-flex"
             tooltip="Remove repository"
             aria-label={`Remove ${repository.name}`}
             onClick={onRemove}

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/components/ui/dialog";
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
-import { Item, ItemActions, ItemContent, ItemDescription, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
+import { Item, ItemContent, ItemDescription, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
@@ -127,27 +127,35 @@ interface GitHubItem {
 }
 
 const GITHUB_ITEMS_KEY = "lite.github-items";
-const REMOVED_GITHUB_ITEMS_KEY = "lite.github-items.removed";
+const REMOVED_GITHUB_REPOSITORIES_KEY = "lite.github-repositories.removed";
 
-function removedGitHubItems(sessionId: string) {
-  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
+function removedGitHubRepositories(sessionId: string) {
+  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_REPOSITORIES_KEY) ?? "{}") as Record<
+    string,
+    string[]
+  >;
   return new Set(sessions[sessionId] ?? []);
 }
 
-function setGitHubItemRemoved(sessionId: string, url: string, removed: boolean) {
-  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
-  const items = new Set(sessions[sessionId] ?? []);
-  if (removed) items.add(itemKey(url));
-  else items.delete(itemKey(url));
-  if (items.size) sessions[sessionId] = [...items];
+function setGitHubRepositoryRemoved(sessionId: string, url: string, removed: boolean) {
+  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_REPOSITORIES_KEY) ?? "{}") as Record<
+    string,
+    string[]
+  >;
+  const repositories = new Set(sessions[sessionId] ?? []);
+  if (removed) repositories.add(url.toLowerCase());
+  else repositories.delete(url.toLowerCase());
+  if (repositories.size) sessions[sessionId] = [...repositories];
   else delete sessions[sessionId];
-  localStorage.setItem(REMOVED_GITHUB_ITEMS_KEY, JSON.stringify(sessions));
+  localStorage.setItem(REMOVED_GITHUB_REPOSITORIES_KEY, JSON.stringify(sessions));
 }
 
 function sessionGitHubItems(sessionId: string) {
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
-  const removed = removedGitHubItems(sessionId);
-  return (sessions[sessionId] ?? []).filter((item) => !removed.has(itemKey(item.url)));
+  const removed = removedGitHubRepositories(sessionId);
+  return (sessions[sessionId] ?? []).filter(
+    (item) => !removed.has(githubReference(item.url).repositoryUrl.toLowerCase()),
+  );
 }
 
 function retainGitHubItems(sessionId: string, updates: GitHubItem[]) {
@@ -264,77 +272,53 @@ function repositoryGroups(remote: string, status: GitStatus | null, items: GitHu
   return [...groups.values()];
 }
 
-function GitHubItemList({
-  label,
-  items,
-  onRemove,
-}: {
-  label: string;
-  items: RepositoryGroup["items"];
-  onRemove: (item: GitHubItem) => void;
-}) {
+function GitHubItemList({ label, items }: { label: string; items: RepositoryGroup["items"] }) {
   if (!items.length) return null;
   return (
     <div className="border-t">
       <p className="px-3 pt-2 pb-1 text-xs font-medium text-muted-foreground">{label}</p>
       <ItemGroup className="has-data-[size=xs]:gap-0">
-        {items.map((item) => {
-          const { url, title, state, occurredAt, additions, deletions, kind, number } = item;
-          return (
-            <Item
-              key={url}
-              size="xs"
-              className="flex-nowrap items-stretch gap-0 rounded-none p-0 text-left hover:bg-muted"
-            >
+        {items.map(({ url, title, state, occurredAt, additions, deletions, kind, number }) => (
+          <Item
+            key={url}
+            size="xs"
+            className="flex-nowrap items-start rounded-none px-3 text-left hover:bg-muted"
+            render={
               <button
                 type="button"
-                className="flex min-w-0 flex-1 items-start gap-2 px-3 py-2 text-left"
                 title={url}
                 data-context-url={url}
                 onClick={() => void invoke("open_url", { url })}
-              >
-                <ItemMedia variant="icon" className={state ? GITHUB_STATE_ICON[state] : "text-muted-foreground"}>
-                  <GitHubItemIcon kind={kind} state={state} />
-                </ItemMedia>
-                <ItemContent>
-                  <ItemTitle className="w-full">{title ?? `#${number}`}</ItemTitle>
-                  {title ? (
-                    <div className="flex min-w-0 items-center gap-2">
-                      <ItemDescription className="min-w-0 truncate font-mono">
-                        #{number}
-                        {occurredAt ? ` · ${relativeAge(occurredAt)}` : ""}
-                      </ItemDescription>
-                      {additions ? (
-                        <span className="shrink-0 font-mono text-xs text-green-600 dark:text-green-400">
-                          +{additions}
-                        </span>
-                      ) : null}
-                      {deletions ? (
-                        <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{deletions}</span>
-                      ) : null}
-                      {state ? (
-                        <Badge className="ml-auto" variant={GITHUB_STATE[state]}>
-                          {state}
-                        </Badge>
-                      ) : null}
-                    </div>
+              />
+            }
+          >
+            <ItemMedia variant="icon" className={state ? GITHUB_STATE_ICON[state] : "text-muted-foreground"}>
+              <GitHubItemIcon kind={kind} state={state} />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle className="w-full">{title ?? `#${number}`}</ItemTitle>
+              {title ? (
+                <div className="flex min-w-0 items-center gap-2">
+                  <ItemDescription className="min-w-0 truncate font-mono">
+                    #{number}
+                    {occurredAt ? ` · ${relativeAge(occurredAt)}` : ""}
+                  </ItemDescription>
+                  {additions ? (
+                    <span className="shrink-0 font-mono text-xs text-green-600 dark:text-green-400">+{additions}</span>
                   ) : null}
-                </ItemContent>
-              </button>
-              <ItemActions className="self-center pr-1">
-                <ActionIconButton
-                  size="icon-xs"
-                  className="text-muted-foreground hover:text-destructive"
-                  tooltip={`Remove ${kind}`}
-                  aria-label={`Remove ${kind} #${number}`}
-                  onClick={() => onRemove(item)}
-                >
-                  <Trash2 />
-                </ActionIconButton>
-              </ItemActions>
-            </Item>
-          );
-        })}
+                  {deletions ? (
+                    <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{deletions}</span>
+                  ) : null}
+                  {state ? (
+                    <Badge className="ml-auto" variant={GITHUB_STATE[state]}>
+                      {state}
+                    </Badge>
+                  ) : null}
+                </div>
+              ) : null}
+            </ItemContent>
+          </Item>
+        ))}
       </ItemGroup>
     </div>
   );
@@ -1227,11 +1211,11 @@ function DiffViewer({
 function RepositoryCard({
   repository,
   onOpenDiff,
-  onRemoveItem,
+  onRemove,
 }: {
   repository: RepositoryGroup;
   onOpenDiff: (path: string) => void;
-  onRemoveItem: (item: GitHubItem) => void;
+  onRemove?: () => void;
 }) {
   const pullRequests = repository.items.filter((item) => item.kind === "pull request");
   const issues = repository.items.filter((item) => item.kind === "issue");
@@ -1265,19 +1249,32 @@ function RepositoryCard({
 
   return (
     <section className="overflow-hidden rounded-lg border">
-      {repository.url ? (
-        <button
-          type="button"
-          className="flex w-full flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2.5 text-left hover:bg-muted"
-          title={`Open ${repository.url}`}
-          data-context-url={repository.url}
-          onClick={() => void invoke("open_url", { url: repository.url })}
-        >
-          {header}
-        </button>
-      ) : (
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2.5">{header}</div>
-      )}
+      <div className="flex items-start">
+        {repository.url ? (
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2.5 text-left hover:bg-muted"
+            title={`Open ${repository.url}`}
+            data-context-url={repository.url}
+            onClick={() => void invoke("open_url", { url: repository.url })}
+          >
+            {header}
+          </button>
+        ) : (
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2.5">{header}</div>
+        )}
+        {onRemove ? (
+          <ActionIconButton
+            size="icon-sm"
+            className="mt-1.5 mr-1.5 text-muted-foreground hover:text-destructive"
+            tooltip="Remove repository"
+            aria-label={`Remove ${repository.name}`}
+            onClick={onRemove}
+          >
+            <Trash2 />
+          </ActionIconButton>
+        ) : null}
+      </div>
       {repository.changes.length ? (
         <div className="border-t px-2.5 py-2">
           <p className="mb-1 px-0.5 text-xs font-medium">Changes</p>
@@ -1312,8 +1309,8 @@ function RepositoryCard({
           })}
         </div>
       ) : null}
-      <GitHubItemList label="Pull requests" items={pullRequests} onRemove={onRemoveItem} />
-      <GitHubItemList label="Issues" items={issues} onRemove={onRemoveItem} />
+      <GitHubItemList label="Pull requests" items={pullRequests} />
+      <GitHubItemList label="Issues" items={issues} />
     </section>
   );
 }
@@ -1326,9 +1323,9 @@ export function clearInspectorCache(sessionId: string) {
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
   delete sessions[sessionId];
   localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
-  const removed = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
+  const removed = JSON.parse(localStorage.getItem(REMOVED_GITHUB_REPOSITORIES_KEY) ?? "{}") as Record<string, string[]>;
   delete removed[sessionId];
-  localStorage.setItem(REMOVED_GITHUB_ITEMS_KEY, JSON.stringify(removed));
+  localStorage.setItem(REMOVED_GITHUB_REPOSITORIES_KEY, JSON.stringify(removed));
 }
 
 function GitPanel({
@@ -1446,19 +1443,21 @@ function GitPanel({
     setDiffPath("");
   }, []);
 
-  function removeItem(item: GitHubItem) {
-    setGitHubItemRemoved(sessionId, item.url, true);
+  function removeRepository(repository: RepositoryGroup) {
+    const url = repository.url;
+    if (!url) return;
+    setGitHubRepositoryRemoved(sessionId, url, true);
     setItems(sessionGitHubItems(sessionId));
     let toastId = "";
     toastId = toast.add({
-      title: "Removed",
-      description: item.title ?? item.url,
+      title: "Removed repository",
+      description: repository.name,
       type: "success",
       timeout: 8000,
       actionProps: {
         children: "Undo",
         onClick: () => {
-          setGitHubItemRemoved(sessionId, item.url, false);
+          setGitHubRepositoryRemoved(sessionId, url, false);
           setItems(sessionGitHubItems(sessionId));
           toast.close(toastId);
         },
@@ -1475,6 +1474,7 @@ function GitPanel({
   }, [error, onLoad, status]);
 
   const repositories = repositoryGroups(remote, status ?? null, items);
+  const itemRepositories = new Set(items.map((item) => githubReference(item.url).repositoryUrl.toLowerCase()));
   // Searching narrows each card to what matches — a changed path, an item's title or number, or the
   // repository's own name — and drops the cards left holding nothing.
   const lowered = query.trim().toLowerCase();
@@ -1516,7 +1516,11 @@ function GitPanel({
                 key={(repository.url ?? repository.path)?.toLowerCase()}
                 repository={repository}
                 onOpenDiff={(path) => void openDiff(path)}
-                onRemoveItem={removeItem}
+                onRemove={
+                  repository.url && itemRepositories.has(repository.url.toLowerCase())
+                    ? () => removeRepository(repository)
+                    : undefined
+                }
               />
             ))}
             {lowered && status !== undefined && repositories.length && !shown.length ? (

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -114,6 +114,10 @@ function githubReference(url: string): GitHubReference {
   };
 }
 
+function githubRepositoryKey(url: string) {
+  return url.split("/").slice(3, 5).join("/").toLowerCase();
+}
+
 // Every optional field arrives from Serde as null, never as a missing key. A state of null is a link
 // GitHub could not be asked about rather than one it disowned; those are dropped before they arrive.
 interface GitHubItem {
@@ -127,35 +131,29 @@ interface GitHubItem {
 }
 
 const GITHUB_ITEMS_KEY = "lite.github-items";
-const REMOVED_GITHUB_REPOSITORIES_KEY = "lite.github-repositories.removed";
+const REMOVED_GITHUB_ITEMS_KEY = "lite.github-items.removed";
 
-function removedGitHubRepositories(sessionId: string) {
-  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_REPOSITORIES_KEY) ?? "{}") as Record<
-    string,
-    string[]
-  >;
+function removedGitHubItems(sessionId: string) {
+  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
   return new Set(sessions[sessionId] ?? []);
 }
 
-function setGitHubRepositoryRemoved(sessionId: string, url: string, removed: boolean) {
-  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_REPOSITORIES_KEY) ?? "{}") as Record<
-    string,
-    string[]
-  >;
-  const repositories = new Set(sessions[sessionId] ?? []);
-  if (removed) repositories.add(url.toLowerCase());
-  else repositories.delete(url.toLowerCase());
-  if (repositories.size) sessions[sessionId] = [...repositories];
+function setGitHubItemsRemoved(sessionId: string, urls: string[], removed: boolean) {
+  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
+  const items = new Set(sessions[sessionId] ?? []);
+  for (const url of urls) {
+    if (removed) items.add(itemKey(url));
+    else items.delete(itemKey(url));
+  }
+  if (items.size) sessions[sessionId] = [...items];
   else delete sessions[sessionId];
-  localStorage.setItem(REMOVED_GITHUB_REPOSITORIES_KEY, JSON.stringify(sessions));
+  localStorage.setItem(REMOVED_GITHUB_ITEMS_KEY, JSON.stringify(sessions));
 }
 
 function sessionGitHubItems(sessionId: string) {
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
-  const removed = removedGitHubRepositories(sessionId);
-  return (sessions[sessionId] ?? []).filter(
-    (item) => !removed.has(githubReference(item.url).repositoryUrl.toLowerCase()),
-  );
+  const removed = removedGitHubItems(sessionId);
+  return (sessions[sessionId] ?? []).filter((item) => !removed.has(itemKey(item.url)));
 }
 
 function retainGitHubItems(sessionId: string, updates: GitHubItem[]) {
@@ -1323,9 +1321,9 @@ export function clearInspectorCache(sessionId: string) {
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
   delete sessions[sessionId];
   localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
-  const removed = JSON.parse(localStorage.getItem(REMOVED_GITHUB_REPOSITORIES_KEY) ?? "{}") as Record<string, string[]>;
+  const removed = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
   delete removed[sessionId];
-  localStorage.setItem(REMOVED_GITHUB_REPOSITORIES_KEY, JSON.stringify(removed));
+  localStorage.setItem(REMOVED_GITHUB_ITEMS_KEY, JSON.stringify(removed));
 }
 
 function GitPanel({
@@ -1446,7 +1444,11 @@ function GitPanel({
   function removeRepository(repository: RepositoryGroup) {
     const url = repository.url;
     if (!url) return;
-    setGitHubRepositoryRemoved(sessionId, url, true);
+    const urls = items
+      .filter((item) => githubRepositoryKey(item.url) === githubRepositoryKey(url))
+      .map((item) => item.url);
+    if (!urls.length) return;
+    setGitHubItemsRemoved(sessionId, urls, true);
     setItems(sessionGitHubItems(sessionId));
     let toastId = "";
     toastId = toast.add({
@@ -1457,7 +1459,7 @@ function GitPanel({
       actionProps: {
         children: "Undo",
         onClick: () => {
-          setGitHubRepositoryRemoved(sessionId, url, false);
+          setGitHubItemsRemoved(sessionId, urls, false);
           setItems(sessionGitHubItems(sessionId));
           toast.close(toastId);
         },
@@ -1473,8 +1475,14 @@ function GitPanel({
     if (status !== undefined || error) onLoad("git");
   }, [error, onLoad, status]);
 
-  const repositories = repositoryGroups(remote, status ?? null, items);
-  const itemRepositories = new Set(items.map((item) => githubReference(item.url).repositoryUrl.toLowerCase()));
+  const removedRepositories = new Set(
+    [...removedGitHubItems(sessionId)].map((item) => item.slice(0, item.lastIndexOf("#"))),
+  );
+  const repositories = repositoryGroups(remote, status ?? null, items).filter(
+    (repository) =>
+      !repository.url || repository.items.length || !removedRepositories.has(githubRepositoryKey(repository.url)),
+  );
+  const itemRepositories = new Set(items.map((item) => githubRepositoryKey(item.url)));
   // Searching narrows each card to what matches — a changed path, an item's title or number, or the
   // repository's own name — and drops the cards left holding nothing.
   const lowered = query.trim().toLowerCase();
@@ -1517,7 +1525,7 @@ function GitPanel({
                 repository={repository}
                 onOpenDiff={(path) => void openDiff(path)}
                 onRemove={
-                  repository.url && itemRepositories.has(repository.url.toLowerCase())
+                  repository.url && itemRepositories.has(githubRepositoryKey(repository.url))
                     ? () => removeRepository(repository)
                     : undefined
                 }

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -155,7 +155,7 @@ function retainGitHubItems(sessionId: string, updates: GitHubItem[]) {
   const items = mergeGitHubItems(sessions[sessionId] ?? [], updates);
   sessions[sessionId] = items;
   localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
-  return items;
+  return sessionGitHubItems(sessionId);
 }
 
 // Full-screen terminals can redraw a link away before the Git panel is opened. Remember references

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -50,11 +50,12 @@ import {
 } from "@/components/ui/dialog";
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
-import { Item, ItemContent, ItemDescription, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemGroup, ItemMedia, ItemTitle } from "@/components/ui/item";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { toast } from "@/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { githubItemReferences, itemKey, likelyGitHubItems, mergeGitHubItems } from "@/github-items";
 import { SEMANTIC_PROGRESS_CLASSES, type SemanticTone } from "@/lib/semantic-styles";
@@ -126,10 +127,27 @@ interface GitHubItem {
 }
 
 const GITHUB_ITEMS_KEY = "lite.github-items";
+const REMOVED_GITHUB_ITEMS_KEY = "lite.github-items.removed";
+
+function removedGitHubItems(sessionId: string) {
+  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
+  return new Set(sessions[sessionId] ?? []);
+}
+
+function setGitHubItemRemoved(sessionId: string, url: string, removed: boolean) {
+  const sessions = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
+  const items = new Set(sessions[sessionId] ?? []);
+  if (removed) items.add(itemKey(url));
+  else items.delete(itemKey(url));
+  if (items.size) sessions[sessionId] = [...items];
+  else delete sessions[sessionId];
+  localStorage.setItem(REMOVED_GITHUB_ITEMS_KEY, JSON.stringify(sessions));
+}
 
 function sessionGitHubItems(sessionId: string) {
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
-  return sessions[sessionId] ?? [];
+  const removed = removedGitHubItems(sessionId);
+  return (sessions[sessionId] ?? []).filter((item) => !removed.has(itemKey(item.url)));
 }
 
 function retainGitHubItems(sessionId: string, updates: GitHubItem[]) {
@@ -246,53 +264,77 @@ function repositoryGroups(remote: string, status: GitStatus | null, items: GitHu
   return [...groups.values()];
 }
 
-function GitHubItemList({ label, items }: { label: string; items: RepositoryGroup["items"] }) {
+function GitHubItemList({
+  label,
+  items,
+  onRemove,
+}: {
+  label: string;
+  items: RepositoryGroup["items"];
+  onRemove: (item: GitHubItem) => void;
+}) {
   if (!items.length) return null;
   return (
     <div className="border-t">
       <p className="px-3 pt-2 pb-1 text-xs font-medium text-muted-foreground">{label}</p>
       <ItemGroup className="has-data-[size=xs]:gap-0">
-        {items.map(({ url, title, state, occurredAt, additions, deletions, kind, number }) => (
-          <Item
-            key={url}
-            size="xs"
-            className="flex-nowrap items-start rounded-none px-3 text-left hover:bg-muted"
-            render={
+        {items.map((item) => {
+          const { url, title, state, occurredAt, additions, deletions, kind, number } = item;
+          return (
+            <Item
+              key={url}
+              size="xs"
+              className="flex-nowrap items-stretch gap-0 rounded-none p-0 text-left hover:bg-muted"
+            >
               <button
                 type="button"
+                className="flex min-w-0 flex-1 items-start gap-2 px-3 py-2 text-left"
                 title={url}
                 data-context-url={url}
                 onClick={() => void invoke("open_url", { url })}
-              />
-            }
-          >
-            <ItemMedia variant="icon" className={state ? GITHUB_STATE_ICON[state] : "text-muted-foreground"}>
-              <GitHubItemIcon kind={kind} state={state} />
-            </ItemMedia>
-            <ItemContent>
-              <ItemTitle className="w-full">{title ?? `#${number}`}</ItemTitle>
-              {title ? (
-                <div className="flex min-w-0 items-center gap-2">
-                  <ItemDescription className="min-w-0 truncate font-mono">
-                    #{number}
-                    {occurredAt ? ` · ${relativeAge(occurredAt)}` : ""}
-                  </ItemDescription>
-                  {additions ? (
-                    <span className="shrink-0 font-mono text-xs text-green-600 dark:text-green-400">+{additions}</span>
+              >
+                <ItemMedia variant="icon" className={state ? GITHUB_STATE_ICON[state] : "text-muted-foreground"}>
+                  <GitHubItemIcon kind={kind} state={state} />
+                </ItemMedia>
+                <ItemContent>
+                  <ItemTitle className="w-full">{title ?? `#${number}`}</ItemTitle>
+                  {title ? (
+                    <div className="flex min-w-0 items-center gap-2">
+                      <ItemDescription className="min-w-0 truncate font-mono">
+                        #{number}
+                        {occurredAt ? ` · ${relativeAge(occurredAt)}` : ""}
+                      </ItemDescription>
+                      {additions ? (
+                        <span className="shrink-0 font-mono text-xs text-green-600 dark:text-green-400">
+                          +{additions}
+                        </span>
+                      ) : null}
+                      {deletions ? (
+                        <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{deletions}</span>
+                      ) : null}
+                      {state ? (
+                        <Badge className="ml-auto" variant={GITHUB_STATE[state]}>
+                          {state}
+                        </Badge>
+                      ) : null}
+                    </div>
                   ) : null}
-                  {deletions ? (
-                    <span className="shrink-0 font-mono text-xs text-red-600 dark:text-red-400">-{deletions}</span>
-                  ) : null}
-                  {state ? (
-                    <Badge className="ml-auto" variant={GITHUB_STATE[state]}>
-                      {state}
-                    </Badge>
-                  ) : null}
-                </div>
-              ) : null}
-            </ItemContent>
-          </Item>
-        ))}
+                </ItemContent>
+              </button>
+              <ItemActions className="self-center pr-1">
+                <ActionIconButton
+                  size="icon-xs"
+                  className="text-muted-foreground hover:text-destructive"
+                  tooltip={`Remove ${kind}`}
+                  aria-label={`Remove ${kind} #${number}`}
+                  onClick={() => onRemove(item)}
+                >
+                  <Trash2 />
+                </ActionIconButton>
+              </ItemActions>
+            </Item>
+          );
+        })}
       </ItemGroup>
     </div>
   );
@@ -1185,9 +1227,11 @@ function DiffViewer({
 function RepositoryCard({
   repository,
   onOpenDiff,
+  onRemoveItem,
 }: {
   repository: RepositoryGroup;
   onOpenDiff: (path: string) => void;
+  onRemoveItem: (item: GitHubItem) => void;
 }) {
   const pullRequests = repository.items.filter((item) => item.kind === "pull request");
   const issues = repository.items.filter((item) => item.kind === "issue");
@@ -1268,8 +1312,8 @@ function RepositoryCard({
           })}
         </div>
       ) : null}
-      <GitHubItemList label="Pull requests" items={pullRequests} />
-      <GitHubItemList label="Issues" items={issues} />
+      <GitHubItemList label="Pull requests" items={pullRequests} onRemove={onRemoveItem} />
+      <GitHubItemList label="Issues" items={issues} onRemove={onRemoveItem} />
     </section>
   );
 }
@@ -1282,6 +1326,9 @@ export function clearInspectorCache(sessionId: string) {
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
   delete sessions[sessionId];
   localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
+  const removed = JSON.parse(localStorage.getItem(REMOVED_GITHUB_ITEMS_KEY) ?? "{}") as Record<string, string[]>;
+  delete removed[sessionId];
+  localStorage.setItem(REMOVED_GITHUB_ITEMS_KEY, JSON.stringify(removed));
 }
 
 function GitPanel({
@@ -1399,6 +1446,26 @@ function GitPanel({
     setDiffPath("");
   }, []);
 
+  function removeItem(item: GitHubItem) {
+    setGitHubItemRemoved(sessionId, item.url, true);
+    setItems(sessionGitHubItems(sessionId));
+    let toastId = "";
+    toastId = toast.add({
+      title: "Removed",
+      description: item.title ?? item.url,
+      type: "success",
+      timeout: 8000,
+      actionProps: {
+        children: "Undo",
+        onClick: () => {
+          setGitHubItemRemoved(sessionId, item.url, false);
+          setItems(sessionGitHubItems(sessionId));
+          toast.close(toastId);
+        },
+      },
+    });
+  }
+
   useEffect(() => {
     void refresh();
   }, [refresh]);
@@ -1449,6 +1516,7 @@ function GitPanel({
                 key={(repository.url ?? repository.path)?.toLowerCase()}
                 repository={repository}
                 onOpenDiff={(path) => void openDiff(path)}
+                onRemoveItem={removeItem}
               />
             ))}
             {lowered && status !== undefined && repositories.length && !shown.length ? (


### PR DESCRIPTION
## Summary
- add a remove icon to the top-right of Git repository cards, matching sidebar hover behavior
- hide the whole card while retaining tombstones for the PRs/issues removed with it, so future new items can surface the repository without restoring old ones
- restore the removal batch from the shared Undo toast
- bump Lite from 0.0.38 to 0.0.39

## Validation
- bun run check
- bun test
- bun run build
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Git repository cards can now be removed and restored through an Undo toast, while preserving removal state for existing GitHub items per session.

### 📊 Key Changes

- Added a hover/focus-visible trash button to repository cards for repositories with tracked GitHub items.
- Stores removed GitHub item keys in session-scoped local storage and filters them from the Git panel.
- Hides removed repository cards while allowing newly discovered items from the repository to appear later without restoring previously removed items.
- Added an 8-second “Undo” toast that restores the entire repository removal batch.
- Bumped the Lite version from `0.0.38` to `0.0.39`.

### 🎯 Purpose & Impact

- Users can remove unwanted repositories from the Git panel and undo the removal without losing the underlying cached data.
- Clearing an inspector session now also clears its repository-removal state.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
