### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -77,7 +77,7 @@ body:
     attributes:
       label: Minimal Reproducible Example
       description: >
-        When asking a question, people will be better able to provide help if you provide the exact steps they can follow to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+        When asking a question, people will be better able to provide help if you provide the exact steps they can follow to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example).
       placeholder: |
         1. Open Lite and start a new session with ...
         2. ...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     url: https://github.com/ultralytics/lite/releases/latest
     about: Download the latest Ultralytics Lite release
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
-Lite is a fast, local workspace for [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://developers.openai.com/codex/cli) on OpenAI, [DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/codex), or [OpenRouter](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli), [Gemini CLI](https://google-gemini.github.io/gemini-cli/), [Kimi Code](https://www.kimi.com/code), [Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/), and your shell. Keep agent sessions, files, and Git context together without repository indexing, telemetry, or a cloud service.
+Lite is a fast, local workspace for [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://learn.chatgpt.com/docs/codex/cli) on OpenAI, [DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/codex), or [OpenRouter](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli), [Gemini CLI](https://google-gemini.github.io/gemini-cli/), [Kimi Code](https://www.kimi.com/code), [Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/), and your shell. Keep agent sessions, files, and Git context together without repository indexing, telemetry, or a cloud service.
 
 <div align="center">
   <br>
@@ -74,7 +74,7 @@ After installing Lite, open **Settings** from the gear in the top bar and choose
 Install the provider CLIs you want to use:
 
 - [Claude Code](https://code.claude.com/docs/en/setup)
-- [Codex](https://developers.openai.com/codex/cli)
+- [Codex](https://learn.chatgpt.com/docs/codex/cli)
 - [Gemini CLI](https://google-gemini.github.io/gemini-cli/)
 - [Kimi Code](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html) — Windows also needs Git for Windows
 - [Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
-Lite 是一个快速的本地工作区，支持 [Claude Code](https://code.claude.com/docs/en/overview)、基于 OpenAI、[DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/codex) 或 [OpenRouter](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli) 的 [Codex](https://developers.openai.com/codex/cli)、[Gemini CLI](https://google-gemini.github.io/gemini-cli/)、[Kimi Code](https://www.kimi.com/code)、[Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/) 以及你的 shell。它把 agent 会话、文件和 Git 上下文放在一起，同时不做仓库索引、不采集遥测数据，也不依赖任何云服务。
+Lite 是一个快速的本地工作区，支持 [Claude Code](https://code.claude.com/docs/en/overview)、基于 OpenAI、[DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/codex) 或 [OpenRouter](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli) 的 [Codex](https://learn.chatgpt.com/docs/codex/cli)、[Gemini CLI](https://google-gemini.github.io/gemini-cli/)、[Kimi Code](https://www.kimi.com/code)、[Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/) 以及你的 shell。它把 agent 会话、文件和 Git 上下文放在一起，同时不做仓库索引、不采集遥测数据，也不依赖任何云服务。
 
 <div align="center">
   <br>
@@ -74,7 +74,7 @@ chmod +x Lite_*_linux_amd64.AppImage
 安装你需要使用的 provider CLI：
 
 - [Claude Code](https://code.claude.com/docs/en/setup)
-- [Codex](https://developers.openai.com/codex/cli)
+- [Codex](https://learn.chatgpt.com/docs/codex/cli)
 - [Kimi Code](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html) —— Windows 还需要安装 Git for Windows
 
 在 Lite 中打开每个 provider 并完成一次常规登录。每个 CLI 都把凭据保存在自己的本地存储中，因此之后的 Lite 会话会复用同一份认证信息。Lite 从不读取或复制这些存储。当某个 CLI 缺失时，新建会话对话框会提示你，并给出对应的安装指引。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3592,7 +3592,7 @@ async fn open_setup_docs(agent: String, provider: Option<String>) -> Result<(), 
     }
     let url = match (agent.as_str(), provider.as_deref()) {
         ("claude", _) => "https://code.claude.com/docs/en/setup",
-        ("codex", _) => "https://developers.openai.com/codex/cli",
+        ("codex", _) => "https://learn.chatgpt.com/docs/codex/cli",
         ("gemini", _) => "https://google-gemini.github.io/gemini-cli/",
         ("kimi", _) => {
             "https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html"


### PR DESCRIPTION
Canonicalizes Ultralytics links and refreshes one link that has permanently moved.

## Trailing slashes (2)

Removed the terminating path slash from every `ultralytics.com` / `*.ultralytics.com` URL:

- `.github/ISSUE_TEMPLATE/bug-report.yml` — `docs.ultralytics.com/help/minimum-reproducible-example/` → `…/minimum-reproducible-example`
- `.github/ISSUE_TEMPLATE/config.yml` — `community.ultralytics.com/` → `community.ultralytics.com`

Re-verified afterwards: zero Ultralytics URLs in the repo keep a terminating slash. Only slashes that terminate a path were touched — path separators, the URL-encoded `https%3A%2F%2Fcommunity.ultralytics.com` shields.io badge parameter in both READMEs, license-header URLs, and the `ultralytics.com/discord` vanity shortlink are all unchanged.

## Redirect refresh (1 accepted, 4 rejected)

Accepted — genuine permanent move, verified `308` with a self-canonical `200` destination:

- `developers.openai.com/codex/cli` → `learn.chatgpt.com/docs/codex/cli` (5 occurrences: `README.md` ×2, `README.zh-CN.md` ×2, and the `open_setup_docs` Codex setup link in `src-tauri/src/lib.rs`, kept in sync so the in-app button and the docs agree)

Rejected after review:

- `github.com/ultralytics/lite/releases/latest` → `…/releases/tag/v0.0.39` — a `302` that version-pins an evergreen alias. Baking in a release tag would freeze the download link in `README.md` and in the issue-template contact link at whatever version happened to be current.
- `reddit.com/r/ultralytics` → `www.reddit.com/r/ultralytics/` — host canonicalization only, and the resolved form re-adds a trailing slash.
- `www.rust-lang.org/tools/install` → `rust-lang.org/tools/install/` — same: apex-vs-`www` canonicalization plus a re-added trailing slash, not a content move.
- `api-docs.deepseek.com/quick_start/agent_integrations/codex` → same path with a trailing slash — a `302` that only adds a slash.

No dead links were flagged.

## Notes

- `src-tauri/src/lib.rs` keeps `base_url: "https://api.deepseek.com/"` as-is. That trailing slash is contractual: it is an OpenAI-compatible API base that the Codex harness concatenates paths onto, not a documentation link.
- `tests/github-items.test.ts` fixtures assert exact GitHub URLs and were deliberately left alone; none are Ultralytics-domain URLs.

## Validation

Full diff reviewed line by line — it is URL text only, with no structural or logic changes. `cargo fmt --check` passes, both changed issue templates parse as valid YAML, and `prettier@3.8.5 --print-width 120 --check` reports both READMEs already conform. Frontend lint/typecheck were not run locally because no `.ts`/`.tsx` file is touched; CI covers them.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated documentation, issue-template, and in-app Codex links to their current destinations while removing trailing slashes from Ultralytics URLs.

### 📊 Key Changes
- Replaced five `developers.openai.com/codex/cli` references with `learn.chatgpt.com/docs/codex/cli` in both READMEs and the Tauri setup-docs link.
- Removed trailing slashes from the minimum reproducible example and Ultralytics Community URLs in GitHub issue templates.
- Kept unrelated trailing slashes and URLs unchanged, including API base URLs, encoded badge parameters, and non-Ultralytics links.

### 🎯 Purpose & Impact
- README users and the in-app Codex setup action now open the updated Codex documentation.
- Issue-template links use canonical Ultralytics URL forms.
- No application logic or structural behavior changed.