### PR TITLE
Bump anchore/sbom-action from v0.24.0 to v0.24.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install production dependencies
         run: bun install --frozen-lockfile --production
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0.24.0
+        uses: anchore/sbom-action@v0.24.2
         env:
           SYFT_SOURCE_NAME: Lite
           SYFT_SOURCE_VERSION: ${{ needs.check.outputs.tag }}


### PR DESCRIPTION
Bump anchore/sbom-action from v0.24.0 to v0.24.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the publish workflow to use `anchore/sbom-action` v0.24.2 instead of v0.24.0 for SBOM generation.

### 📊 Key Changes
- Changed the `Generate SBOM` step in `.github/workflows/publish.yml` from `anchore/sbom-action@v0.24.0` to `anchore/sbom-action@v0.24.2`.
- Preserved the existing SBOM configuration, including the `Lite` source name and release tag version.

### 🎯 Purpose & Impact
- The publish workflow now runs SBOM generation with the newer `anchore/sbom-action` patch release.
- No other workflow steps or application code were changed.