### PR TITLE
Remember inspector state per session

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1944,7 +1944,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.40"
+version = "0.0.41"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -348,6 +348,7 @@ const TABS = [
   { value: "usage", label: "Usage", icon: ChartNoAxesColumn },
 ] as const;
 type InspectorTab = (typeof TABS)[number]["value"];
+const inspectorTabsBySession = new Map<string, InspectorTab>();
 
 // Every optional field arrives from Serde as null, never as a missing key.
 interface UsageWindow {
@@ -1356,6 +1357,7 @@ const usageCache = new Map<string, UsageSnapshot | null>();
 export function clearInspectorCache(sessionId: string) {
   usageCache.delete(sessionId);
   fileEditorsBySession.delete(sessionId);
+  inspectorTabsBySession.delete(sessionId);
   const sessions = JSON.parse(localStorage.getItem(GITHUB_ITEMS_KEY) ?? "{}") as Record<string, GitHubItem[]>;
   delete sessions[sessionId];
   localStorage.setItem(GITHUB_ITEMS_KEY, JSON.stringify(sessions));
@@ -1741,10 +1743,10 @@ export const Inspector = memo(function Inspector({
   onExpand: () => void;
   onCollapse: () => void;
 }) {
-  const [tab, setTab] = useState<string>(TABS[0].value);
+  const [tab, setTab] = useState<InspectorTab>(() => inspectorTabsBySession.get(session.id) ?? TABS[0].value);
   const fileSearch = useRef<HTMLInputElement>(null);
   const gitSearch = useRef<HTMLInputElement>(null);
-  const [visited, setVisited] = useState(() => new Set<string>([TABS[0].value]));
+  const [visited, setVisited] = useState(() => new Set<string>([tab]));
   // A tab already names the panel it shows, so the panel does not name itself again. The refresh button
   // rebuilds whichever is open, and every explicit Files visit rebuilds that disk snapshot as well.
   const [reload, setReload] = useState({ files: 0, git: 0, usage: 0 });
@@ -1764,9 +1766,11 @@ export const Inspector = memo(function Inspector({
   }
 
   function selectTab(value: string) {
-    setTab(value);
-    visitTab(value);
-    if (value === "files") refreshTab(value);
+    const next = value as InspectorTab;
+    inspectorTabsBySession.set(session.id, next);
+    setTab(next);
+    visitTab(next);
+    if (next === "files") refreshTab(next);
   }
 
   // Collapsed, the panel is the strip of tabs it collapsed from: the one you pick is the one it reopens


### PR DESCRIPTION
## Summary

- restore each session’s active right-side inspector tab when switching back
- reuse the existing per-session inspector cache so open files remount with their session
- clear remembered tab state through the existing session cleanup path
- bump the patch version to 0.0.41

## Validation

- `bun run check`
- `bun test` (20 passed)
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Inspector tab selections are now remembered per session and restored when returning to that session, with cleanup support and a patch version bump to 0.0.41.

### 📊 Key Changes

- Added an in-memory `inspectorTabsBySession` cache keyed by session ID.
- Initialized each `Inspector` instance from the cached session tab, falling back to the default tab.
- Stored tab selections when users switch tabs and used the selected tab for initial visited-panel state.
- Removed remembered tab state through `clearInspectorCache()`, alongside other session-specific caches.
- Bumped the Tauri package version from `0.0.40` to `0.0.41`.

### 🎯 Purpose & Impact

- Switching away from a session and returning to it restores the last selected right-side Inspector tab.
- Clearing a session also clears its remembered Inspector tab, preventing stale state from persisting.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
