### PR TITLE
Inherit the active session directory

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1944,7 +1944,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.41"
+version = "0.0.42"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1697,8 +1697,11 @@ pub fn capture_claude_status(path: &str, activity_path: &str) -> Result<(), Stri
 fn default_directory(
     app: AppHandle,
     roots: State<Roots>,
+    path: Option<String>,
 ) -> Result<Option<DirectoryGrant>, String> {
-    default_directory_path(&app)
+    path.map(PathBuf::from)
+        .filter(|path| path.is_dir())
+        .or_else(|| default_directory_path(&app))
         .map(|path| grant_directory(&app, &roots, path, None))
         .transpose()
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1656,7 +1656,7 @@ function App() {
   const receiveOutput = useRef<(sessionId: string, runId: string, data: Uint8Array) => void>(() => {});
   const recoveries = useRef(new Map<string, Promise<void>>());
   const recoveryFailures = useRef(new Set<string>());
-  const directoryUpdates = useRef(new Map<string, Promise<void>>());
+  const directoryUpdates = useRef(new Map<string, { path: string; update: Promise<void> }>());
   // Sessions whose worktree the user agreed to force-remove, mapped to whether the approval
   // covered real changes (true) or only ignored files and submodules (false); read at cleanup.
   const forceWorktree = useRef(new Map<string, boolean>());
@@ -1766,7 +1766,9 @@ function App() {
   };
   const openNewSession = useCallback((choice?: string) => {
     const session = selectedRef.current;
-    setNewSessionPath(session && !session.host ? session.cwd : undefined);
+    setNewSessionPath(
+      session && !session.host ? (directoryUpdates.current.get(session.id)?.path ?? session.cwd) : undefined,
+    );
     setNewSessionChoice(choice);
     setNewSessionOpen(true);
   }, []);
@@ -2070,7 +2072,7 @@ function App() {
     const pending = directoryUpdates.current.get(sessionId);
     // A return to the current cwd still belongs behind an in-flight change.
     if (!pending && session.cwd === path) return;
-    const update = (pending ?? Promise.resolve())
+    const update = (pending?.update ?? Promise.resolve())
       .then(async () => {
         const current = sessionsRef.current.find((item) => item.id === sessionId);
         if (!current) return;
@@ -2083,9 +2085,9 @@ function App() {
         );
       })
       .catch((reason) => setError(String(reason)));
-    directoryUpdates.current.set(sessionId, update);
+    directoryUpdates.current.set(sessionId, { path, update });
     void update.then(() => {
-      if (directoryUpdates.current.get(sessionId) === update) directoryUpdates.current.delete(sessionId);
+      if (directoryUpdates.current.get(sessionId)?.update === update) directoryUpdates.current.delete(sessionId);
     });
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1581,6 +1581,7 @@ function App() {
   const [attention, setAttention] = useState<string[]>([]);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [newSessionChoice, setNewSessionChoice] = useState<string>();
+  const [newSessionPath, setNewSessionPath] = useState<string>();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [fileBrowserVersion, setFileBrowserVersion] = useState(0);
   const [notifications, setNotifications] = useState(() => localStorage.getItem(NOTIFICATIONS_KEY) !== "false");
@@ -1763,6 +1764,12 @@ function App() {
       void recoverRef.current(session).catch(() => {});
     } else if (!startingIds.has(session.id)) void resumeSession(session);
   };
+  const openNewSession = useCallback((choice?: string) => {
+    const session = selectedRef.current;
+    setNewSessionPath(session && !session.host ? session.cwd : undefined);
+    setNewSessionChoice(choice);
+    setNewSessionOpen(true);
+  }, []);
 
   // A drag reports every frame, so a side changes state only when the answer changes: handing back the
   // same object leaves React with nothing to redraw while the divider moves.
@@ -1890,7 +1897,7 @@ function App() {
         return;
       }
       if (matchesShortcut(event, "switchSession")) setSessionSwitcherOpen(true);
-      else if (matchesShortcut(event, "newSession")) setNewSessionOpen(true);
+      else if (matchesShortcut(event, "newSession")) openNewSession();
       else if (matchesShortcut(event, "settings")) setSettingsOpen(true);
       else if (matchesShortcut(event, "closeSession") && selectedRef.current) closeRef.current(selectedRef.current);
       else if (matchesShortcut(event, "nextAttention")) {
@@ -1918,7 +1925,7 @@ function App() {
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [openNewSession]);
 
   useEffect(() => {
     localStorage.setItem(
@@ -2373,7 +2380,7 @@ function App() {
     setSettingsOpen(false);
     try {
       const grant =
-        (await invoke<{ id: string; path: string } | null>("default_directory")) ??
+        (await invoke<{ id: string; path: string } | null>("default_directory", { path: null })) ??
         (await invoke<{ id: string; path: string } | null>("choose_directory"));
       if (!grant) return;
       createSession({
@@ -3153,7 +3160,7 @@ function App() {
                         tooltipSide="right"
                         aria-label="New session"
                         data-context-new-session
-                        onClick={() => setNewSessionOpen(true)}
+                        onClick={() => openNewSession()}
                       >
                         <Plus />
                       </ActionIconButton>
@@ -3204,7 +3211,7 @@ function App() {
                         tooltip="New session"
                         aria-label="New session"
                         data-context-new-session
-                        onClick={() => setNewSessionOpen(true)}
+                        onClick={() => openNewSession()}
                       >
                         <Plus />
                       </ActionIconButton>
@@ -3442,13 +3449,7 @@ function App() {
                     )}
                   </div>
                 ) : (
-                  <Welcome
-                    onChoose={(choice) => {
-                      setNewSessionChoice(choice);
-                      setNewSessionOpen(true);
-                    }}
-                    onSettings={() => setSettingsOpen(true)}
-                  />
+                  <Welcome onChoose={openNewSession} onSettings={() => setSettingsOpen(true)} />
                 )}
                 {error ? (
                   <div className="flex shrink-0 items-start gap-2 border-t bg-destructive/10 px-3 py-2 text-xs text-destructive">
@@ -3814,11 +3815,15 @@ function App() {
           <NewSessionDialog
             open={newSessionOpen}
             choice={newSessionChoice}
+            initialPath={newSessionPath}
             remoteSsh={remoteSsh}
             onOpenChange={(open) => {
               setNewSessionOpen(open);
               // A welcome tile's choice is for the dialog it opened; the next opening is the user's own.
-              if (!open) setNewSessionChoice(undefined);
+              if (!open) {
+                setNewSessionChoice(undefined);
+                setNewSessionPath(undefined);
+              }
             }}
             onCreate={createSession}
           />
@@ -3831,7 +3836,7 @@ function App() {
             startingIds={startingIds}
             shellAgents={shellAgents}
             commands={[
-              { id: "new-session", label: "New session", shortcut: "newSession", run: () => setNewSessionOpen(true) },
+              { id: "new-session", label: "New session", shortcut: "newSession", run: openNewSession },
               {
                 id: "next-attention",
                 label: "Open the next session waiting on you",

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -94,6 +94,7 @@ interface Availability {
 export function NewSessionDialog({
   open: isOpen,
   choice: chosen,
+  initialPath,
   remoteSsh,
   onOpenChange,
   onCreate,
@@ -101,6 +102,7 @@ export function NewSessionDialog({
   open: boolean;
   // A choice made outside the dialog — a welcome tile — which the dialog opens on.
   choice?: string;
+  initialPath?: string;
   remoteSsh: boolean;
   onOpenChange: (open: boolean) => void;
   onCreate: (session: Session) => void;
@@ -205,7 +207,7 @@ export function NewSessionDialog({
     setAvailability({});
     setAuth(undefined);
     if (!remote) {
-      void invoke<DirectoryGrant | null>("default_directory")
+      void invoke<DirectoryGrant | null>("default_directory", { path: initialPath ?? null })
         .then((selected) => {
           if (disposed && selected) void invoke("revoke_directory", { rootId: selected.id });
           else if (selected) {
@@ -235,7 +237,7 @@ export function NewSessionDialog({
     return () => {
       disposed = true;
     };
-  }, [isOpen, remote]);
+  }, [initialPath, isOpen, remote]);
 
   async function chooseFolder() {
     setError("");


### PR DESCRIPTION
## Summary

- snapshot the selected local session current working directory whenever New session opens
- seed the existing project-folder grant from that directory, with the saved default as fallback
- route every New session entry point through the same action
- bump Lite from 0.0.41 to 0.0.42

Fixes https://github.com/ultralytics/lite/issues/137

## Validation

- `bun run check`
- `bun test` (20 passing)
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite 0.0.42 makes New session inherit the selected local session’s current directory, falling back to the saved default when needed.

### 📊 Key Changes

- Added `openNewSession`, which captures the selected local session’s current directory, including pending directory changes.
- Routed toolbar buttons, keyboard shortcuts, command actions, and welcome-screen options through the shared New session flow.
- Updated `NewSessionDialog` to pass the captured path to the Rust `default_directory` command.
- Updated `default_directory` to validate the supplied path and fall back to the saved default directory if it is unavailable.
- Bumped the Lite application version from 0.0.41 to 0.0.42.

### 🎯 Purpose & Impact

- Opening New session from a local session now starts with that session’s active project directory selected; remote sessions continue without an inherited path.
- The existing saved default directory remains the fallback when the captured directory is invalid or unavailable.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
