### PR TITLE
Fix terminal resize after display disconnect

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1956,7 +1956,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.42"
+version = "0.0.43"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { FitAddon } from "@xterm/addon-fit";
 import { type ISearchOptions, SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -305,11 +306,15 @@ export function TerminalView({
     // through. Fitting on each one rewraps the scrollback and hands the child a window size it is
     // never shown at, so the terminal is fitted once the size has settled.
     let settle = 0;
-    const observer = new ResizeObserver(() => {
+    const settleResize = () => {
       window.clearTimeout(settle);
       settle = window.setTimeout(resize, 100);
-    });
+    };
+    const observer = new ResizeObserver(settleResize);
     observer.observe(container);
+    // WebKit can miss the element resize when macOS moves a window onto the built-in display after
+    // an external display disconnects. The native window event reaches the same fit owner.
+    const resized = getCurrentWindow().onResized(settleResize);
     // Command and the zoom keys resize the type, as they do in a terminal app.
     terminal.attachCustomKeyEventHandler((event) => {
       if (event.type !== "keydown") return true;
@@ -362,6 +367,7 @@ export function TerminalView({
       window.clearTimeout(searchRefresh);
       window.clearTimeout(outputRefresh);
       observer.disconnect();
+      void resized.then((unlisten) => unlisten());
       searchResults.dispose();
       scroll.dispose();
       input.dispose();


### PR DESCRIPTION
## Summary

- refit terminals from Tauri native window resize events as well as element resize observations
- keep both resize sources on the existing settled fit path
- restore PTY dimensions after macOS moves Lite to the built-in display
- bump Lite from 0.0.42 to 0.0.43 for the patch release

## Validation

- live diagnosis: 1346x949 Lite window retained stale 65x128 PTYs after Studio Display disconnect
- `bun run check`
- `bun test` (20 passing)
- `bun run build`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Terminal resizing now responds to both element and native Tauri window resize events, restoring PTY dimensions after macOS display disconnects; Lite was bumped to 0.0.43.

### 📊 Key Changes

- Added a shared debounced resize handler for terminal fitting.
- Registered the handler with Tauri’s current-window `onResized` event in addition to `ResizeObserver`.
- Removed the native resize listener during terminal cleanup.
- Updated the Lite package version from 0.0.42 to 0.0.43, including the generated Cargo lockfile update.

### 🎯 Purpose & Impact

- Terminal PTY dimensions are refit when macOS moves Lite to the built-in display after an external display disconnect, including cases where WebKit misses the element resize event.
- Existing delayed fitting behavior is preserved, avoiding repeated intermediate terminal resizes during window changes.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
