### PR TITLE
Fix Markdown links and active session contrast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1401,7 +1401,7 @@ function SessionRow({
       }}
       // Never wrapped: Item wraps by default, and a row narrow enough to push the buttons onto a second
       // line takes the tooltip's anchor out from under the pointer that opened it.
-      className={`relative cursor-pointer flex-nowrap transition-[color,background-color,opacity] data-[shifted]:transition-transform data-[shifted]:duration-150 data-[shifted]:ease-out motion-reduce:data-[shifted]:transition-none after:pointer-events-none after:absolute after:inset-x-1 after:z-10 after:hidden after:h-0.5 after:rounded-full after:bg-primary data-[drop=before]:after:-top-0.5 data-[drop=before]:after:block data-[drop=after]:after:-bottom-0.5 data-[drop=after]:after:block active:opacity-70 ${reorderable ? "select-none active:cursor-grabbing" : ""} ${active ? "bg-sidebar-accent text-sidebar-accent-foreground" : "hover:bg-sidebar-accent/60"}`}
+      className={`relative cursor-pointer flex-nowrap transition-[color,background-color,opacity] data-[shifted]:transition-transform data-[shifted]:duration-150 data-[shifted]:ease-out motion-reduce:data-[shifted]:transition-none after:pointer-events-none after:absolute after:inset-x-1 after:z-10 after:hidden after:h-0.5 after:rounded-full after:bg-primary data-[drop=before]:after:-top-0.5 data-[drop=before]:after:block data-[drop=after]:after:-bottom-0.5 data-[drop=after]:after:block active:opacity-70 ${reorderable ? "select-none active:cursor-grabbing" : ""} ${active ? "border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground dark:border-transparent" : "hover:bg-sidebar-accent/60"}`}
     >
       <ItemMedia>
         <SessionBadge
@@ -3177,7 +3177,9 @@ function App() {
                                 aria-label={attention.includes(session.id) ? `${session.name}; ready` : session.name}
                                 data-context-session={session.id}
                                 className={
-                                  session.id === selectedId ? "bg-sidebar-accent" : "hover:bg-sidebar-accent/60"
+                                  session.id === selectedId
+                                    ? "border-sidebar-border bg-sidebar-accent dark:border-transparent"
+                                    : "hover:bg-sidebar-accent/60"
                                 }
                                 onClick={() => openRef.current(session)}
                               />
@@ -3590,7 +3592,6 @@ function App() {
                     <ReleaseNotes
                       source={friendlyReleaseNotes(releaseNotes)}
                       className="mt-4 border-t pt-3 text-sm [&>h2:first-child]:mt-0"
-                      onOpenLink={(url) => void invoke("open_url", { url })}
                     />
                   </Suspense>
                 ) : null}

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -121,7 +121,7 @@ export function MarkdownPreview({ source, className = "" }: { source: string; cl
         remarkPlugins={[remarkGfm]}
         components={{
           a({ href, children }) {
-            return href ? (
+            return href?.startsWith("http://") || href?.startsWith("https://") ? (
               <a
                 href={href}
                 onClick={(event) => {

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -1,5 +1,6 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import { invoke } from "@tauri-apps/api/core";
 import hljs from "highlight.js/lib/core";
 import bash from "highlight.js/lib/languages/bash";
 import cpp from "highlight.js/lib/languages/cpp";
@@ -113,27 +114,19 @@ function LineNumbers({ count }: { count: number }) {
   );
 }
 
-export function MarkdownPreview({
-  source,
-  className = "",
-  onOpenLink,
-}: {
-  source: string;
-  className?: string;
-  onOpenLink?: (url: string) => void;
-}) {
+export function MarkdownPreview({ source, className = "" }: { source: string; className?: string }) {
   return (
     <article className={`markdown-viewer max-w-none ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
           a({ href, children }) {
-            return href && onOpenLink ? (
+            return href ? (
               <a
                 href={href}
                 onClick={(event) => {
                   event.preventDefault();
-                  onOpenLink(href);
+                  void invoke("open_url", { url: href });
                 }}
               >
                 {children}


### PR DESCRIPTION
## Summary

- open rendered Markdown links in the system browser
- strengthen active session visibility in light mode without changing dark mode

Fixes #151
Fixes #152

## Validation

- bun run check
- bun test
- bun run build
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml
- focused server-render probe confirms Markdown links render as anchors

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Markdown link handling to open HTTP(S) links in the system browser and improved selected-session contrast in light mode while preserving dark-mode styling.

### 📊 Key Changes

- `MarkdownPreview` now intercepts `http://` and `https://` links and invokes the Tauri `open_url` command instead of using a caller-provided callback.
- Removed the `onOpenLink` handler from the release-notes rendering path.
- Added `border-sidebar-border` to active session rows and selected session items, with `dark:border-transparent` to retain the existing dark-mode appearance.

### 🎯 Purpose & Impact

- Clicking supported Markdown links, including release-note links, opens them through the system browser.
- Selected sessions are more clearly distinguished in light mode; dark-mode styling is unchanged.