### PR TITLE
Improve Markdown previews and release 0.0.44

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,8 @@
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.12.3",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
@@ -452,6 +454,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
@@ -470,13 +474,27 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "highlight.js": ["highlight.js@11.12.0", "", {}, "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -626,6 +644,8 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
@@ -641,6 +661,10 @@
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-resizable-panels": ["react-resizable-panels@4.12.3", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-GHMJWnDXui/3RX4bT+cgBP+N3N2nkwcoZATr/2xLFpqQQe7TlBrE0cGM0dUa9ceT7A90tUrSRsiqgRG+g0/2AA=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -708,6 +732,8 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
@@ -715,6 +741,8 @@
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.3",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1956,7 +1956,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.43"
+version = "0.0.44"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.43"
+version = "0.0.44"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ use objc2_user_notifications::{
 };
 
 const MAX_FILE_BYTES: u64 = 500_000;
+const MAX_IMAGE_BYTES: u64 = 10_000_000;
 const DIRECTORY_PAGE_SIZE: usize = 250;
 const MAX_GIT_CHANGES: usize = 500;
 const MAX_GIT_DIFF_BYTES: u64 = 1_000_000;
@@ -4617,6 +4618,50 @@ async fn read_text_file(
 }
 
 #[tauri::command]
+async fn read_image_file(
+    roots: State<'_, Roots>,
+    root_id: String,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    let bytes = if let Some(root) = ssh_root(&roots, &root_id)? {
+        tauri::async_runtime::spawn_blocking(move || {
+            let script = scoped_ssh_script(
+                &root,
+                &path,
+                &format!("head -c {} -- \"$path\"", MAX_IMAGE_BYTES + 1),
+            )?;
+            let mut bytes = Vec::new();
+            ssh_stream(&root, &script, None, |chunk| {
+                if bytes.len() + chunk.len() > MAX_IMAGE_BYTES as usize {
+                    return Err("Image is larger than 10 MB".into());
+                }
+                bytes.extend_from_slice(chunk);
+                Ok(())
+            })?;
+            Ok::<Vec<u8>, String>(bytes)
+        })
+        .await
+        .map_err(|error| error.to_string())??
+    } else {
+        let root = root_path(&roots, &root_id)?;
+        let path = scoped_path(&root, &path)?;
+        tauri::async_runtime::spawn_blocking(move || {
+            let mut bytes = Vec::new();
+            fs::File::open(path)
+                .and_then(|file| file.take(MAX_IMAGE_BYTES + 1).read_to_end(&mut bytes))
+                .map_err(|error| error.to_string())?;
+            if bytes.len() > MAX_IMAGE_BYTES as usize {
+                return Err("Image is larger than 10 MB".into());
+            }
+            Ok::<Vec<u8>, String>(bytes)
+        })
+        .await
+        .map_err(|error| error.to_string())??
+    };
+    Ok(tauri::ipc::Response::new(bytes))
+}
+
+#[tauri::command]
 async fn write_text_file(
     roots: State<'_, Roots>,
     root_id: String,
@@ -6223,6 +6268,7 @@ pub fn run() {
             delete_session_data,
             list_directory,
             read_text_file,
+            read_image_file,
             write_text_file,
             delete_entry,
             hide_hidden_files,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; font-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; font-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; font-src 'self'; img-src 'self' blob: data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {

--- a/src/App.css
+++ b/src/App.css
@@ -105,45 +105,121 @@ html[data-session-dragging] * {
   background-color: var(--syntax-deletion-background);
 }
 
+.markdown-viewer {
+  overflow-wrap: break-word;
+}
+
+.markdown-viewer > :first-child {
+  margin-top: 0;
+}
+
+.markdown-viewer > :last-child {
+  margin-bottom: 0;
+}
+
 .markdown-viewer h1,
 .markdown-viewer h2,
-.markdown-viewer h3 {
-  margin: 1.5em 0 0.6em;
+.markdown-viewer h3,
+.markdown-viewer h4,
+.markdown-viewer h5,
+.markdown-viewer h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
   font-weight: 600;
   line-height: 1.25;
 }
 
 .markdown-viewer h1 {
-  font-size: 1.5em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
+  font-size: 2em;
 }
 .markdown-viewer h2 {
-  font-size: 1.25em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
+  font-size: 1.5em;
 }
 .markdown-viewer h3 {
-  font-size: 1.05em;
+  font-size: 1.25em;
+}
+.markdown-viewer h4 {
+  font-size: 1em;
+}
+.markdown-viewer h5 {
+  font-size: 0.875em;
+}
+.markdown-viewer h6 {
+  color: var(--muted-foreground);
+  font-size: 0.85em;
 }
 .markdown-viewer p,
 .markdown-viewer ul,
 .markdown-viewer ol,
-.markdown-viewer blockquote {
-  margin: 0.8em 0;
+.markdown-viewer dl,
+.markdown-viewer blockquote,
+.markdown-viewer details,
+.markdown-viewer pre,
+.markdown-viewer table {
+  margin-top: 0;
+  margin-bottom: 1rem;
 }
 .markdown-viewer ul {
   list-style: disc;
-  padding-left: 1.4rem;
+  padding-left: 2em;
 }
 .markdown-viewer ol {
   list-style: decimal;
-  padding-left: 1.4rem;
+  padding-left: 2em;
+}
+.markdown-viewer ul ul,
+.markdown-viewer ol ul {
+  list-style-type: circle;
+}
+.markdown-viewer ol ol,
+.markdown-viewer ul ol {
+  list-style-type: lower-roman;
+}
+.markdown-viewer li + li {
+  margin-top: 0.25em;
+}
+.markdown-viewer li > p {
+  margin-top: 1rem;
+}
+.markdown-viewer li > ul,
+.markdown-viewer li > ol {
+  margin-bottom: 0;
 }
 .markdown-viewer a {
-  text-decoration: underline;
+  color: var(--syntax-constant);
+  text-decoration: none;
   text-underline-offset: 3px;
 }
+.markdown-viewer a:hover {
+  text-decoration: underline;
+}
+.markdown-viewer img {
+  display: inline-block;
+  box-sizing: content-box;
+  max-width: 100%;
+  height: auto;
+  vertical-align: middle;
+}
 .markdown-viewer blockquote {
-  border-left: 2px solid var(--border);
-  padding-left: 1rem;
+  border-left: 0.25em solid var(--border);
+  padding: 0 1em;
   color: var(--muted-foreground);
+}
+.markdown-viewer blockquote > :first-child {
+  margin-top: 0;
+}
+.markdown-viewer blockquote > :last-child {
+  margin-bottom: 0;
+}
+.markdown-viewer hr {
+  height: 0.25em;
+  margin: 1.5rem 0;
+  border: 0;
+  background: var(--border);
 }
 .markdown-viewer pre {
   overflow: auto;
@@ -159,13 +235,50 @@ html[data-session-dragging] * {
   padding: 0.1rem 0.3rem;
   font-size: 0.85em;
 }
+.markdown-viewer kbd {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 0.3rem;
+  background: var(--muted);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.8em;
+  line-height: 1;
+  vertical-align: middle;
+}
 .markdown-viewer table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  border-spacing: 0;
   border-collapse: collapse;
 }
 .markdown-viewer th,
 .markdown-viewer td {
   border: 1px solid var(--border);
-  padding: 0.4rem 0.6rem;
+  padding: 0.4rem 0.8rem;
   text-align: left;
+}
+.markdown-viewer th {
+  font-weight: 600;
+}
+.markdown-viewer tr:nth-child(2n) {
+  background: color-mix(in oklab, var(--muted) 55%, transparent);
+}
+.markdown-viewer summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+.markdown-viewer .contains-task-list {
+  padding-left: 0;
+  list-style: none;
+}
+.markdown-viewer .task-list-item {
+  list-style: none;
+}
+.markdown-viewer .task-list-item input {
+  margin: 0 0.4em 0.25em 0;
+  vertical-align: middle;
+  accent-color: var(--syntax-constant);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -54,7 +54,6 @@ html[data-session-dragging] * {
 .hljs-attr,
 .hljs-attribute,
 .hljs-literal,
-.hljs-meta,
 .hljs-number,
 .hljs-operator,
 .hljs-variable,
@@ -69,16 +68,18 @@ html[data-session-dragging] * {
   color: var(--syntax-string);
 }
 .hljs-built_in,
+.hljs-meta,
 .hljs-symbol {
   color: var(--syntax-variable);
 }
 .hljs-comment,
 .hljs-code,
-.hljs-formula {
+.hljs-formula,
+.hljs-quote {
   color: var(--syntax-comment);
+  font-style: italic;
 }
 .hljs-name,
-.hljs-quote,
 .hljs-selector-tag,
 .hljs-selector-pseudo {
   color: var(--syntax-tag);
@@ -90,10 +91,16 @@ html[data-session-dragging] * {
 .hljs-bullet {
   color: var(--syntax-bullet);
 }
+.hljs-link {
+  color: var(--syntax-string);
+  text-decoration: underline;
+}
 .hljs-emphasis {
+  color: var(--syntax-entity);
   font-style: italic;
 }
 .hljs-strong {
+  color: var(--syntax-entity);
   font-weight: 600;
 }
 .hljs-addition {
@@ -225,9 +232,12 @@ html[data-session-dragging] * {
   overflow: auto;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: var(--muted);
+  background: #f6f8fa;
   padding: 0.9rem;
   font-size: 0.85em;
+}
+.dark .markdown-viewer pre {
+  background: #161b22;
 }
 .markdown-viewer :not(pre) > code {
   border-radius: 0.3rem;

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -186,6 +186,8 @@ export function MarkdownPreview({
               >
                 {children}
               </a>
+            ) : href?.startsWith("#") ? (
+              <a href={href}>{children}</a>
             ) : href && onOpenPath ? (
               <a
                 href={href}

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -2,26 +2,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import hljs from "highlight.js/lib/core";
-import bash from "highlight.js/lib/languages/bash";
-import cpp from "highlight.js/lib/languages/cpp";
-import csharp from "highlight.js/lib/languages/csharp";
-import css from "highlight.js/lib/languages/css";
-import diff from "highlight.js/lib/languages/diff";
-import go from "highlight.js/lib/languages/go";
-import java from "highlight.js/lib/languages/java";
-import javascript from "highlight.js/lib/languages/javascript";
-import json from "highlight.js/lib/languages/json";
-import kotlin from "highlight.js/lib/languages/kotlin";
-import markdown from "highlight.js/lib/languages/markdown";
-import php from "highlight.js/lib/languages/php";
-import python from "highlight.js/lib/languages/python";
-import ruby from "highlight.js/lib/languages/ruby";
-import rust from "highlight.js/lib/languages/rust";
-import sql from "highlight.js/lib/languages/sql";
-import typescript from "highlight.js/lib/languages/typescript";
-import xml from "highlight.js/lib/languages/xml";
-import yaml from "highlight.js/lib/languages/yaml";
-import { lazy, useMemo } from "react";
+import { lazy, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
@@ -31,28 +12,74 @@ import remarkGfm from "remark-gfm";
 // when the first file is edited rather than with the first rendered Markdown.
 const SourceEditor = lazy(() => import("@/source-editor"));
 
-const languages = {
-  bash,
-  cpp,
-  csharp,
-  css,
-  diff,
-  go,
-  java,
-  javascript,
-  json,
-  kotlin,
-  markdown,
-  php,
-  python,
-  ruby,
-  rust,
-  sql,
-  typescript,
-  xml,
-  yaml,
+// Match Portal's CodeBlock: grammars load only when a preview actually uses them. INI also owns
+// Highlight.js's TOML alias, which this repository's README needs.
+const languageLoaders: Record<string, () => Promise<{ default: (highlighter: typeof hljs) => unknown }>> = {
+  bash: () => import("highlight.js/lib/languages/bash"),
+  cpp: () => import("highlight.js/lib/languages/cpp"),
+  csharp: () => import("highlight.js/lib/languages/csharp"),
+  css: () => import("highlight.js/lib/languages/css"),
+  diff: () => import("highlight.js/lib/languages/diff"),
+  go: () => import("highlight.js/lib/languages/go"),
+  ini: () => import("highlight.js/lib/languages/ini"),
+  java: () => import("highlight.js/lib/languages/java"),
+  javascript: () => import("highlight.js/lib/languages/javascript"),
+  json: () => import("highlight.js/lib/languages/json"),
+  kotlin: () => import("highlight.js/lib/languages/kotlin"),
+  markdown: () => import("highlight.js/lib/languages/markdown"),
+  php: () => import("highlight.js/lib/languages/php"),
+  python: () => import("highlight.js/lib/languages/python"),
+  ruby: () => import("highlight.js/lib/languages/ruby"),
+  rust: () => import("highlight.js/lib/languages/rust"),
+  sql: () => import("highlight.js/lib/languages/sql"),
+  typescript: () => import("highlight.js/lib/languages/typescript"),
+  xml: () => import("highlight.js/lib/languages/xml"),
+  yaml: () => import("highlight.js/lib/languages/yaml"),
 };
-for (const [name, language] of Object.entries(languages)) hljs.registerLanguage(name, language);
+
+const languageAliases: Record<string, string> = {
+  c: "cpp",
+  cc: "cpp",
+  cs: "csharp",
+  h: "cpp",
+  hpp: "cpp",
+  html: "xml",
+  htm: "xml",
+  js: "javascript",
+  jsx: "javascript",
+  kt: "kotlin",
+  md: "markdown",
+  mdx: "markdown",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  shell: "bash",
+  sh: "bash",
+  svg: "xml",
+  toml: "ini",
+  ts: "typescript",
+  tsx: "typescript",
+  yml: "yaml",
+  zsh: "bash",
+};
+const pendingLanguages = new Map<string, Promise<void>>();
+
+function loadLanguage(language: string): Promise<void> {
+  const requested = language.toLowerCase();
+  const name = languageAliases[requested] ?? requested;
+  if (hljs.getLanguage(requested)) return Promise.resolve();
+  const loader = languageLoaders[name];
+  if (!loader) return Promise.resolve();
+  const pending = pendingLanguages.get(name);
+  if (pending) return pending;
+  const task = loader()
+    .then(({ default: grammar }) => hljs.registerLanguage(name, grammar as Parameters<typeof hljs.registerLanguage>[1]))
+    .catch(() => {
+      pendingLanguages.delete(name);
+    });
+  pendingLanguages.set(name, task);
+  return task;
+}
 
 const extensionLanguages: Record<string, string> = {
   bash: "bash",
@@ -71,6 +98,7 @@ const extensionLanguages: Record<string, string> = {
   js: "javascript",
   json: "json",
   jsx: "javascript",
+  ini: "ini",
   kt: "kotlin",
   md: "markdown",
   mdx: "markdown",
@@ -82,6 +110,7 @@ const extensionLanguages: Record<string, string> = {
   sql: "sql",
   ts: "typescript",
   tsx: "typescript",
+  toml: "toml",
   svg: "xml",
   xml: "xml",
   yaml: "yaml",
@@ -96,7 +125,22 @@ function highlighted(source: string, language?: string) {
 }
 
 function HighlightedCode({ source, language, className }: { source: string; language?: string; className?: string }) {
-  const html = useMemo(() => highlighted(source, language), [source, language]);
+  const [ready, setReady] = useState(() => !language || Boolean(hljs.getLanguage(language)));
+  useEffect(() => {
+    if (!language || hljs.getLanguage(language)) {
+      setReady(true);
+      return;
+    }
+    setReady(false);
+    let cancelled = false;
+    void loadLanguage(language).then(() => {
+      if (!cancelled) setReady(Boolean(hljs.getLanguage(language)));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [language]);
+  const html = useMemo(() => highlighted(source, ready ? language : undefined), [source, language, ready]);
   return <code className={`hljs ${className ?? ""}`} dangerouslySetInnerHTML={{ __html: html }} />;
 }
 

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -73,6 +73,7 @@ const extensionLanguages: Record<string, string> = {
   rb: "ruby",
   rs: "rust",
   sh: "bash",
+  shell: "bash",
   ts: "typescript",
   tsx: "typescript",
   svg: "xml",
@@ -81,6 +82,7 @@ const extensionLanguages: Record<string, string> = {
 };
 
 function highlighted(source: string, language?: string) {
+  language = language && (extensionLanguages[language.toLowerCase()] ?? language.toLowerCase());
   if (source.length <= 200_000 && language && hljs.getLanguage(language))
     return hljs.highlight(source, { language }).value;
   return source.replace(/[&<>]/g, (character) => (character === "&" ? "&amp;" : character === "<" ? "&lt;" : "&gt;"));
@@ -187,6 +189,7 @@ export function MarkdownPreview({
               <a
                 href={href}
                 onClick={(event) => {
+                  if (href.startsWith("?")) event.preventDefault();
                   if (!external && !local) return;
                   event.preventDefault();
                   if (external) {

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -176,17 +176,18 @@ export function MarkdownPreview({
         rehypePlugins={[rehypeRaw, rehypeSanitize]}
         components={{
           a({ href, children }) {
-            return href && /^https?:\/\//i.test(href) ? (
+            const external = href && (/^https?:\/\//i.test(href) || href.startsWith("//"));
+            return external ? (
               <a
                 href={href}
                 onClick={(event) => {
                   event.preventDefault();
-                  void invoke("open_url", { url: href });
+                  void invoke("open_url", { url: href.startsWith("//") ? `https:${href}` : href });
                 }}
               >
                 {children}
               </a>
-            ) : href?.startsWith("#") ? (
+            ) : href?.startsWith("#") || (href && /^[a-z][a-z\d+.-]*:/i.test(href)) ? (
               <a href={href}>{children}</a>
             ) : href && onOpenPath ? (
               <a

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -23,6 +23,8 @@ import xml from "highlight.js/lib/languages/xml";
 import yaml from "highlight.js/lib/languages/yaml";
 import { lazy, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 // The editor is the heavier half of this file's imports and only an open file needs it, so it loads
@@ -114,14 +116,23 @@ function LineNumbers({ count }: { count: number }) {
   );
 }
 
-export function MarkdownPreview({ source, className = "" }: { source: string; className?: string }) {
+export function MarkdownPreview({
+  source,
+  className = "",
+  onOpenPath,
+}: {
+  source: string;
+  className?: string;
+  onOpenPath?: (path: string) => void;
+}) {
   return (
     <article className={`markdown-viewer max-w-none ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeSanitize]}
         components={{
           a({ href, children }) {
-            return href?.startsWith("http://") || href?.startsWith("https://") ? (
+            return href && /^https?:\/\//i.test(href) ? (
               <a
                 href={href}
                 onClick={(event) => {
@@ -131,8 +142,18 @@ export function MarkdownPreview({ source, className = "" }: { source: string; cl
               >
                 {children}
               </a>
+            ) : href && onOpenPath ? (
+              <a
+                href={href}
+                onClick={(event) => {
+                  event.preventDefault();
+                  onOpenPath(href);
+                }}
+              >
+                {children}
+              </a>
             ) : (
-              <span className="text-foreground underline">{children}</span>
+              <span className="text-[var(--syntax-constant)] underline">{children}</span>
             );
           },
           code({ className, children, ...props }) {
@@ -144,8 +165,8 @@ export function MarkdownPreview({ source, className = "" }: { source: string; cl
               <code {...props}>{children}</code>
             );
           },
-          img({ alt }) {
-            return <span className="text-muted-foreground">[Image: {alt}]</span>;
+          img({ node: _node, alt = "", ...props }) {
+            return <img alt={alt} loading="lazy" decoding="async" {...props} />;
           },
         }}
       >
@@ -163,6 +184,7 @@ export default function CodePreview({
   baseline,
   fontSize,
   onChange,
+  onOpenPath,
 }: {
   path: string;
   source: string;
@@ -171,10 +193,11 @@ export default function CodePreview({
   baseline?: string;
   fontSize?: number;
   onChange?: (source: string) => void;
+  onOpenPath?: (path: string) => void;
 }) {
   const extension = path.split(".").pop()?.toLowerCase() ?? "";
   if (rendered && (extension === "md" || extension === "mdx")) {
-    return <MarkdownPreview source={source} className="px-6 py-5" />;
+    return <MarkdownPreview source={source} className="px-6 py-5" onOpenPath={onOpenPath} />;
   }
   if (rendered && ["htm", "html", "svg"].includes(extension)) {
     return (

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -2,7 +2,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import hljs from "highlight.js/lib/core";
-import { type ImgHTMLAttributes, lazy, useEffect, useMemo, useState } from "react";
+import { type ImgHTMLAttributes, lazy, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
@@ -151,27 +151,37 @@ function PreviewImage({
   ...props
 }: ImgHTMLAttributes<HTMLImageElement> & { onReadPath?: (path: string) => Promise<ArrayBuffer> }) {
   const local = Boolean(src && onReadPath && !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(src));
+  const image = useRef<HTMLImageElement>(null);
   const [resolved, setResolved] = useState<string>();
   useEffect(() => {
     setResolved(undefined);
     if (!local || !src || !onReadPath) return;
     let active = true;
     let objectUrl: string | undefined;
-    void onReadPath(src)
-      .then((bytes) => {
-        if (!active) return;
-        objectUrl = URL.createObjectURL(
-          new Blob([bytes], { type: /\.svg(?:[?#]|$)/i.test(src) ? "image/svg+xml" : "" }),
-        );
-        setResolved(objectUrl);
-      })
-      .catch(() => {});
+    const load = () => {
+      void onReadPath(src)
+        .then((bytes) => {
+          if (!active) return;
+          objectUrl = URL.createObjectURL(
+            new Blob([bytes], { type: /\.svg(?:[?#]|$)/i.test(src) ? "image/svg+xml" : "" }),
+          );
+          setResolved(objectUrl);
+        })
+        .catch(() => {});
+    };
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries[0]?.isIntersecting) return;
+      observer.disconnect();
+      load();
+    });
+    if (image.current) observer.observe(image.current);
     return () => {
       active = false;
+      observer.disconnect();
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [local, onReadPath, src]);
-  return <img src={local ? resolved : src} alt={alt} loading="lazy" decoding="async" {...props} />;
+  return <img ref={image} src={local ? resolved : src} alt={alt} loading="lazy" decoding="async" {...props} />;
 }
 
 // A gutter beside the source rather than a number on each line: a highlighted span may open on one line
@@ -214,7 +224,10 @@ export function MarkdownPreview({
                 href={href}
                 onClick={(event) => {
                   event.preventDefault();
-                  void invoke("open_url", { url: href.startsWith("//") ? `https:${href}` : href });
+                  const url = href.startsWith("//")
+                    ? `https:${href}`
+                    : href.replace(/^https?:/i, (scheme) => scheme.toLowerCase());
+                  void invoke("open_url", { url });
                 }}
               >
                 {children}

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -2,7 +2,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import hljs from "highlight.js/lib/core";
-import { lazy, useEffect, useMemo, useState } from "react";
+import { type ImgHTMLAttributes, lazy, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
@@ -144,6 +144,36 @@ function HighlightedCode({ source, language, className }: { source: string; lang
   return <code className={`hljs ${className ?? ""}`} dangerouslySetInnerHTML={{ __html: html }} />;
 }
 
+function PreviewImage({
+  src,
+  alt = "",
+  onReadPath,
+  ...props
+}: ImgHTMLAttributes<HTMLImageElement> & { onReadPath?: (path: string) => Promise<ArrayBuffer> }) {
+  const local = Boolean(src && onReadPath && !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(src));
+  const [resolved, setResolved] = useState<string>();
+  useEffect(() => {
+    setResolved(undefined);
+    if (!local || !src || !onReadPath) return;
+    let active = true;
+    let objectUrl: string | undefined;
+    void onReadPath(src)
+      .then((bytes) => {
+        if (!active) return;
+        objectUrl = URL.createObjectURL(
+          new Blob([bytes], { type: /\.svg(?:[?#]|$)/i.test(src) ? "image/svg+xml" : "" }),
+        );
+        setResolved(objectUrl);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [local, onReadPath, src]);
+  return <img src={local ? resolved : src} alt={alt} loading="lazy" decoding="async" {...props} />;
+}
+
 // A gutter beside the source rather than a number on each line: a highlighted span may open on one line
 // and close on another, so the markup cannot be cut per line without tearing. Nothing here wraps, so a
 // column of numbers on the same leading stays level with the code, and it is skipped by a copy and by a
@@ -164,10 +194,12 @@ export function MarkdownPreview({
   source,
   className = "",
   onOpenPath,
+  onReadPath,
 }: {
   source: string;
   className?: string;
   onOpenPath?: (path: string) => void;
+  onReadPath?: (path: string) => Promise<ArrayBuffer>;
 }) {
   return (
     <article className={`markdown-viewer max-w-none ${className}`}>
@@ -187,7 +219,7 @@ export function MarkdownPreview({
               >
                 {children}
               </a>
-            ) : href?.startsWith("#") || (href && /^[a-z][a-z\d+.-]*:/i.test(href)) ? (
+            ) : href?.startsWith("#") || href?.startsWith("?") || (href && /^[a-z][a-z\d+.-]*:/i.test(href)) ? (
               <a href={href}>{children}</a>
             ) : href && onOpenPath ? (
               <a
@@ -213,7 +245,7 @@ export function MarkdownPreview({
             );
           },
           img({ node: _node, alt = "", ...props }) {
-            return <img alt={alt} loading="lazy" decoding="async" {...props} />;
+            return <PreviewImage alt={alt} onReadPath={onReadPath} {...props} />;
           },
         }}
       >
@@ -232,6 +264,7 @@ export default function CodePreview({
   fontSize,
   onChange,
   onOpenPath,
+  onReadPath,
 }: {
   path: string;
   source: string;
@@ -241,10 +274,11 @@ export default function CodePreview({
   fontSize?: number;
   onChange?: (source: string) => void;
   onOpenPath?: (path: string) => void;
+  onReadPath?: (path: string) => Promise<ArrayBuffer>;
 }) {
   const extension = path.split(".").pop()?.toLowerCase() ?? "";
   if (rendered && (extension === "md" || extension === "mdx")) {
-    return <MarkdownPreview source={source} className="px-6 py-5" onOpenPath={onOpenPath} />;
+    return <MarkdownPreview source={source} className="px-6 py-5" onOpenPath={onOpenPath} onReadPath={onReadPath} />;
   }
   if (rendered && ["htm", "html", "svg"].includes(extension)) {
     return (

--- a/src/code-preview.tsx
+++ b/src/code-preview.tsx
@@ -2,6 +2,26 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import cpp from "highlight.js/lib/languages/cpp";
+import csharp from "highlight.js/lib/languages/csharp";
+import css from "highlight.js/lib/languages/css";
+import diff from "highlight.js/lib/languages/diff";
+import go from "highlight.js/lib/languages/go";
+import ini from "highlight.js/lib/languages/ini";
+import java from "highlight.js/lib/languages/java";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import markdown from "highlight.js/lib/languages/markdown";
+import php from "highlight.js/lib/languages/php";
+import python from "highlight.js/lib/languages/python";
+import ruby from "highlight.js/lib/languages/ruby";
+import rust from "highlight.js/lib/languages/rust";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
 import { type ImgHTMLAttributes, lazy, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -12,108 +32,50 @@ import remarkGfm from "remark-gfm";
 // when the first file is edited rather than with the first rendered Markdown.
 const SourceEditor = lazy(() => import("@/source-editor"));
 
-// Match Portal's CodeBlock: grammars load only when a preview actually uses them. INI also owns
-// Highlight.js's TOML alias, which this repository's README needs.
-const languageLoaders: Record<string, () => Promise<{ default: (highlighter: typeof hljs) => unknown }>> = {
-  bash: () => import("highlight.js/lib/languages/bash"),
-  cpp: () => import("highlight.js/lib/languages/cpp"),
-  csharp: () => import("highlight.js/lib/languages/csharp"),
-  css: () => import("highlight.js/lib/languages/css"),
-  diff: () => import("highlight.js/lib/languages/diff"),
-  go: () => import("highlight.js/lib/languages/go"),
-  ini: () => import("highlight.js/lib/languages/ini"),
-  java: () => import("highlight.js/lib/languages/java"),
-  javascript: () => import("highlight.js/lib/languages/javascript"),
-  json: () => import("highlight.js/lib/languages/json"),
-  kotlin: () => import("highlight.js/lib/languages/kotlin"),
-  markdown: () => import("highlight.js/lib/languages/markdown"),
-  php: () => import("highlight.js/lib/languages/php"),
-  python: () => import("highlight.js/lib/languages/python"),
-  ruby: () => import("highlight.js/lib/languages/ruby"),
-  rust: () => import("highlight.js/lib/languages/rust"),
-  sql: () => import("highlight.js/lib/languages/sql"),
-  typescript: () => import("highlight.js/lib/languages/typescript"),
-  xml: () => import("highlight.js/lib/languages/xml"),
-  yaml: () => import("highlight.js/lib/languages/yaml"),
+const languages = {
+  bash,
+  cpp,
+  csharp,
+  css,
+  diff,
+  go,
+  ini,
+  java,
+  javascript,
+  json,
+  kotlin,
+  markdown,
+  php,
+  python,
+  ruby,
+  rust,
+  sql,
+  typescript,
+  xml,
+  yaml,
 };
-
-const languageAliases: Record<string, string> = {
-  c: "cpp",
-  cc: "cpp",
-  cs: "csharp",
-  h: "cpp",
-  hpp: "cpp",
-  html: "xml",
-  htm: "xml",
-  js: "javascript",
-  jsx: "javascript",
-  kt: "kotlin",
-  md: "markdown",
-  mdx: "markdown",
-  py: "python",
-  rb: "ruby",
-  rs: "rust",
-  shell: "bash",
-  sh: "bash",
-  svg: "xml",
-  toml: "ini",
-  ts: "typescript",
-  tsx: "typescript",
-  yml: "yaml",
-  zsh: "bash",
-};
-const pendingLanguages = new Map<string, Promise<void>>();
-
-function loadLanguage(language: string): Promise<void> {
-  const requested = language.toLowerCase();
-  const name = languageAliases[requested] ?? requested;
-  if (hljs.getLanguage(requested)) return Promise.resolve();
-  const loader = languageLoaders[name];
-  if (!loader) return Promise.resolve();
-  const pending = pendingLanguages.get(name);
-  if (pending) return pending;
-  const task = loader()
-    .then(({ default: grammar }) => hljs.registerLanguage(name, grammar as Parameters<typeof hljs.registerLanguage>[1]))
-    .catch(() => {
-      pendingLanguages.delete(name);
-    });
-  pendingLanguages.set(name, task);
-  return task;
-}
+for (const [name, language] of Object.entries(languages)) hljs.registerLanguage(name, language);
 
 const extensionLanguages: Record<string, string> = {
-  bash: "bash",
   c: "cpp",
   cc: "cpp",
-  cpp: "cpp",
   cs: "csharp",
-  css: "css",
-  diff: "diff",
-  go: "go",
   h: "cpp",
   hpp: "cpp",
   htm: "xml",
   html: "xml",
-  java: "java",
   js: "javascript",
-  json: "json",
   jsx: "javascript",
-  ini: "ini",
   kt: "kotlin",
   md: "markdown",
   mdx: "markdown",
-  php: "php",
   py: "python",
   rb: "ruby",
   rs: "rust",
   sh: "bash",
-  sql: "sql",
   ts: "typescript",
   tsx: "typescript",
-  toml: "toml",
   svg: "xml",
-  xml: "xml",
-  yaml: "yaml",
   yml: "yaml",
   zsh: "bash",
 };
@@ -125,54 +87,50 @@ function highlighted(source: string, language?: string) {
 }
 
 function HighlightedCode({ source, language, className }: { source: string; language?: string; className?: string }) {
-  const [ready, setReady] = useState(() => !language || Boolean(hljs.getLanguage(language)));
-  useEffect(() => {
-    if (!language || hljs.getLanguage(language)) {
-      setReady(true);
-      return;
-    }
-    setReady(false);
-    let cancelled = false;
-    void loadLanguage(language).then(() => {
-      if (!cancelled) setReady(Boolean(hljs.getLanguage(language)));
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [language]);
-  const html = useMemo(() => highlighted(source, ready ? language : undefined), [source, language, ready]);
+  const html = useMemo(() => highlighted(source, language), [source, language]);
   return <code className={`hljs ${className ?? ""}`} dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+function linkedFilePath(currentPath: string, href: string) {
+  try {
+    const current = currentPath.replace(/\\/g, "/");
+    const encoded = current.split("/").map(encodeURIComponent).join("/");
+    const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${encoded}`);
+    if (target.protocol === "file:") return decodeURIComponent(target.pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+  } catch {
+    // A malformed link is shown as authored but cannot name a local file.
+  }
 }
 
 function PreviewImage({
   src,
   alt = "",
-  onReadPath,
+  path,
+  rootId,
   ...props
-}: ImgHTMLAttributes<HTMLImageElement> & { onReadPath?: (path: string) => Promise<ArrayBuffer> }) {
-  const local = Boolean(src && onReadPath && !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(src));
+}: ImgHTMLAttributes<HTMLImageElement> & { path: string; rootId?: string }) {
+  const local = Boolean(src && rootId && path && !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(src));
   const image = useRef<HTMLImageElement>(null);
   const [resolved, setResolved] = useState<string>();
   useEffect(() => {
     setResolved(undefined);
-    if (!local || !src || !onReadPath) return;
+    if (!local || !src || !rootId) return;
     let active = true;
     let objectUrl: string | undefined;
-    const load = () => {
-      void onReadPath(src)
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries[0]?.isIntersecting) return;
+      observer.disconnect();
+      void invoke<ArrayBuffer | number[]>("read_image_file", { rootId, path: linkedFilePath(path, src) })
         .then((bytes) => {
           if (!active) return;
           objectUrl = URL.createObjectURL(
-            new Blob([bytes], { type: /\.svg(?:[?#]|$)/i.test(src) ? "image/svg+xml" : "" }),
+            new Blob([bytes instanceof ArrayBuffer ? bytes : Uint8Array.from(bytes)], {
+              type: /\.svg(?:[?#]|$)/i.test(src) ? "image/svg+xml" : "",
+            }),
           );
           setResolved(objectUrl);
         })
         .catch(() => {});
-    };
-    const observer = new IntersectionObserver((entries) => {
-      if (!entries[0]?.isIntersecting) return;
-      observer.disconnect();
-      load();
     });
     if (image.current) observer.observe(image.current);
     return () => {
@@ -180,7 +138,7 @@ function PreviewImage({
       observer.disconnect();
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [local, onReadPath, src]);
+  }, [local, path, rootId, src]);
   return <img ref={image} src={local ? resolved : src} alt={alt} loading="lazy" decoding="async" {...props} />;
 }
 
@@ -203,13 +161,15 @@ function LineNumbers({ count }: { count: number }) {
 export function MarkdownPreview({
   source,
   className = "",
+  path = "",
   onOpenPath,
-  onReadPath,
+  rootId,
 }: {
   source: string;
   className?: string;
+  path?: string;
   onOpenPath?: (path: string) => void;
-  onReadPath?: (path: string) => Promise<ArrayBuffer>;
+  rootId?: string;
 }) {
   return (
     <article className={`markdown-viewer max-w-none ${className}`}>
@@ -218,34 +178,30 @@ export function MarkdownPreview({
         rehypePlugins={[rehypeRaw, rehypeSanitize]}
         components={{
           a({ href, children }) {
-            const external = href && (/^https?:\/\//i.test(href) || href.startsWith("//"));
-            return external ? (
+            if (!href) return <span>{children}</span>;
+            const external = /^(?:https?:)?\/\//i.test(href);
+            const local = !/^(?:[a-z][a-z\d+.-]*:|[?#])/i.test(href) && !external;
+            if (local && !onOpenPath)
+              return <span className="text-[var(--syntax-constant)] underline">{children}</span>;
+            return (
               <a
                 href={href}
                 onClick={(event) => {
+                  if (!external && !local) return;
                   event.preventDefault();
-                  const url = href.startsWith("//")
-                    ? `https:${href}`
-                    : href.replace(/^https?:/i, (scheme) => scheme.toLowerCase());
-                  void invoke("open_url", { url });
+                  if (external) {
+                    const url = href.startsWith("//")
+                      ? `https:${href}`
+                      : href.replace(/^https?:/i, (scheme) => scheme.toLowerCase());
+                    void invoke("open_url", { url });
+                  } else {
+                    const target = linkedFilePath(path, href);
+                    if (target) onOpenPath?.(target);
+                  }
                 }}
               >
                 {children}
               </a>
-            ) : href?.startsWith("#") || href?.startsWith("?") || (href && /^[a-z][a-z\d+.-]*:/i.test(href)) ? (
-              <a href={href}>{children}</a>
-            ) : href && onOpenPath ? (
-              <a
-                href={href}
-                onClick={(event) => {
-                  event.preventDefault();
-                  onOpenPath(href);
-                }}
-              >
-                {children}
-              </a>
-            ) : (
-              <span className="text-[var(--syntax-constant)] underline">{children}</span>
             );
           },
           code({ className, children, ...props }) {
@@ -258,7 +214,7 @@ export function MarkdownPreview({
             );
           },
           img({ node: _node, alt = "", ...props }) {
-            return <PreviewImage alt={alt} onReadPath={onReadPath} {...props} />;
+            return <PreviewImage alt={alt} rootId={rootId} path={path} {...props} />;
           },
         }}
       >
@@ -277,7 +233,7 @@ export default function CodePreview({
   fontSize,
   onChange,
   onOpenPath,
-  onReadPath,
+  rootId,
 }: {
   path: string;
   source: string;
@@ -287,11 +243,13 @@ export default function CodePreview({
   fontSize?: number;
   onChange?: (source: string) => void;
   onOpenPath?: (path: string) => void;
-  onReadPath?: (path: string) => Promise<ArrayBuffer>;
+  rootId?: string;
 }) {
   const extension = path.split(".").pop()?.toLowerCase() ?? "";
   if (rendered && (extension === "md" || extension === "mdx")) {
-    return <MarkdownPreview source={source} className="px-6 py-5" onOpenPath={onOpenPath} onReadPath={onReadPath} />;
+    return (
+      <MarkdownPreview source={source} className="px-6 py-5" onOpenPath={onOpenPath} rootId={rootId} path={path} />
+    );
   }
   if (rendered && ["htm", "html", "svg"].includes(extension)) {
     return (
@@ -309,7 +267,11 @@ export default function CodePreview({
   return (
     <pre className="flex min-h-full overflow-auto font-mono">
       <LineNumbers count={source.split("\n").length} />
-      <HighlightedCode source={source} language={extensionLanguages[extension]} className="py-4 pr-4 pl-3" />
+      <HighlightedCode
+        source={source}
+        language={extensionLanguages[extension] ?? extension}
+        className="py-4 pr-4 pl-3"
+      />
     </pre>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -105,14 +105,14 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
   /* GitHub light syntax colors, shared by the code preview and the terminal palette */
-  --syntax-keyword: #d73a49;
-  --syntax-entity: #6f42c1;
-  --syntax-constant: #005cc5;
-  --syntax-string: #032f62;
-  --syntax-variable: #e36209;
-  --syntax-comment: #6a737d;
-  --syntax-tag: #22863a;
-  --syntax-bullet: #735c0f;
+  --syntax-keyword: #cf222e;
+  --syntax-entity: #8250df;
+  --syntax-constant: #0550ae;
+  --syntax-string: #0a3069;
+  --syntax-variable: #953800;
+  --syntax-comment: #6e7781;
+  --syntax-tag: #116329;
+  --syntax-bullet: #953800;
   --syntax-addition: #22863a;
   --syntax-addition-background: #f0fff4;
   --syntax-deletion: #b31d28;
@@ -166,7 +166,7 @@
   --syntax-variable: #ffa657;
   --syntax-comment: #8b949e;
   --syntax-tag: #7ee787;
-  --syntax-bullet: #f2cc60;
+  --syntax-bullet: #ffa657;
   --syntax-addition: #aff5b4;
   --syntax-addition-background: #033a16;
   --syntax-deletion: #ffdcd7;

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -1151,7 +1151,8 @@ function FilesPanel({
     if (!selected) return;
     try {
       const current = selected.path.replace(/\\/g, "/");
-      const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${current}`);
+      const encoded = current.split("/").map(encodeURIComponent).join("/");
+      const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${encoded}`);
       if (target.protocol !== "file:") return;
       const path = decodeURIComponent(target.pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
       void openFile({ name: folderName(path), path, isDirectory: false, isSymlink: false });

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -786,6 +786,17 @@ function FileTree({
 
 const RENDERED_FILE = /\.(?:html?|mdx?|svg)$/i;
 
+function linkedFilePath(currentPath: string, href: string) {
+  try {
+    const current = currentPath.replace(/\\/g, "/");
+    const encoded = current.split("/").map(encodeURIComponent).join("/");
+    const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${encoded}`);
+    if (target.protocol === "file:") return decodeURIComponent(target.pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+  } catch {
+    // A malformed link is shown as authored but cannot name a local file.
+  }
+}
+
 function usePreviewViewer<T extends HTMLElement>(onBack: () => void) {
   const viewer = useRef<T>(null);
 
@@ -879,6 +890,7 @@ function FileViewer({
   fontSize,
   onBack,
   onOpenPath,
+  onReadPath,
   onDraftChange,
   onSave,
 }: {
@@ -891,6 +903,7 @@ function FileViewer({
   fontSize: number;
   onBack: () => void;
   onOpenPath: (path: string) => void;
+  onReadPath: (path: string) => Promise<ArrayBuffer>;
   onDraftChange: (contents: string) => void;
   onSave: (contents: string) => Promise<void>;
 }) {
@@ -1024,6 +1037,7 @@ function FileViewer({
                       source={draft}
                       rendered
                       onOpenPath={dirty ? undefined : onOpenPath}
+                      onReadPath={onReadPath}
                     />
                   </Suspense>
                 </div>
@@ -1149,17 +1163,20 @@ function FilesPanel({
 
   function openLinkedFile(href: string) {
     if (!selected) return;
-    try {
-      const current = selected.path.replace(/\\/g, "/");
-      const encoded = current.split("/").map(encodeURIComponent).join("/");
-      const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${encoded}`);
-      if (target.protocol !== "file:") return;
-      const path = decodeURIComponent(target.pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
-      void openFile({ name: folderName(path), path, isDirectory: false, isSymlink: false });
-    } catch {
-      // A malformed link is shown as authored but cannot name a local file.
-    }
+    const path = linkedFilePath(selected.path, href);
+    if (path) void openFile({ name: folderName(path), path, isDirectory: false, isSymlink: false });
   }
+
+  const readLinkedImage = useCallback(
+    async (href: string) => {
+      if (!selected) throw new Error("No file is selected");
+      const path = linkedFilePath(selected.path, href);
+      if (!path) throw new Error("Image path is invalid");
+      const bytes = await invoke<ArrayBuffer | number[]>("read_image_file", { rootId, path });
+      return bytes instanceof ArrayBuffer ? bytes : Uint8Array.from(bytes).buffer;
+    },
+    [rootId, selected],
+  );
 
   // The tree is hidden behind an open file rather than thrown away, so stepping back returns to the
   // folders exactly as they were left — expanded, loaded, and scrolled — without rereading the disk.
@@ -1179,6 +1196,7 @@ function FilesPanel({
           fontSize={fontSize}
           onBack={closeFile}
           onOpenPath={openLinkedFile}
+          onReadPath={readLinkedImage}
           onDraftChange={changeDraft}
           onSave={saveFile}
         />

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -786,17 +786,6 @@ function FileTree({
 
 const RENDERED_FILE = /\.(?:html?|mdx?|svg)$/i;
 
-function linkedFilePath(currentPath: string, href: string) {
-  try {
-    const current = currentPath.replace(/\\/g, "/");
-    const encoded = current.split("/").map(encodeURIComponent).join("/");
-    const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${encoded}`);
-    if (target.protocol === "file:") return decodeURIComponent(target.pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
-  } catch {
-    // A malformed link is shown as authored but cannot name a local file.
-  }
-}
-
 function usePreviewViewer<T extends HTMLElement>(onBack: () => void) {
   const viewer = useRef<T>(null);
 
@@ -890,7 +879,7 @@ function FileViewer({
   fontSize,
   onBack,
   onOpenPath,
-  onReadPath,
+  rootId,
   onDraftChange,
   onSave,
 }: {
@@ -903,7 +892,7 @@ function FileViewer({
   fontSize: number;
   onBack: () => void;
   onOpenPath: (path: string) => void;
-  onReadPath: (path: string) => Promise<ArrayBuffer>;
+  rootId: string;
   onDraftChange: (contents: string) => void;
   onSave: (contents: string) => Promise<void>;
 }) {
@@ -1037,7 +1026,7 @@ function FileViewer({
                       source={draft}
                       rendered
                       onOpenPath={dirty ? undefined : onOpenPath}
-                      onReadPath={onReadPath}
+                      rootId={rootId}
                     />
                   </Suspense>
                 </div>
@@ -1161,23 +1150,6 @@ function FilesPanel({
     setSelected(null);
   }
 
-  function openLinkedFile(href: string) {
-    if (!selected) return;
-    const path = linkedFilePath(selected.path, href);
-    if (path) void openFile({ name: folderName(path), path, isDirectory: false, isSymlink: false });
-  }
-
-  const readLinkedImage = useCallback(
-    async (href: string) => {
-      if (!selected) throw new Error("No file is selected");
-      const path = linkedFilePath(selected.path, href);
-      if (!path) throw new Error("Image path is invalid");
-      const bytes = await invoke<ArrayBuffer | number[]>("read_image_file", { rootId, path });
-      return bytes instanceof ArrayBuffer ? bytes : Uint8Array.from(bytes).buffer;
-    },
-    [rootId, selected],
-  );
-
   // The tree is hidden behind an open file rather than thrown away, so stepping back returns to the
   // folders exactly as they were left — expanded, loaded, and scrolled — without rereading the disk.
   // A new root grant is a different tree, so it starts over the way a first open does; the open file
@@ -1195,8 +1167,8 @@ function FilesPanel({
           loading={loading}
           fontSize={fontSize}
           onBack={closeFile}
-          onOpenPath={openLinkedFile}
-          onReadPath={readLinkedImage}
+          onOpenPath={(path) => void openFile({ name: folderName(path), path, isDirectory: false, isSymlink: false })}
+          rootId={rootId}
           onDraftChange={changeDraft}
           onSave={saveFile}
         />

--- a/src/inspector.tsx
+++ b/src/inspector.tsx
@@ -878,6 +878,7 @@ function FileViewer({
   loading,
   fontSize,
   onBack,
+  onOpenPath,
   onDraftChange,
   onSave,
 }: {
@@ -889,6 +890,7 @@ function FileViewer({
   loading: boolean;
   fontSize: number;
   onBack: () => void;
+  onOpenPath: (path: string) => void;
   onDraftChange: (contents: string) => void;
   onSave: (contents: string) => Promise<void>;
 }) {
@@ -1017,7 +1019,12 @@ function FileViewer({
               <ScrollArea className="size-full">
                 <div style={contentZoomStyle(fontSize)}>
                   <Suspense fallback={<Loading label="Opening preview…" />}>
-                    <CodePreview path={entry.path} source={draft} rendered />
+                    <CodePreview
+                      path={entry.path}
+                      source={draft}
+                      rendered
+                      onOpenPath={dirty ? undefined : onOpenPath}
+                    />
                   </Suspense>
                 </div>
               </ScrollArea>
@@ -1140,6 +1147,19 @@ function FilesPanel({
     setSelected(null);
   }
 
+  function openLinkedFile(href: string) {
+    if (!selected) return;
+    try {
+      const current = selected.path.replace(/\\/g, "/");
+      const target = new URL(href, `file://${current.startsWith("/") ? "" : "/"}${current}`);
+      if (target.protocol !== "file:") return;
+      const path = decodeURIComponent(target.pathname).replace(/^\/([A-Za-z]:\/)/, "$1");
+      void openFile({ name: folderName(path), path, isDirectory: false, isSymlink: false });
+    } catch {
+      // A malformed link is shown as authored but cannot name a local file.
+    }
+  }
+
   // The tree is hidden behind an open file rather than thrown away, so stepping back returns to the
   // folders exactly as they were left — expanded, loaded, and scrolled — without rereading the disk.
   // A new root grant is a different tree, so it starts over the way a first open does; the open file
@@ -1157,6 +1177,7 @@ function FilesPanel({
           loading={loading}
           fontSize={fontSize}
           onBack={closeFile}
+          onOpenPath={openLinkedFile}
           onDraftChange={changeDraft}
           onSave={saveFile}
         />


### PR DESCRIPTION
Markdown previews now render sanitized HTML, blue links, responsive remote and workspace images, and horizontal icon rows. Code blocks use Portal's syntax colors and include TOML highlighting. Version 0.0.44 includes the fixes for #151 and #152.

Rendering stays in the existing lazy preview module. Highlight.js uses its existing registration path; local image reads use Rust's workspace scope and a viewport-triggered read with blob cleanup.

Validation: lint, TypeScript, dead-code scan, 20 frontend tests, production build, Rust formatting/compilation and 7 Rust tests passed. README rendering retains 23 images; focused rendering checks confirm highlighting for Bash, TOML, Python, JavaScript, TypeScript, HTML, YAML, and Rust. Startup gzip is 204.25 kB; the preview chunk is 133.59 kB gzip.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Markdown previews now render richer, sanitized content with improved links, images, responsive formatting, and syntax highlighting, alongside the Lite 0.0.44 release.

### 📊 Key Changes

- Added `rehypeRaw` and `rehypeSanitize` to support sanitized HTML in Markdown previews.
- Added blue external links, workspace-relative file links, remote images, and lazy-loaded local images read through the Rust workspace scope with a 10 MB limit and blob cleanup.
- Expanded Markdown styling for headings, tables, task lists, blockquotes, keyboard input, horizontal rules, responsive images, and horizontal icon rows.
- Updated code previews to use GitHub-style Portal syntax colors, recognize language names and extensions more consistently, and add INI/TOML-compatible highlighting through the existing Highlight.js registration path.
- Bumped the Tauri package version from 0.0.43 to 0.0.44 and updated the CSP to permit HTTPS, blob, and data image sources.

### 🎯 Purpose & Impact

- Markdown files can now display supported HTML, remote images, local workspace images, and links that open related workspace files when the current file is not dirty.
- Code and Markdown previews have more consistent formatting and highlighting across supported languages; the PR description reports successful lint, TypeScript, dead-code, frontend, build, Rust, and focused rendering validation.
<details><summary>📋 Skipped 2 files (lock files, generated, images, etc.)</summary>

- `bun.lock`
- `src-tauri/Cargo.lock`
</details>
