### PR TITLE
Fix Codex session identity and harness update feedback (0.0.46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Download Lite from the [latest GitHub Release](https://github.com/ultralytics/li
 2. Open the disk image and drag **Lite** into **Applications**.
 3. Open Lite from **Applications**. If macOS blocks the unsigned app, open **System Settings → Privacy & Security**, set **Allow applications from** to **App Store & Known Developers**, select **Open Anyway** for Lite, then confirm.
 
+To reopen Lite after restarting your Mac, leave it open and select **Reopen windows when logging back in** in the macOS restart or shutdown dialog. Lite restores its saved tabs when it opens. Quit Lite before shutting down if you do not want it to reopen. This uses [macOS's built-in app restoration](https://support.apple.com/en-us/102318).
+
 <div align="center">
   <img src="https://github.com/user-attachments/assets/a7d3a991-91f2-4d9b-ba57-a8d80bbc37f5" width="70%" alt="Approving Lite in macOS System Settings">
 </div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1956,7 +1956,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.45"
+version = "0.0.46"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.45"
+version = "0.0.46"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3478,10 +3478,7 @@ async fn install_agent(agent: String) -> Result<String, String> {
             let path = resolve_executable(executable)
                 .ok_or_else(|| format!("Installed {agent}, but could not find it in your PATH"))?;
             let mut probe = Command::new(path);
-            probe
-                .arg("--version")
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null());
+            probe.arg("--version").stderr(Stdio::null());
             if let Some(path) = user_path() {
                 probe.env("PATH", path);
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2403,8 +2403,8 @@ fn codex_thread_ids(server: &CodexServer, cwd: &Path) -> Result<HashSet<String>,
         .collect())
 }
 
-// Codex reports its thread in this PTY's title. Resolve a shortened title only against
-// matching IDs, never against whichever conversation appeared next in the same folder.
+// A new Codex thread reports its full ID before it is saved. Only shortened titles need
+// saved-thread discovery; a full ID already identifies the conversation owned by this PTY.
 #[tauri::command]
 async fn record_codex_session(
     app: AppHandle,
@@ -2414,7 +2414,8 @@ async fn record_codex_session(
     title: String,
 ) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let prefix = title.strip_suffix("...").unwrap_or(&title);
+        let (identity, name) = title.split_once(" | ").unwrap_or((&title, ""));
+        let prefix = identity.strip_suffix("...").unwrap_or(identity);
         if !(20..=36).contains(&prefix.len())
             || !prefix
                 .bytes()
@@ -2432,19 +2433,28 @@ async fn record_codex_session(
         {
             return Ok(());
         }
-        let roots = app.state::<Roots>();
-        let ids = if let Some(root) = ssh_root(&roots, &root_id)? {
-            ssh_provider_session_ids(&root, "codex")?
+        let id = if let Some(id) = [identity, name]
+            .into_iter()
+            .filter(|id| id.starts_with(prefix))
+            .find_map(|id| uuid::Uuid::parse_str(id).ok())
+        {
+            id.to_string()
         } else {
-            codex_thread_ids(&app.state::<CodexServer>(), &root_path(&roots, &root_id)?)?
+            let roots = app.state::<Roots>();
+            let ids = if let Some(root) = ssh_root(&roots, &root_id)? {
+                ssh_provider_session_ids(&root, "codex")?
+            } else {
+                codex_thread_ids(&app.state::<CodexServer>(), &root_path(&roots, &root_id)?)?
+            };
+            let mut matching = ids.iter().filter(|id| id.starts_with(prefix));
+            let id = matching
+                .next()
+                .ok_or("Codex has not saved the reported conversation")?;
+            if matching.next().is_some() {
+                return Err("Codex reported an ambiguous conversation ID".into());
+            }
+            id.clone()
         };
-        let mut matching = ids.iter().filter(|id| id.starts_with(prefix));
-        let id = matching
-            .next()
-            .ok_or("Codex has not saved the reported conversation")?;
-        if matching.next().is_some() {
-            return Err("Codex reported an ambiguous conversation ID".into());
-        }
         // Serialize the association with stopping/replacing its owning PTY.
         let sessions = app.state::<Sessions>();
         let running = sessions.0.lock().map_err(|error| error.to_string())?;
@@ -2452,7 +2462,7 @@ async fn record_codex_session(
             .get(&session_id)
             .is_some_and(|session| session.run_id == run_id)
         {
-            update_provider_session(&app, &provider_sessions, &session_id, Some(id.clone()))?;
+            update_provider_session(&app, &provider_sessions, &session_id, Some(id))?;
         }
         Ok(())
     })
@@ -3401,7 +3411,7 @@ async fn agent_availability(
 }
 
 #[tauri::command]
-async fn install_agent(agent: String) -> Result<(), String> {
+async fn install_agent(agent: String) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let mut command = if agent == "kimi" || agent == "claude" {
             let url = if agent == "kimi" {
@@ -3470,16 +3480,18 @@ async fn install_agent(agent: String) -> Result<(), String> {
             let mut probe = Command::new(path);
             probe
                 .arg("--version")
-                .stdout(Stdio::null())
+                .stdout(Stdio::piped())
                 .stderr(Stdio::null());
             if let Some(path) = user_path() {
                 probe.env("PATH", path);
             }
-            return probe
-                .status()
-                .map_err(|error| format!("Installed {agent}, but could not run it: {error}"))?
+            let output = probe
+                .output()
+                .map_err(|error| format!("Installed {agent}, but could not run it: {error}"))?;
+            return output
+                .status
                 .success()
-                .then_some(())
+                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
                 .ok_or_else(|| {
                     format!(
                         "Installed {agent}, but it cannot run with the current system requirements"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2403,8 +2403,8 @@ fn codex_thread_ids(server: &CodexServer, cwd: &Path) -> Result<HashSet<String>,
         .collect())
 }
 
-// A new Codex thread reports its full ID before it is saved. Only shortened titles need
-// saved-thread discovery; a full ID already identifies the conversation owned by this PTY.
+// Before saving a new thread, Codex reports "shortened-id | full-id". Keep both parts
+// so that this complete identity report can be recorded without saved-thread discovery.
 #[tauri::command]
 async fn record_codex_session(
     app: AppHandle,
@@ -2433,10 +2433,8 @@ async fn record_codex_session(
         {
             return Ok(());
         }
-        let id = if let Some(id) = [identity, name]
-            .into_iter()
-            .filter(|id| id.starts_with(prefix))
-            .find_map(|id| uuid::Uuid::parse_str(id).ok())
+        let id = if name.starts_with(prefix)
+            && let Ok(id) = uuid::Uuid::parse_str(name)
         {
             id.to_string()
         } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2128,8 +2128,8 @@ function App() {
         const session = sessionsRef.current.find((item) => item.id === sessionId);
         const [identity, ...name] = title.split(" | ");
         if (session?.agent === "codex" && /^[\da-f-]{20,36}(?:\.\.\.)?$/i.test(identity)) {
-          void invoke("record_codex_session", { sessionId, runId, rootId: session.rootId, title: identity }).catch(
-            (reason) => setError(String(reason)),
+          void invoke("record_codex_session", { sessionId, runId, rootId: session.rootId, title }).catch((reason) =>
+            setError(String(reason)),
           );
           if (name.length && !name[0].startsWith(identity.replace("...", ""))) markTitle(sessionId, name.join(" | "));
         } else markTitle(sessionId, title);

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -73,7 +73,7 @@ function ToastDescription({ className, ...props }: ToastPrimitive.Description.Pr
   return (
     <ToastPrimitive.Description
       data-slot="toast-description"
-      className={cn("truncate text-xs text-muted-foreground", className)}
+      className={cn("line-clamp-3 text-xs break-words text-muted-foreground", className)}
       {...props}
     />
   );

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { toast } from "@/components/ui/toast";
 import { AUTH_PROVIDERS, type ProviderAuth, ProviderAuthDescription } from "@/provider-auth";
 import { defaultSessionName, type Session, sessionLabel } from "@/types";
 
@@ -345,10 +346,12 @@ export function NewSessionDialog({
   }
 
   async function install(option: (typeof SESSION_CHOICES)[number] = choice) {
+    const updating = !availability[option.id]?.installable;
+    const label = sessionLabel({ agent: option.agent });
     setInstalling(option.id);
     setError("");
     try {
-      await invoke("install_agent", { agent: option.agent });
+      const version = await invoke<string>("install_agent", { agent: option.agent });
       const results = await Promise.all(
         SESSION_CHOICES.filter((candidate) => candidate.agent === option.agent).map(
           async (candidate) =>
@@ -363,10 +366,20 @@ export function NewSessionDialog({
       );
       setAvailability((current) => ({ ...current, ...Object.fromEntries(results) }));
       const result = results.find(([id]) => id === option.id)?.[1];
-      if (result && !result.available && result.installable) setError(result.detail);
-      else setUpdates((current) => ({ ...current, [option.agent]: false }));
+      if (result && !result.available && result.installable) throw new Error(result.detail);
+      setUpdates((current) => ({ ...current, [option.agent]: false }));
+      toast.add({
+        title: `${label} ${updating ? "update" : "installation"} complete`,
+        description: `${version ? `${version}. ` : ""}New sessions will use this version.`,
+        type: "success",
+      });
     } catch (reason) {
       setError(String(reason));
+      toast.add({
+        title: `${label} ${updating ? "update" : "installation"} failed`,
+        description: String(reason),
+        type: "error",
+      });
     } finally {
       setInstalling("");
     }

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -351,7 +351,19 @@ export function NewSessionDialog({
     setInstalling(option.id);
     setError("");
     try {
-      const version = await invoke<string>("install_agent", { agent: option.agent });
+      const version = await invoke<string>("install_agent", { agent: option.agent }).catch((reason) => {
+        toast.add({
+          title: `${label} ${updating ? "update" : "installation"} failed`,
+          description: String(reason),
+          type: "error",
+        });
+        throw reason;
+      });
+      toast.add({
+        title: `${label} ${updating ? "update" : "installation"} complete`,
+        description: `${version ? `${version}. ` : ""}New sessions will use this version.`,
+        type: "success",
+      });
       const results = await Promise.all(
         SESSION_CHOICES.filter((candidate) => candidate.agent === option.agent).map(
           async (candidate) =>
@@ -368,18 +380,8 @@ export function NewSessionDialog({
       const result = results.find(([id]) => id === option.id)?.[1];
       if (result && !result.available && result.installable) throw new Error(result.detail);
       setUpdates((current) => ({ ...current, [option.agent]: false }));
-      toast.add({
-        title: `${label} ${updating ? "update" : "installation"} complete`,
-        description: `${version ? `${version}. ` : ""}New sessions will use this version.`,
-        type: "success",
-      });
     } catch (reason) {
       setError(String(reason));
-      toast.add({
-        title: `${label} ${updating ? "update" : "installation"} failed`,
-        description: String(reason),
-        type: "error",
-      });
     } finally {
       setInstalling("");
     }

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -378,8 +378,8 @@ export function NewSessionDialog({
       );
       setAvailability((current) => ({ ...current, ...Object.fromEntries(results) }));
       const result = results.find(([id]) => id === option.id)?.[1];
-      if (result && !result.available && result.installable) throw new Error(result.detail);
-      setUpdates((current) => ({ ...current, [option.agent]: false }));
+      if (result && !result.available && result.installable) setError(`Could not refresh ${label}: ${result.detail}`);
+      else setUpdates((current) => ({ ...current, [option.agent]: false }));
     } catch (reason) {
       setError(String(reason));
     } finally {


### PR DESCRIPTION
Codex can report a new conversation before it appears in its saved-thread list. Lite now passes the complete PTY title to Rust and records the matching full UUID from Codex’s paired `shortened-id | full-id` report directly, fixing the false “Codex has not saved the reported conversation” banner. Standalone UUID titles and shortened titles for named conversations retain exact prefix resolution and the existing PTY ownership checks.

Harness install/update actions now show success or failure toasts. Success includes the CLI version verified after installation; failures include the installer error. A later availability-refresh failure keeps the successful installer result and displays its own inline error. Toast descriptions wrap to three lines so the result remains readable.

Documents macOS’s existing “Reopen windows when logging back in” behavior. Lite already participates in native relaunch; no login item or background service is needed. Bumps the patch version to **0.0.46**.

Validation:
- `bun run check`, `bun test` (20 tests), and `bun run build`.
- `cargo fmt --check` and `cargo test` (7 tests).
- Native Tauri smoke with installed Codex 0.153.4: two fresh tabs in the same directory recorded different full UUIDs; a saved named conversation retained its original UUID; all three had no red saved-conversation error. Used isolated Lite app data and no model turns.
- Browser checks of the real refresh-button handler with controlled installer responses: success/version, failure/error, fresh installation, and successful installation followed by a failed status refresh, including the Codex/DeepSeek row; visual inspection of both outcomes.
- Actual macOS reboot restoration remains a manual check.
- Live Codex shell-output check: OSC 0 title injection through command stdout was stripped by the TUI; direct `/dev/tty` output failed because the command had no controlling terminal. The early capture path accepts only a full UUID paired with its matching reported prefix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Lite 0.0.46 records Codex sessions from their complete reported identity and provides clearer harness installation/update feedback.

### 📊 Key Changes

- Passes the complete PTY title to Rust and records Codex’s full UUID when it matches the reported shortened ID, while retaining prefix-based lookup and ambiguity checks as fallback.
- Preserves the existing session ownership validation when associating Codex conversations with Lite sessions.
- Changes `install_agent` to return the installed CLI version and adds success or failure toasts; refresh errors are shown separately without replacing a successful installation result.
- Allows toast descriptions to wrap across up to three lines and documents macOS’s existing **Reopen windows when logging back in** behavior.
- Bumps the native application version from `0.0.45` to `0.0.46`.

### 🎯 Purpose & Impact

- Codex conversations can be associated immediately from the full UUID reported in the PTY title, avoiding the previous saved-thread discovery error when Codex has not yet listed the conversation.
- Harness installation and update actions now display the verified version on success or the installer error on failure, while later availability-refresh failures remain visible independently.
- Lite can restore saved tabs through macOS native app restoration; no login item or background service is added.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
