### PR TITLE
Let users cancel a hanging harness install or update (0.0.49)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1962,7 +1962,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.48"
+version = "0.0.49"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.48"
+version = "0.0.49"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,10 @@ const SUPPORTED_KEYS: [&str; 6] = [
 #[derive(Default)]
 struct PendingNotification(Mutex<Option<String>>);
 
+// The one harness installer that may run at a time, held here so a cancel can reach it.
+#[derive(Default)]
+struct Installer(Mutex<Option<std::process::Child>>);
+
 #[cfg(target_os = "macos")]
 objc2::define_class!(
     #[unsafe(super(NSObject))]
@@ -3408,8 +3412,9 @@ async fn agent_availability(
     })
 }
 
+// Resolves to no version when the install was cancelled, which is not a failure to report.
 #[tauri::command]
-async fn install_agent(agent: String) -> Result<String, String> {
+async fn install_agent(app: AppHandle, agent: String) -> Result<Option<String>, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let mut command = if agent == "kimi" || agent == "claude" {
             let url = if agent == "kimi" {
@@ -3449,6 +3454,13 @@ async fn install_agent(agent: String) -> Result<String, String> {
             command.env("PATH", path);
         }
         command.stdout(Stdio::null()).stderr(Stdio::piped());
+        // A pipeline installer keeps stderr open through every process it spawned, so a cancel has
+        // to reach the whole group before this read can end.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
         let mut child = command
             .spawn()
             .map_err(|error| format!("Could not run the installer: {error}"))?;
@@ -3456,6 +3468,8 @@ async fn install_agent(agent: String) -> Result<String, String> {
             .stderr
             .take()
             .ok_or("Could not read installer errors")?;
+        let installer = app.state::<Installer>();
+        *installer.0.lock().map_err(|error| error.to_string())? = Some(child);
         let mut detail = Vec::with_capacity(16_384);
         let mut buffer = [0_u8; 4096];
         while let Ok(count) = stderr.read(&mut buffer) {
@@ -3467,6 +3481,14 @@ async fn install_agent(agent: String) -> Result<String, String> {
                 detail.drain(..detail.len() - 16_384);
             }
         }
+        let Some(mut child) = installer
+            .0
+            .lock()
+            .map_err(|error| error.to_string())?
+            .take()
+        else {
+            return Ok(None);
+        };
         let status = child
             .wait()
             .map_err(|error| format!("Could not finish the installer: {error}"))?;
@@ -3486,7 +3508,7 @@ async fn install_agent(agent: String) -> Result<String, String> {
             return output
                 .status
                 .success()
-                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+                .then(|| Some(String::from_utf8_lossy(&output.stdout).trim().to_owned()))
                 .ok_or_else(|| {
                     format!(
                         "Installed {agent}, but it cannot run with the current system requirements"
@@ -3503,6 +3525,30 @@ async fn install_agent(agent: String) -> Result<String, String> {
     })
     .await
     .map_err(|error| format!("Could not finish the install: {error}"))?
+}
+
+#[tauri::command]
+fn cancel_install(installer: State<'_, Installer>) -> Result<(), String> {
+    let Some(mut child) = installer
+        .0
+        .lock()
+        .map_err(|error| error.to_string())?
+        .take()
+    else {
+        return Ok(());
+    };
+    let id = child.id().to_string();
+    #[cfg(unix)]
+    let _ = Command::new("kill")
+        .args(["-TERM", "--", &format!("-{id}")])
+        .status();
+    #[cfg(windows)]
+    let _ = Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &id])
+        .status();
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
 }
 
 #[tauri::command]
@@ -6248,6 +6294,7 @@ pub fn run() {
         .manage(Sessions::default())
         .manage(WakeLock::default())
         .manage(PendingNotification::default())
+        .manage(Installer::default())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             app.manage(load_roots(app.handle()));
@@ -6299,6 +6346,7 @@ pub fn run() {
             read_usage,
             agent_availability,
             agent_update_available,
+            cancel_install,
             install_agent,
             open_setup_docs,
             open_url,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,9 +66,32 @@ const SUPPORTED_KEYS: [&str; 6] = [
 #[derive(Default)]
 struct PendingNotification(Mutex<Option<String>>);
 
-// The one harness installer that may run at a time, held here so a cancel can reach it.
+// The one harness installer that may run at a time, held here so a cancel can reach it. A cancel
+// that lands before the installer registers is kept, so registration can honor it.
 #[derive(Default)]
-struct Installer(Mutex<Option<std::process::Child>>);
+enum InstallSlot {
+    #[default]
+    Idle,
+    Cancelled,
+    Running(std::process::Child),
+}
+
+#[derive(Default)]
+struct Installer(Mutex<InstallSlot>);
+
+// Installers are pipelines, so only the whole group ending releases the stderr pipe Lite reads.
+fn stop_installer(mut child: std::process::Child) {
+    #[cfg(unix)]
+    let _ = Command::new("kill")
+        .args(["-KILL", "--", &format!("-{}", child.id())])
+        .status();
+    #[cfg(windows)]
+    let _ = Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &child.id().to_string()])
+        .status();
+    let _ = child.kill();
+    let _ = child.wait();
+}
 
 #[cfg(target_os = "macos")]
 objc2::define_class!(
@@ -3415,7 +3438,8 @@ async fn agent_availability(
 // Resolves to no version when the install was cancelled, which is not a failure to report.
 #[tauri::command]
 async fn install_agent(app: AppHandle, agent: String) -> Result<Option<String>, String> {
-    tauri::async_runtime::spawn_blocking(move || {
+    let handle = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         let mut command = if agent == "kimi" || agent == "claude" {
             let url = if agent == "kimi" {
                 "https://code.kimi.com/kimi-code/install"
@@ -3469,7 +3493,13 @@ async fn install_agent(app: AppHandle, agent: String) -> Result<Option<String>, 
             .take()
             .ok_or("Could not read installer errors")?;
         let installer = app.state::<Installer>();
-        *installer.0.lock().map_err(|error| error.to_string())? = Some(child);
+        let mut slot = installer.0.lock().map_err(|error| error.to_string())?;
+        if matches!(*slot, InstallSlot::Cancelled) {
+            stop_installer(child);
+            return Ok(None);
+        }
+        *slot = InstallSlot::Running(child);
+        drop(slot);
         let mut detail = Vec::with_capacity(16_384);
         let mut buffer = [0_u8; 4096];
         while let Ok(count) = stderr.read(&mut buffer) {
@@ -3481,14 +3511,11 @@ async fn install_agent(app: AppHandle, agent: String) -> Result<Option<String>, 
                 detail.drain(..detail.len() - 16_384);
             }
         }
-        let Some(mut child) = installer
-            .0
-            .lock()
-            .map_err(|error| error.to_string())?
-            .take()
-        else {
+        let mut slot = installer.0.lock().map_err(|error| error.to_string())?;
+        let InstallSlot::Running(mut child) = std::mem::take(&mut *slot) else {
             return Ok(None);
         };
+        drop(slot);
         let status = child
             .wait()
             .map_err(|error| format!("Could not finish the installer: {error}"))?;
@@ -3524,30 +3551,21 @@ async fn install_agent(app: AppHandle, agent: String) -> Result<Option<String>, 
         })
     })
     .await
-    .map_err(|error| format!("Could not finish the install: {error}"))?
+    .map_err(|error| format!("Could not finish the install: {error}"))?;
+    // Every exit leaves the slot idle, so a cancel from this attempt cannot reach the next one.
+    if let Ok(mut slot) = handle.state::<Installer>().0.lock() {
+        *slot = InstallSlot::Idle;
+    }
+    result
 }
 
 #[tauri::command]
 fn cancel_install(installer: State<'_, Installer>) -> Result<(), String> {
-    let Some(mut child) = installer
-        .0
-        .lock()
-        .map_err(|error| error.to_string())?
-        .take()
-    else {
-        return Ok(());
-    };
-    let id = child.id().to_string();
-    #[cfg(unix)]
-    let _ = Command::new("kill")
-        .args(["-TERM", "--", &format!("-{id}")])
-        .status();
-    #[cfg(windows)]
-    let _ = Command::new("taskkill")
-        .args(["/T", "/F", "/PID", &id])
-        .status();
-    let _ = child.kill();
-    let _ = child.wait();
+    let mut slot = installer.0.lock().map_err(|error| error.to_string())?;
+    if let InstallSlot::Running(child) = std::mem::replace(&mut *slot, InstallSlot::Cancelled) {
+        drop(slot);
+        stop_installer(child);
+    }
     Ok(())
 }
 

--- a/src/new-session-dialog.tsx
+++ b/src/new-session-dialog.tsx
@@ -356,7 +356,7 @@ export function NewSessionDialog({
     setInstalling(option.id);
     setError("");
     try {
-      const version = await invoke<string>("install_agent", { agent: option.agent }).catch((reason) => {
+      const version = await invoke<string | null>("install_agent", { agent: option.agent }).catch((reason) => {
         toast.add({
           title: `${label} ${updating ? "update" : "installation"} failed`,
           description: String(reason),
@@ -364,6 +364,7 @@ export function NewSessionDialog({
         });
         throw reason;
       });
+      if (version === null) return;
       toast.add({
         title: `${label} ${updating ? "update" : "installation"} complete`,
         description: `${version ? `${version}. ` : ""}New sessions will use this version.`,
@@ -758,8 +759,16 @@ export function NewSessionDialog({
             {error ? <p className="text-xs text-destructive">{error}</p> : null}
           </DialogBody>
           <DialogFooter>
-            <Button variant="outline" disabled={Boolean(installing) || creating} onClick={() => changeOpen(false)}>
-              Cancel
+            <Button
+              variant="outline"
+              disabled={creating}
+              onClick={() =>
+                installing
+                  ? void invoke("cancel_install").catch((reason) => setError(String(reason)))
+                  : changeOpen(false)
+              }
+            >
+              {installing ? `Cancel ${availability[installing]?.installable ? "install" : "update"}` : "Cancel"}
             </Button>
             <Button type="submit" disabled={!ready}>
               {(!remote && !status) || (installing && missing?.installable) ? <Spinner /> : null}


### PR DESCRIPTION
Installing or updating a harness from the new-session dialog blocked until the installer exited. On a poor connection the \`curl | bash\` or \`npm install -g\` pipeline can sit forever, and the dialog refused to close or cancel, leaving Lite stuck with no way out.

| Journey | Result |
| --- | --- |
| Start an install or update | Lite keeps the installer process in one managed slot and starts it in its own process group. |
| Press Cancel while it runs | The footer button reads Cancel install / Cancel update and terminates the whole installer group, so the stderr read ends and the dialog is usable again. No failure toast; nothing is reported for a cancel the user asked for. |
| Let it finish | Unchanged: success toast, availability refresh, and the version probe. |

Bumps the native package and lockfile to **0.0.49**. No new dependencies.

Validation:

- `bun run check`: Biome, TypeScript, and Knip passed.
- `cargo fmt` and `cargo check` passed.
- Verified on macOS with a standalone program mirroring the installer path: killing the process group of a `sh -c "a | b"` pipeline closed stderr within the poll interval, the leader exited with SIGTERM, and no child processes were left behind.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Added cancellable harness installation and update handling in the new-session dialog so users can stop a hanging installer without leaving Lite blocked.

### 📊 Key Changes

- Added a managed installer slot that tracks the active process and handles cancellation requests that arrive before process registration.
- Started Unix installers in their own process groups and added platform-specific termination for the entire installer pipeline.
- Added the `cancel_install` Tauri command and changed `install_agent` to return no result for user-initiated cancellations, preventing failure or success notifications.
- Updated the dialog footer to show **Cancel install** or **Cancel update** while active, and bumped the native package and lockfile to version `0.0.49`.

### 🎯 Purpose & Impact

- Users can cancel a running install or update from the dialog, including installers blocked in `curl | bash` or `npm install -g` pipelines; the dialog becomes usable again without a failure toast.
- Completed installs and updates retain their existing success notification, availability refresh, and version-probing behavior.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
