### PR TITLE
Fix terminal zoom latency across sessions (0.0.50)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1962,7 +1962,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.49"
+version = "0.0.50"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -406,10 +406,10 @@ export function TerminalView({
 
   useEffect(() => {
     const terminal = terminalRef.current;
-    if (!terminal || terminal.options.fontSize === fontSize) return;
+    if (!active || !terminal || terminal.options.fontSize === fontSize) return;
     terminal.options.fontSize = fontSize;
-    requestAnimationFrame(() => resizeRef.current());
-  }, [fontSize]);
+    resizeRef.current();
+  }, [active, fontSize]);
 
   useEffect(() => {
     if (!searchOpen) return;


### PR DESCRIPTION
Zooming a terminal currently updates and refits every mounted session, including hidden terminals with full scrollback. Apply font changes only to the active terminal, and apply the current size when a background session is selected. Fit immediately after changing the font, removing the extra animation-frame delay. Bump the patch version from 0.0.49 to 0.0.50.

Fixes #165

Validation:
- Reproduced with the real `TerminalView` and patched xterm in WebKit on macOS, with native IPC mocked. Across six keyboard/context-action zooms, eight sessions with 5,000 lines each took a median 417 ms to settle before and 114 ms after; resize requests fell from eight to one. Single-session timing stayed around 49 ms. Timing includes three animation frames and is a browser harness measurement, not native-app end-to-end latency.
- WebKit and Chromium checks passed for tab activation and terminal/PTY resize arguments, background output, scroll position, search selection and focus, zoom reset/limits, element resizing, and the native resize event callback.
- `bun run check`, `bun test`, `bun run build`, `cargo fmt --check`, `cargo test`, and `git diff --check` passed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Terminal zoom now updates only the active session and resizes it immediately, reducing latency when multiple terminals contain large scrollbacks.

### 📊 Key Changes
- Restricted font-size updates in `src/terminal.tsx` to active terminals.
- Applied the resize immediately after changing the font size instead of waiting for an animation frame.
- Re-ran the font-size effect when terminal activity changes so selected background sessions receive the current size.
- Bumped the application version from `0.0.49` to `0.0.50` in the Rust package metadata and lockfile.

### 🎯 Purpose & Impact
- Zooming no longer triggers font updates and resize requests for every mounted hidden terminal; the reported harness measurement reduced resize requests from eight to one for eight large sessions.
- Selecting a background terminal applies the current font size and resizes that terminal.
- Single-session behavior remains functionally unchanged apart from the immediate resize timing.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
