### PR TITLE
Fix Codex usage after account switches (v0.0.51)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1962,7 +1962,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lite"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "atomicwrites",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "lite"
-version = "0.0.50"
+version = "0.0.51"
 description = "A fast, local workspace for AI coding agents."
 authors = ["Ultralytics"]
 edition = "2024"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2158,7 +2158,7 @@ fn codex_executable() -> Result<PathBuf, String> {
     })
 }
 
-fn ensure_codex_server(server: &CodexServer) -> Result<(), String> {
+fn ensure_codex_server(server: &CodexServer, listen: &str) -> Result<(), String> {
     let mut server = server.0.lock().map_err(|error| error.to_string())?;
     let endpoint = server.endpoint.clone();
     if let Some(child) = server.child.as_mut() {
@@ -2202,9 +2202,12 @@ fn ensure_codex_server(server: &CodexServer) -> Result<(), String> {
     }
     let mut command = Command::new(codex_executable()?);
     #[cfg(unix)]
-    command.args(["app-server", "--listen", "unix://"]);
+    command.args(["app-server", "--listen", listen]);
     #[cfg(windows)]
-    command.args(["app-server", "--listen", &server.endpoint]);
+    {
+        let _ = listen;
+        command.args(["app-server", "--listen", &server.endpoint]);
+    }
     if let Some(path) = user_path() {
         command.env("PATH", path);
     }
@@ -2243,7 +2246,7 @@ fn codex_requests(
     server: &CodexServer,
     requests: &[(u64, &str, serde_json::Value)],
 ) -> Result<HashMap<u64, serde_json::Value>, String> {
-    ensure_codex_server(server)?;
+    ensure_codex_server(server, "unix://")?;
     let endpoint = server
         .0
         .lock()
@@ -2335,21 +2338,58 @@ fn codex_usage(
     thread_id: Option<&str>,
     account: bool,
 ) -> Result<UsageSnapshot, String> {
-    let mut requests = Vec::new();
+    let mut responses = HashMap::new();
     if account {
-        requests.extend([
-            (1, "account/rateLimits/read", serde_json::json!({})),
-            (2, "account/usage/read", serde_json::json!({})),
-        ]);
+        // Token refresh on a shared server refuses workspace changes. A fresh process reads
+        // the current login without Lite accessing credentials or disturbing active sessions.
+        #[cfg(unix)]
+        let socket_directory = {
+            use std::os::unix::fs::DirBuilderExt;
+            let directory = Path::new("/tmp")
+                .canonicalize()
+                .map_err(|error| error.to_string())?
+                .join(format!("lite-{}", uuid::Uuid::new_v4()));
+            fs::DirBuilder::new()
+                .mode(0o700)
+                .create(&directory)
+                .map_err(|error| error.to_string())?;
+            directory
+        };
+        #[cfg(unix)]
+        let socket_path = socket_directory.join("usage.sock");
+        #[cfg(unix)]
+        let endpoint = format!("unix://{}", path_text(&socket_path));
+        #[cfg(windows)]
+        let endpoint = String::new();
+        let account_server = CodexServer(Mutex::new(CodexServerState {
+            child: None,
+            endpoint: endpoint.clone(),
+        }));
+        let result = ensure_codex_server(&account_server, &endpoint).and_then(|()| {
+            let server = account_server.0.lock().map_err(|error| error.to_string())?;
+            codex_requests_once(
+                &server.endpoint,
+                &[
+                    (1, "account/rateLimits/read", serde_json::json!({})),
+                    (2, "account/usage/read", serde_json::json!({})),
+                ],
+            )
+        });
+        stop_codex_server(&account_server);
+        #[cfg(unix)]
+        let _ = fs::remove_dir_all(socket_directory);
+        responses.extend(result?);
     }
     if let Some(thread_id) = thread_id {
-        requests.push((
-            3,
-            "thread/read",
-            serde_json::json!({"threadId": thread_id, "includeTurns": false}),
-        ));
+        responses.extend(codex_requests(
+            server,
+            &[(
+                3,
+                "thread/read",
+                serde_json::json!({"threadId": thread_id, "includeTurns": false}),
+            )],
+        )?);
     }
-    let responses = codex_requests(server, &requests)?;
     let rates = responses.get(&1);
     let summary = responses.get(&2);
 


### PR DESCRIPTION
Switching between personal and company Codex accounts can leave the Usage tab using a revoked OAuth token from the long-lived app server. The UI cache is keyed by session ID, not email; Codex caches authentication and guards token refresh against account-ID changes.

Read account rate limits and token usage through a fresh, short-lived Codex app server on each explicit Usage read. Reuse the existing launch, bounded WebSocket exchange, and shutdown code; clean up the private Unix socket directory on success or failure. Keep thread/context reads on the shared server so loaded conversations remain available. Bump Lite from 0.0.50 to 0.0.51 in Cargo.toml and Cargo.lock.

Validation: `bun run check`, `bun test` (24 passing), `cargo fmt --check`, and `cargo test` (7 passing), and `bun run tauri build --debug --no-bundle` passed. A live installed-Codex probe returned both account endpoints successfully and verified helper/socket cleanup. Full two-account switching has not been exercised interactively; CI validates all three platforms.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Lite to read Codex account usage through a fresh short-lived app server, preventing stale shared-server authentication after account switches, and bumped the version to 0.0.51.

### 📊 Key Changes

- Added a separate Codex server flow for account rate-limit and token-usage requests.
- Creates a private Unix socket directory for each account-usage read, then stops the temporary server and removes the directory after success or failure.
- Keeps `thread/read` requests on the existing shared Codex server so active conversations remain available.
- Updated Codex server startup to accept a configurable listen endpoint on Unix systems while retaining the existing Windows endpoint behavior.
- Bumped the Lite package version from 0.0.50 to 0.0.51 in `Cargo.toml` and `Cargo.lock`.

### 🎯 Purpose & Impact

- Explicit Usage reads now use a newly launched Codex process, allowing authentication to reflect the currently active account instead of relying on credentials cached by the long-lived server.
- Thread reads continue using the shared server.
- No user-facing change beyond more reliable account usage data after switching Codex accounts.
<details><summary>📋 Skipped 1 file (lock files, generated, images, etc.)</summary>

- `src-tauri/Cargo.lock`
</details>
